### PR TITLE
[YUNIKORN-434] Add check for placement rule not defined and queue not found

### DIFF
--- a/pkg/scheduler/scheduling_partition.go
+++ b/pkg/scheduler/scheduling_partition.go
@@ -114,6 +114,13 @@ func (psc *partitionSchedulingContext) addSchedulingApplication(schedulingApp *S
 	}
 	// we have a queue name either from placement or direct
 	schedulingQueue := psc.getQueue(queueName)
+
+	// Check if queue does not exist and placement rule is also not defined
+	if schedulingQueue == nil && !psc.placementManager.IsInitialised() {
+		return fmt.Errorf("application cannot be submitted to non existing queue %s for application %s",
+			schedulingApp.ApplicationInfo.QueueName, appID)
+	}
+
 	// check if the queue already exist and what we have is a leaf queue with submit access
 	if schedulingQueue != nil &&
 		(!schedulingQueue.isLeafQueue() || !schedulingQueue.checkSubmitAccess(schedulingApp.ApplicationInfo.GetUser())) {


### PR DESCRIPTION
Scheduler pod crashes when queue name in pod spec does not contain DOT.

It fails with below error:

`2020-10-02T13:49:59.871Z        DEBUG   scheduler/scheduler.go:230      enqueued event  {"eventType": "*schedulerevent.SchedulerApplicationsUpdateEvent", "event": {"AddedApplications":[{"ApplicationID":"application-sleep-test","Partition":"[mycluster]default","QueueName":"test","SubmissionTime":1601646599870976327}],"RemovedApplications":null}, "currentQueueSize": 0}
panic: runtime error: slice bounds out of range

goroutine 69 [running]:
github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*partitionSchedulingContext).createSchedulingQueue(0xc0001fe7e0, 0xc000043cfc, 0x4, 0xc000593a58, 0x7, 0xc0038e42f0, 0x1, 0x1, 0x0, 0xfffffff1886e0900)
        /home/travis/gopath/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200909001345-c2699e725c8a/pkg/scheduler/scheduling_partition.go:237 +0x8e9
github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*partitionSchedulingContext).addSchedulingApplication(0xc0001fe7e0, 0xc0036bec60, 0x0, 0x0)
        /home/travis/gopath/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200909001345-c2699e725c8a/pkg/scheduler/scheduling_partition.go:124 +0x670
github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*ClusterSchedulingContext).addSchedulingApplication(0xc0004508a0, 0xc0036bec60, 0x0, 0x0)
        /home/travis/gopath/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200909001345-c2699e725c8a/pkg/scheduler/scheduling_context.go:114 +0x105
github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*Scheduler).addNewApplication(0xc00022a000, 0xc0000a1100, 0xc003936381, 0x9)
        /home/travis/gopath/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200909001345-c2699e725c8a/pkg/scheduler/scheduler.go:209 +0x11b
github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*Scheduler).processApplicationUpdateEvent(0xc00022a000, 0xc0063c22a0)
        /home/travis/gopath/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200909001345-c2699e725c8a/pkg/scheduler/scheduler.go:447 +0x76e
github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*Scheduler).handleSchedulerEvent(0xc00022a000)
        /home/travis/gopath/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200909001345-c2699e725c8a/pkg/scheduler/scheduler.go:596 +0x3e5
created by github.com/apache/incubator-yunikorn-core/pkg/scheduler.(*Scheduler).StartService
        /home/travis/gopath/pkg/mod/github.com/apache/incubator-yunikorn-core@v0.0.0-20200909001345-c2699e725c8a/pkg/scheduler/scheduler.go:67 +0x6d`