### PR TITLE
[YUNIKORN-1163] Return history of application state transitions in REST API

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -53,6 +53,11 @@ const (
 	AppTagStateAwareDisable string = "application.stateaware.disable"
 )
 
+type EventLogEntry struct {
+	EventTime        time.Time
+	ApplicationState string
+}
+
 type Application struct {
 	ApplicationID  string
 	Partition      string
@@ -80,6 +85,7 @@ type Application struct {
 	gangSchedulingStyle  string                 // gang scheduling style can be hard (after timeout we fail the application), or soft (after timeeout we schedule it as a normal application)
 	finishedTime         time.Time              // the time of finishing this application. the default value is zero time
 	rejectedMessage      string                 // If the application is rejected, save the rejected message
+	eventLog             []*EventLogEntry       // event log for this application
 
 	rmEventHandler     handler.EventHandler
 	rmID               string
@@ -106,6 +112,7 @@ func NewApplication(siApp *si.AddApplicationRequest, ugi security.UserGroup, eve
 		placeholderAsk:       resources.NewResourceFromProto(siApp.PlaceholderAsk),
 		finishedTime:         time.Time{},
 		rejectedMessage:      "",
+		eventLog:             make([]*EventLogEntry, 0),
 	}
 	placeholderTimeout := common.ConvertSITimeout(siApp.ExecutionTimeoutMilliSeconds)
 	if time.Duration(0) == placeholderTimeout {
@@ -140,6 +147,20 @@ func (sa *Application) String() string {
 
 func (sa *Application) SetState(state string) {
 	sa.stateMachine.SetState(state)
+}
+
+func (sa *Application) recordEvent(time time.Time, appState string, prevState string) {
+	// lock is not acquired here as it is already held during HandleApplicationEvent() / OnStateChange()
+	sa.eventLog = append(sa.eventLog, &EventLogEntry{
+		EventTime:        time,
+		ApplicationState: appState,
+	})
+}
+
+func (sa *Application) GetEventLog() []*EventLogEntry {
+	sa.RLock()
+	defer sa.RUnlock()
+	return sa.eventLog
 }
 
 // Set the reservation delay.
@@ -224,6 +245,7 @@ func (sa *Application) HandleApplicationEventWithInfo(event applicationEvent, ev
 // It sends an event about the state change to the shim as an application update.
 // The only state that does not generate an event is Rejected.
 func (sa *Application) OnStateChange(event *fsm.Event, eventInfo string) {
+	sa.recordEvent(time.Now(), event.Dst, event.Src)
 	if event.Dst == Rejected.String() || sa.rmEventHandler == nil {
 		return
 	}
@@ -281,6 +303,9 @@ func (sa *Application) timeoutStateTimer(expectedState string, event application
 				sa.notifyRMAllocationReleased(sa.rmID, toRelease, si.TerminationType_TIMEOUT, "releasing placeholders on app complete")
 				sa.clearStateTimer()
 			} else {
+				// HandleApplicationEvent assumes the lock to be held
+				sa.Lock()
+				defer sa.Unlock()
 				//nolint: errcheck
 				_ = sa.HandleApplicationEvent(event)
 			}

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -395,7 +395,7 @@ func TestAllocAskStateChange(t *testing.T) {
 	assert.Equal(t, app.RemoveAllocationAsk(aKey), 0, "ask should have been removed, no reservations")
 	assert.Assert(t, app.IsCompleting(), "Application should be in waiting state")
 
-	log := app.GetEventLog()
+	log := app.GetStateLog()
 	assert.Equal(t, len(log), 4, "wrong number of app events")
 	assert.Equal(t, log[0].ApplicationState, Accepted.String())
 	assert.Equal(t, log[1].ApplicationState, Completing.String())
@@ -652,7 +652,7 @@ func TestStateChangeOnUpdate(t *testing.T) {
 	app.RemoveAllocation(uuid)
 	assert.Assert(t, app.IsCompleting(), "Application did not change as expected: %s", app.CurrentState())
 
-	log := app.GetEventLog()
+	log := app.GetStateLog()
 	assert.Equal(t, len(log), 3, "wrong number of app events")
 	assert.Equal(t, log[0].ApplicationState, Accepted.String())
 	assert.Equal(t, log[1].ApplicationState, Starting.String())
@@ -716,7 +716,7 @@ func TestStateChangeOnPlaceholderAdd(t *testing.T) {
 	app.RemoveAllocation(uuid)
 	assert.Assert(t, app.IsCompleting(), "Application did not change as expected: %s", app.CurrentState())
 
-	log := app.GetEventLog()
+	log := app.GetStateLog()
 	assert.Equal(t, len(log), 2, "wrong number of app events")
 	assert.Equal(t, log[0].ApplicationState, Accepted.String())
 	assert.Equal(t, log[1].ApplicationState, Completing.String())
@@ -900,7 +900,7 @@ func TestStateTimeOut(t *testing.T) {
 	if app.stateTimer != nil {
 		t.Fatalf("Startup timer has not be cleared on time out as expected, %v", app.stateTimer)
 	}
-	log := app.GetEventLog()
+	log := app.GetStateLog()
 	assert.Equal(t, len(log), 3, "wrong number of app events")
 	assert.Equal(t, log[0].ApplicationState, Accepted.String())
 	assert.Equal(t, log[1].ApplicationState, Starting.String())
@@ -927,7 +927,7 @@ func TestCompleted(t *testing.T) {
 	err = common.WaitFor(1*time.Millisecond, time.Millisecond*200, app.IsExpired)
 	assert.NilError(t, err, "Application did not progress into Expired state")
 
-	log := app.GetEventLog()
+	log := app.GetStateLog()
 	assert.Equal(t, len(log), 4, "wrong number of app events")
 	assert.Equal(t, log[0].ApplicationState, Accepted.String())
 	assert.Equal(t, log[1].ApplicationState, Completing.String())
@@ -954,7 +954,7 @@ func TestRejected(t *testing.T) {
 	err = common.WaitFor(1*time.Millisecond, time.Millisecond*200, app.IsExpired)
 	assert.NilError(t, err, "Application did not progress into Expired state")
 
-	log := app.GetEventLog()
+	log := app.GetStateLog()
 	assert.Equal(t, len(log), 2, "wrong number of app events")
 	assert.Equal(t, log[0].ApplicationState, Rejected.String())
 	assert.Equal(t, log[1].ApplicationState, Expired.String())
@@ -990,7 +990,7 @@ func TestOnStatusChangeCalled(t *testing.T) {
 	assert.Equal(t, app.CurrentState(), Accepted.String(), "application state has been changed unexpectedly")
 	assert.Assert(t, !testHandler.isHandled(), "unexpected event send to the RM")
 
-	log := app.GetEventLog()
+	log := app.GetStateLog()
 	assert.Equal(t, len(log), 1, "wrong number of app events")
 	assert.Equal(t, log[0].ApplicationState, Accepted.String())
 }
@@ -1119,7 +1119,7 @@ func runTimeoutPlaceholderTest(t *testing.T, expectedState string, gangSchedulin
 	// a released placeholder still holds the resource until release confirmed by the RM
 	assert.Assert(t, resources.Equals(app.GetPlaceholderResource(), resources.Multiply(res, 2)), "Unexpected placeholder resources for the app")
 
-	log := app.GetEventLog()
+	log := app.GetStateLog()
 	assert.Equal(t, len(log), 2, "wrong number of app events")
 	assert.Equal(t, log[0].ApplicationState, Accepted.String())
 	assert.Equal(t, log[1].ApplicationState, expectedState)

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -394,6 +394,13 @@ func TestAllocAskStateChange(t *testing.T) {
 	// and back to waiting again, now from running
 	assert.Equal(t, app.RemoveAllocationAsk(aKey), 0, "ask should have been removed, no reservations")
 	assert.Assert(t, app.IsCompleting(), "Application should be in waiting state")
+
+	log := app.GetEventLog()
+	assert.Equal(t, len(log), 4, "wrong number of app events")
+	assert.Equal(t, log[0].ApplicationState, Accepted.String())
+	assert.Equal(t, log[1].ApplicationState, Completing.String())
+	assert.Equal(t, log[2].ApplicationState, Running.String())
+	assert.Equal(t, log[3].ApplicationState, Completing.String())
 }
 
 // test recover ask
@@ -644,6 +651,12 @@ func TestStateChangeOnUpdate(t *testing.T) {
 	// remove the allocation, ask has been removed so nothing left
 	app.RemoveAllocation(uuid)
 	assert.Assert(t, app.IsCompleting(), "Application did not change as expected: %s", app.CurrentState())
+
+	log := app.GetEventLog()
+	assert.Equal(t, len(log), 3, "wrong number of app events")
+	assert.Equal(t, log[0].ApplicationState, Accepted.String())
+	assert.Equal(t, log[1].ApplicationState, Starting.String())
+	assert.Equal(t, log[2].ApplicationState, Completing.String())
 }
 
 func TestStateChangeOnPlaceholderAdd(t *testing.T) {
@@ -702,6 +715,11 @@ func TestStateChangeOnPlaceholderAdd(t *testing.T) {
 	// remove the allocation, ask has been removed so nothing left
 	app.RemoveAllocation(uuid)
 	assert.Assert(t, app.IsCompleting(), "Application did not change as expected: %s", app.CurrentState())
+
+	log := app.GetEventLog()
+	assert.Equal(t, len(log), 2, "wrong number of app events")
+	assert.Equal(t, log[0].ApplicationState, Accepted.String())
+	assert.Equal(t, log[1].ApplicationState, Completing.String())
 }
 
 func TestAllocations(t *testing.T) {
@@ -882,6 +900,11 @@ func TestStateTimeOut(t *testing.T) {
 	if app.stateTimer != nil {
 		t.Fatalf("Startup timer has not be cleared on time out as expected, %v", app.stateTimer)
 	}
+	log := app.GetEventLog()
+	assert.Equal(t, len(log), 3, "wrong number of app events")
+	assert.Equal(t, log[0].ApplicationState, Accepted.String())
+	assert.Equal(t, log[1].ApplicationState, Starting.String())
+	assert.Equal(t, log[2].ApplicationState, Running.String())
 }
 
 func TestCompleted(t *testing.T) {
@@ -903,6 +926,13 @@ func TestCompleted(t *testing.T) {
 
 	err = common.WaitFor(1*time.Millisecond, time.Millisecond*200, app.IsExpired)
 	assert.NilError(t, err, "Application did not progress into Expired state")
+
+	log := app.GetEventLog()
+	assert.Equal(t, len(log), 4, "wrong number of app events")
+	assert.Equal(t, log[0].ApplicationState, Accepted.String())
+	assert.Equal(t, log[1].ApplicationState, Completing.String())
+	assert.Equal(t, log[2].ApplicationState, Completed.String())
+	assert.Equal(t, log[3].ApplicationState, Expired.String())
 }
 
 func TestRejected(t *testing.T) {
@@ -923,6 +953,11 @@ func TestRejected(t *testing.T) {
 
 	err = common.WaitFor(1*time.Millisecond, time.Millisecond*200, app.IsExpired)
 	assert.NilError(t, err, "Application did not progress into Expired state")
+
+	log := app.GetEventLog()
+	assert.Equal(t, len(log), 2, "wrong number of app events")
+	assert.Equal(t, log[0].ApplicationState, Rejected.String())
+	assert.Equal(t, log[1].ApplicationState, Expired.String())
 }
 
 func TestGetTag(t *testing.T) {
@@ -954,6 +989,10 @@ func TestOnStatusChangeCalled(t *testing.T) {
 	assert.Assert(t, err != nil, "error expected and not seen")
 	assert.Equal(t, app.CurrentState(), Accepted.String(), "application state has been changed unexpectedly")
 	assert.Assert(t, !testHandler.isHandled(), "unexpected event send to the RM")
+
+	log := app.GetEventLog()
+	assert.Equal(t, len(log), 1, "wrong number of app events")
+	assert.Equal(t, log[0].ApplicationState, Accepted.String())
 }
 
 func TestReplaceAllocation(t *testing.T) {
@@ -1079,6 +1118,11 @@ func runTimeoutPlaceholderTest(t *testing.T, expectedState string, gangSchedulin
 	assert.Assert(t, resources.IsZero(app.GetPendingResource()), "pending placeholder resources should be zero")
 	// a released placeholder still holds the resource until release confirmed by the RM
 	assert.Assert(t, resources.Equals(app.GetPlaceholderResource(), resources.Multiply(res, 2)), "Unexpected placeholder resources for the app")
+
+	log := app.GetEventLog()
+	assert.Equal(t, len(log), 2, "wrong number of app events")
+	assert.Equal(t, log[0].ApplicationState, Accepted.String())
+	assert.Equal(t, log[1].ApplicationState, expectedState)
 }
 
 func TestTimeoutPlaceholderAllocReleased(t *testing.T) {

--- a/pkg/webservice/dao/application_info.go
+++ b/pkg/webservice/dao/application_info.go
@@ -34,6 +34,12 @@ type ApplicationDAOInfo struct {
 	State           string              `json:"applicationState"`
 	User            string              `json:"user"`
 	RejectedMessage string              `json:"rejectedMessage"`
+	Events          []EventDAOInfo      `json:"events"`
+}
+
+type EventDAOInfo struct {
+	EventTime int64  `json:"eventTime"`
+	State     string `json:"applicationState"`
 }
 
 type AllocationDAOInfo struct {

--- a/pkg/webservice/dao/application_info.go
+++ b/pkg/webservice/dao/application_info.go
@@ -34,12 +34,12 @@ type ApplicationDAOInfo struct {
 	State           string              `json:"applicationState"`
 	User            string              `json:"user"`
 	RejectedMessage string              `json:"rejectedMessage"`
-	Events          []EventDAOInfo      `json:"events"`
+	StateLog        []StateDAOInfo      `json:"stateLog"`
 }
 
-type EventDAOInfo struct {
-	EventTime int64  `json:"eventTime"`
-	State     string `json:"applicationState"`
+type StateDAOInfo struct {
+	Time             int64  `json:"time"`
+	ApplicationState string `json:"applicationState"`
 }
 
 type AllocationDAOInfo struct {

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -294,6 +294,15 @@ func getApplicationJSON(app *objects.Application) *dao.ApplicationDAOInfo {
 		}
 		allocationInfo = append(allocationInfo, allocInfo)
 	}
+	events := app.GetEventLog()
+	eventsInfo := make([]dao.EventDAOInfo, 0, len(events))
+	for _, event := range events {
+		eventInfo := dao.EventDAOInfo{
+			EventTime: event.EventTime.UnixNano(),
+			State:     event.ApplicationState,
+		}
+		eventsInfo = append(eventsInfo, eventInfo)
+	}
 
 	return &dao.ApplicationDAOInfo{
 		ApplicationID:   app.ApplicationID,
@@ -307,6 +316,7 @@ func getApplicationJSON(app *objects.Application) *dao.ApplicationDAOInfo {
 		State:           app.CurrentState(),
 		User:            app.GetUser().User,
 		RejectedMessage: app.GetRejectedMessage(),
+		Events:          eventsInfo,
 	}
 }
 

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -294,14 +294,14 @@ func getApplicationJSON(app *objects.Application) *dao.ApplicationDAOInfo {
 		}
 		allocationInfo = append(allocationInfo, allocInfo)
 	}
-	events := app.GetEventLog()
-	eventsInfo := make([]dao.EventDAOInfo, 0, len(events))
-	for _, event := range events {
-		eventInfo := dao.EventDAOInfo{
-			EventTime: event.EventTime.UnixNano(),
-			State:     event.ApplicationState,
+	stateLog := app.GetStateLog()
+	stateLogInfo := make([]dao.StateDAOInfo, 0, len(stateLog))
+	for _, state := range stateLog {
+		stateInfo := dao.StateDAOInfo{
+			Time:             state.Time.UnixNano(),
+			ApplicationState: state.ApplicationState,
 		}
-		eventsInfo = append(eventsInfo, eventInfo)
+		stateLogInfo = append(stateLogInfo, stateInfo)
 	}
 
 	return &dao.ApplicationDAOInfo{
@@ -316,7 +316,7 @@ func getApplicationJSON(app *objects.Application) *dao.ApplicationDAOInfo {
 		State:           app.CurrentState(),
 		User:            app.GetUser().User,
 		RejectedMessage: app.GetRejectedMessage(),
-		Events:          eventsInfo,
+		StateLog:        stateLogInfo,
 	}
 }
 


### PR DESCRIPTION
### What is this PR for?
Expose application state transitions in the REST API as part of the application objects.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1163

### How should this be tested?
Unit tests updated to verify event logs.

### Screenshots (if appropriate)
<img width="375" alt="stateLog" src="https://user-images.githubusercontent.com/12699633/160882668-2d75606f-b9f0-4559-8960-acf07d7d9223.png">

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
