### PR TITLE
[YUNIKORN-75] REST API for changing log level

### DIFF
--- a/pkg/entrypoint/entrypoint.go
+++ b/pkg/entrypoint/entrypoint.go
@@ -27,6 +27,8 @@ import (
 	"github.com/apache/incubator-yunikorn-core/pkg/rmproxy"
 	"github.com/apache/incubator-yunikorn-core/pkg/scheduler"
 	"github.com/apache/incubator-yunikorn-core/pkg/webservice"
+
+	"go.uber.org/zap"
 )
 
 // options used to control how services are started
@@ -46,6 +48,11 @@ func StartAllServices() *ServiceContext {
 			metricsHistorySize: 1440,
 			eventCacheEnabled:  false,
 		})
+}
+
+func StartAllServicesWithLogger(logger *zap.Logger, zapConfigs *zap.Config) *ServiceContext {
+	log.InitializeLogger(logger, zapConfigs)
+	return StartAllServices()
 }
 
 // Visible by tests

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -722,3 +722,21 @@ func getQueueApplications(w http.ResponseWriter, r *http.Request) {
 		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
 	}
 }
+
+func setLogLevel(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	writeHeaders(w)
+	level := vars["level"]
+	if err := log.SetLogLevel(level); err != nil {
+		buildJSONErrorResponse(w, err.Error(), http.StatusBadRequest)
+	}
+}
+
+func getLogLevel(w http.ResponseWriter, r *http.Request) {
+	writeHeaders(w)
+	zapConfig := log.GetConfig()
+	if _, err := w.Write([]byte(zapConfig.Level.Level().String())); err != nil {
+		log.Logger().Error("Could not get log level", zap.Error(err))
+		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -148,6 +148,18 @@ var webRoutes = routes{
 	},
 	route{
 		"Scheduler",
+		"PUT",
+		"/ws/v1/loglevel/{level}",
+		setLogLevel,
+	},
+	route{
+		"Scheduler",
+		"GET",
+		"/ws/v1/loglevel",
+		getLogLevel,
+	},
+	route{
+		"Scheduler",
 		"GET",
 		"/ws/v1/partition/{partition}/nodes",
 		getPartitionNodes,


### PR DESCRIPTION
### What is this PR for?
Adding a new method to entrypoint.go so that a zap logger and configuration can be injected when creating it from the shim. This makes it possible to change the log level dynamically in both components. 
Adding new REST endpoints to change/retrieve the current log level.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-75

### How should this be tested?
Use the new REST endpoints `/ws/v1/loglevel/<newlevel>` (PUT) for changing the log level and `/ws/v1/loglevel/` (GET) for retrieving it.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
