### PR TITLE
[YUNIKORN-543] Automate core application state diagram generation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,13 @@ test: clean
 	go test ./... $(RACE) -tags deadlock -coverprofile=coverage.txt -covermode=atomic
 	go vet $(REPO)...
 
+# Generate FSM graphs (dot/png)
+.PHONY: fsm_graph
+fsm_graph: clean
+	@echo "generating FSM graphs"
+	go test -tags graphviz -run 'Test.*FsmGraph' ./pkg/scheduler/objects
+	scripts/generate-fsm-graph-images.sh
+
 # Simple clean of generated files only (no local cleanup).
 .PHONY: clean
 clean:

--- a/pkg/scheduler/objects/application_graphviz_test.go
+++ b/pkg/scheduler/objects/application_graphviz_test.go
@@ -1,0 +1,39 @@
+// +build graphviz
+
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package objects
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/looplab/fsm"
+	"gotest.tools/assert"
+)
+
+func TestApplicationFsmGraph(t *testing.T) {
+	graph := fsm.Visualize(NewAppState())
+
+	err := os.MkdirAll("../../../_output/fsm", 0755)
+	assert.NilError(t, err, "Creating output dir failed")
+	ioutil.WriteFile("../../../_output/fsm/application-state.dot", []byte(graph), 0644)
+	assert.NilError(t, err, "Writing graph failed")
+}

--- a/scripts/generate-fsm-graph-images.sh
+++ b/scripts/generate-fsm-graph-images.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+WORKDIR=$(pwd)/_output/fsm
+
+output_fsm() {
+  # print digraph header
+   head -n +1 "$1.dot"
+  # add options
+  echo "concentrate=true"
+  # print rest of file, eliminating transitions from same state to same state
+  # and cleaning up some verbose labels
+  tail -n +2 "$1.dot" | \
+	grep -E -v '"(\w+)" -> "\1"' | \
+	grep -v AppAllocationAsk | \
+	sed 's/Application/ App/g'
+}
+
+cd "${WORKDIR}"
+
+for dot in *.dot; do
+  base=$(echo "${dot}" | sed 's_\.dot$__')
+  
+  output_fsm "${base}" | dot -Tpng > "${base}.png"
+done
+


### PR DESCRIPTION
### What is this PR for?
Automate generation of .dot/.png files for the core scheduler application state.

New Makefile target `fsm_graph` will generate FSM graphs for the application state, and output to `_output/fsm` both the original `.dot` files as well as `.png` images. These may be directly used for website documentation.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-543

### How should this be tested?
Test succeeds.

### Screenshots (if appropriate)
![application-state](https://user-images.githubusercontent.com/12699633/138321914-4796c29f-452b-4923-adca-ef59af071fba.png)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation
