### PR TITLE
[YUNIKORN-922] Add application.stateaware.disable tag handling

### DIFF
--- a/pkg/scheduler/objects/application_state.go
+++ b/pkg/scheduler/objects/application_state.go
@@ -146,7 +146,12 @@ func NewAppState() *fsm.FSM {
 				event.Args[0].(*Application).clearStateTimer()
 			},
 			fmt.Sprintf("enter_%s", Starting.String()): func(event *fsm.Event) {
-				setTimer(startingTimeout, event, RunApplication)
+				app, ok := event.Args[0].(*Application)
+				if !ok {
+					log.Logger().Warn("The first argument is not an Application")
+					return
+				}
+				setTimer(app.startTimeout, event, RunApplication)
 			},
 			fmt.Sprintf("enter_%s", Completing.String()): func(event *fsm.Event) {
 				setTimer(completingTimeout, event, CompleteApplication)

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -860,6 +860,21 @@ func TestStateTimeOut(t *testing.T) {
 	if !app.stateMachine.Is(Running.String()) || app.stateTimer != nil {
 		t.Fatalf("State is not running or timer was not cleared, state: %s, timer %v", app.stateMachine.Current(), app.stateTimer)
 	}
+
+	startingTimeout = time.Minute * 5
+	app = newApplicationWithTags(appID2, "default", "root.a", map[string]string{AppTagStateAwareDisable: "true"})
+	err = app.HandleApplicationEvent(RunApplication)
+	assert.NilError(t, err, "no error expected new to accepted (timeout test)")
+	err = app.HandleApplicationEvent(RunApplication)
+	assert.NilError(t, err, "no error expected accepted to starting (timeout test)")
+	// give it some time to run and progress
+	time.Sleep(time.Millisecond * 100)
+	if app.IsStarting() {
+		t.Fatal("Starting state should have timed out")
+	}
+	if app.stateTimer != nil {
+		t.Fatalf("Startup timer has not be cleared on time out as expected, %v", app.stateTimer)
+	}
 }
 
 func TestCompleted(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
Add an application tag `application.stateaware.disable` to allow the application to skip state-aware timeout for transitioning to Running state.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-922

### How should this be tested?
Added local unit tests which pass.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [x] - It needs documentation.
