### PR TITLE
[YUNIKORN-1164] Fix inconsistent lock behavior in application.go

### DIFF
--- a/pkg/scheduler/objects/application_state.go
+++ b/pkg/scheduler/objects/application_state.go
@@ -20,8 +20,9 @@ package objects
 
 import (
 	"fmt"
-	"go.uber.org/zap"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/apache/yunikorn-core/pkg/log"
 	"github.com/apache/yunikorn-core/pkg/metrics"
@@ -150,12 +151,12 @@ func NewAppState() *fsm.FSM {
 			},
 			fmt.Sprintf("leave_%s", New.String()): func(event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
-				metrics.GetQueueMetrics(app.QueuePath).IncQueueApplicationsAccepted()
+				metrics.GetQueueMetrics(app.queuePath).IncQueueApplicationsAccepted()
 				metrics.GetSchedulerMetrics().IncTotalApplicationsAccepted()
 			},
 			fmt.Sprintf("enter_%s", Rejected.String()): func(event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
-				metrics.GetQueueMetrics(app.QueuePath).IncQueueApplicationsRejected()
+				metrics.GetQueueMetrics(app.queuePath).IncQueueApplicationsRejected()
 				metrics.GetSchedulerMetrics().IncTotalApplicationsRejected()
 				app.setStateTimer(terminatedTimeout, app.stateMachine.Current(), ExpireApplication)
 				app.finishedTime = time.Now()
@@ -166,26 +167,26 @@ func NewAppState() *fsm.FSM {
 			},
 			fmt.Sprintf("enter_%s", Running.String()): func(event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
-				metrics.GetQueueMetrics(app.QueuePath).IncQueueApplicationsRunning()
+				metrics.GetQueueMetrics(app.queuePath).IncQueueApplicationsRunning()
 				metrics.GetSchedulerMetrics().IncTotalApplicationsRunning()
 			},
 			fmt.Sprintf("leave_%s", Running.String()): func(event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
-				metrics.GetQueueMetrics(app.QueuePath).DecQueueApplicationsRunning()
+				metrics.GetQueueMetrics(app.queuePath).DecQueueApplicationsRunning()
 				metrics.GetSchedulerMetrics().DecTotalApplicationsRunning()
 			},
 			fmt.Sprintf("enter_%s", Completed.String()): func(event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				metrics.GetSchedulerMetrics().IncTotalApplicationsCompleted()
-				metrics.GetQueueMetrics(app.QueuePath).IncQueueApplicationsCompleted()
+				metrics.GetQueueMetrics(app.queuePath).IncQueueApplicationsCompleted()
 				app.setStateTimer(terminatedTimeout, app.stateMachine.Current(), ExpireApplication)
 				app.executeTerminatedCallback()
 				app.clearPlaceholderTimer()
 			},
 			fmt.Sprintf("enter_%s", Failed.String()): func(event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
-				metrics.GetQueueMetrics(app.QueuePath).DecQueueApplicationsRunning()
-				metrics.GetQueueMetrics(app.QueuePath).IncQueueApplicationsFailed()
+				metrics.GetQueueMetrics(app.queuePath).DecQueueApplicationsRunning()
+				metrics.GetQueueMetrics(app.queuePath).IncQueueApplicationsFailed()
 				metrics.GetSchedulerMetrics().DecTotalApplicationsRunning()
 				metrics.GetSchedulerMetrics().IncTotalApplicationsFailed()
 				app.setStateTimer(terminatedTimeout, app.stateMachine.Current(), ExpireApplication)

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -44,7 +44,7 @@ func TestNewApplication(t *testing.T) {
 	siApp := &si.AddApplicationRequest{}
 	app := NewApplication(siApp, user, nil, "")
 	assert.Equal(t, app.ApplicationID, "", "application ID should not be set was not set in SI")
-	assert.Equal(t, app.QueuePath, "", "queue name should not be set was not set in SI")
+	assert.Equal(t, app.GetQueuePath(), "", "queue name should not be set was not set in SI")
 	assert.Equal(t, app.Partition, "", "partition name should not be set was not set in SI")
 	assert.Equal(t, app.rmID, "", "RM ID should not be set was not passed in")
 	assert.Equal(t, app.rmEventHandler, handler.EventHandler(nil), "event handler should be nil")
@@ -76,7 +76,7 @@ func TestNewApplication(t *testing.T) {
 	}
 	app = NewApplication(siApp, user, &appEventHandler{}, "myRM")
 	assert.Equal(t, app.ApplicationID, "appID", "application ID should not be set to SI value")
-	assert.Equal(t, app.QueuePath, "some.queue", "queue name should not be set to SI value")
+	assert.Equal(t, app.GetQueuePath(), "some.queue", "queue name should not be set to SI value")
 	assert.Equal(t, app.Partition, "AnotherPartition", "partition name should be set to SI value")
 	if app.rmEventHandler == nil {
 		t.Fatal("non nil handler was not set in the new app")
@@ -847,7 +847,7 @@ func TestQueueUpdate(t *testing.T) {
 	queue, err := createDynamicQueue(root, "test", false)
 	assert.NilError(t, err, "failed to create test queue")
 	app.SetQueue(queue)
-	assert.Equal(t, app.QueuePath, "root.test")
+	assert.Equal(t, app.GetQueuePath(), "root.test")
 }
 
 func TestStateTimeOut(t *testing.T) {
@@ -1264,13 +1264,11 @@ func TestGetAllRequests(t *testing.T) {
 
 func TestGetQueueNameAfterUnsetQueue(t *testing.T) {
 	app := newApplication(appID1, "default", "root.unknown")
-	assert.Equal(t, app.GetQueuePath(), app.QueuePath)
 	assert.Equal(t, app.GetQueuePath(), "root.unknown")
 
 	// the queue is reset to nil but GetQueuePath should work well
 	app.UnSetQueue()
 	assert.Assert(t, app.queue == nil)
-	assert.Equal(t, app.GetQueuePath(), app.QueuePath)
 	assert.Equal(t, app.GetQueuePath(), "root.unknown")
 }
 

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -316,14 +316,14 @@ func (pc *PartitionContext) AddApplication(app *objects.Application) error {
 	}
 
 	// Put app under the queue
-	queueName := app.QueuePath
+	queueName := app.GetQueuePath()
 	pm := pc.getPlacementManager()
 	if pm.IsInitialised() {
 		err := pm.PlaceApplication(app)
 		if err != nil {
 			return fmt.Errorf("failed to place application %s: %v", appID, err)
 		}
-		queueName = app.QueuePath
+		queueName = app.GetQueuePath()
 		if queueName == "" {
 			return fmt.Errorf("application rejected by placement rules: %s", appID)
 		}
@@ -956,7 +956,7 @@ func (pc *PartitionContext) reserve(app *objects.Application, node *objects.Node
 
 	log.Logger().Info("allocation ask is reserved",
 		zap.String("appID", appID),
-		zap.String("queue", app.QueuePath),
+		zap.String("queue", app.GetQueuePath()),
 		zap.String("allocationKey", ask.AllocationKey),
 		zap.String("node", node.NodeID))
 }
@@ -985,7 +985,7 @@ func (pc *PartitionContext) unReserve(app *objects.Application, node *objects.No
 
 	log.Logger().Info("allocation ask is unreserved",
 		zap.String("appID", appID),
-		zap.String("queue", app.QueuePath),
+		zap.String("queue", app.GetQueuePath()),
 		zap.String("allocationKey", ask.AllocationKey),
 		zap.String("node", node.NodeID),
 		zap.Int("reservationsRemoved", num))
@@ -1499,7 +1499,7 @@ func (pc *PartitionContext) hasUnlimitedNode() bool {
 }
 
 func (pc *PartitionContext) AddRejectedApplication(rejectedApplication *objects.Application, rejectedMessage string) {
-	if err := rejectedApplication.HandleApplicationEventWithInfo(objects.RejectApplication, rejectedMessage); err != nil {
+	if err := rejectedApplication.RejectApplication(rejectedMessage); err != nil {
 		log.Logger().Warn("BUG: Unexpected failure: Application state not changed to Rejected",
 			zap.String("currentState", rejectedApplication.CurrentState()),
 			zap.Error(err))

--- a/pkg/scheduler/partition_manager.go
+++ b/pkg/scheduler/partition_manager.go
@@ -149,7 +149,7 @@ func (manager *partitionManager) remove() {
 		zap.Int("numOfApps", len(apps)),
 		zap.String("partitionName", manager.pc.Name))
 	for i := range apps {
-		_ = apps[i].HandleApplicationEventWithInfo(objects.FailApplication, "PartitionRemoved")
+		_ = apps[i].FailApplication("PartitionRemoved")
 		appID := apps[i].ApplicationID
 		_ = manager.pc.removeApplication(appID)
 	}

--- a/pkg/scheduler/placement/placement.go
+++ b/pkg/scheduler/placement/placement.go
@@ -150,7 +150,7 @@ func (m *AppPlacementManager) PlaceApplication(app *objects.Application) error {
 			log.Logger().Error("rule execution failed",
 				zap.String("ruleName", checkRule.getName()),
 				zap.Error(err))
-			app.QueuePath = ""
+			app.SetQueuePath("")
 			return err
 		}
 		// queueName returned make sure ACL allows access and create the queueName if not exist
@@ -206,7 +206,7 @@ func (m *AppPlacementManager) PlaceApplication(app *objects.Application) error {
 		zap.String("queueName", queueName))
 	// no more rules to check no queueName found reject placement
 	if queueName == "" {
-		app.QueuePath = ""
+		app.SetQueuePath("")
 		return fmt.Errorf("application rejected: no placement rule matched")
 	}
 	// Add the queue into the application, overriding what was submitted

--- a/pkg/scheduler/placement/placement_test.go
+++ b/pkg/scheduler/placement/placement_test.go
@@ -219,7 +219,7 @@ partitions:
 
 	// user rule existing queue, acl allowed
 	err = man.PlaceApplication(app)
-	queueName := app.QueuePath
+	queueName := app.GetQueuePath()
 	if err != nil || queueName != "root.testparent.testchild" {
 		t.Errorf("leaf exist: app should have been placed in user queue, queue: '%s', error: %v", queueName, err)
 	}
@@ -231,7 +231,7 @@ partitions:
 	// user rule new queue: fails on create flag
 	app = newApplication("app1", "default", "", user, tags, nil, "")
 	err = man.PlaceApplication(app)
-	queueName = app.QueuePath
+	queueName = app.GetQueuePath()
 	if err == nil || queueName != "" {
 		t.Errorf("leaf to create, no create flag: app should not have been placed, queue: '%s', error: %v", queueName, err)
 	}
@@ -239,7 +239,7 @@ partitions:
 	// provided rule (2nd rule): queue acl allowed, anyone create
 	app = newApplication("app1", "default", "root.fixed.leaf", user, tags, nil, "")
 	err = man.PlaceApplication(app)
-	queueName = app.QueuePath
+	queueName = app.GetQueuePath()
 	if err != nil || queueName != "root.fixed.leaf" {
 		t.Errorf("leave create, acl allow: app should have been placed, queue: '%s', error: %v", queueName, err)
 	}
@@ -251,7 +251,7 @@ partitions:
 	}
 	app = newApplication("app1", "default", "root.fixed.other", user, tags, nil, "")
 	err = man.PlaceApplication(app)
-	queueName = app.QueuePath
+	queueName = app.GetQueuePath()
 	if err == nil || queueName != "" {
 		t.Errorf("leaf to create, acl deny: app should not have been placed, queue: '%s', error: %v", queueName, err)
 	}
@@ -260,7 +260,7 @@ partitions:
 	tags = map[string]string{"namespace": "root.fixed.leaf"}
 	app = newApplication("app1", "default", "", user, tags, nil, "")
 	err = man.PlaceApplication(app)
-	queueName = app.QueuePath
+	queueName = app.GetQueuePath()
 	if err == nil || queueName != "" {
 		t.Errorf("existing leaf, acl deny: app should not have been placed, queue: '%s', error: %v", queueName, err)
 	}
@@ -272,7 +272,7 @@ partitions:
 	}
 	app = newApplication("app1", "default", "", user, tags, nil, "")
 	err = man.PlaceApplication(app)
-	queueName = app.QueuePath
+	queueName = app.GetQueuePath()
 	if err != nil || queueName != "root.fixed.leaf" {
 		t.Errorf("existing leaf, acl allow: app should have been placed, queue: '%s', error: %v", queueName, err)
 	}
@@ -280,7 +280,7 @@ partitions:
 	// provided rule (2nd): submit to parent
 	app = newApplication("app1", "default", "root.fixed", user, nil, nil, "")
 	err = man.PlaceApplication(app)
-	queueName = app.QueuePath
+	queueName = app.GetQueuePath()
 	if err == nil || queueName != "" {
 		t.Errorf("parent queue: app should not have been placed, queue: '%s', error: %v", queueName, err)
 	}

--- a/pkg/scheduler/placement/provided_rule.go
+++ b/pkg/scheduler/placement/provided_rule.go
@@ -53,7 +53,8 @@ func (pr *providedRule) initialise(conf configs.PlacementRule) error {
 
 func (pr *providedRule) placeApplication(app *objects.Application, queueFn func(string) *objects.Queue) (string, error) {
 	// since this is the provided rule we must have a queue in the info already
-	if app.QueuePath == "" {
+	queueName := app.GetQueuePath()
+	if queueName == "" {
 		return "", nil
 	}
 	// before anything run the filter
@@ -65,7 +66,6 @@ func (pr *providedRule) placeApplication(app *objects.Application, queueFn func(
 	}
 	var parentName string
 	var err error
-	queueName := app.QueuePath
 	// if we have a fully qualified queue passed in do not run the parent rule
 	if !strings.HasPrefix(queueName, configs.RootQueue+configs.DOT) {
 		// run the parent rule if set

--- a/pkg/scheduler/placement/rule_test.go
+++ b/pkg/scheduler/placement/rule_test.go
@@ -73,12 +73,16 @@ func TestPlaceApp(t *testing.T) {
 		t.Errorf("test rule place application did not fail, err: %v, ", err)
 	}
 	// place application that should not fail and return the queue in the object
-	queue, err = nr.placeApplication(&objects.Application{QueuePath: "passedin"}, nil)
+	app := &objects.Application{}
+	app.SetQueuePath("passedin")
+	queue, err = nr.placeApplication(app, nil)
 	if err != nil || queue != "passedin" {
 		t.Errorf("test rule place application did not fail, err: %v, ", err)
 	}
 	// place application that should not fail and return the queue in the object
-	queue, err = nr.placeApplication(&objects.Application{QueuePath: "user.name"}, nil)
+	app = &objects.Application{}
+	app.SetQueuePath("user.name")
+	queue, err = nr.placeApplication(app, nil)
 	if err != nil || queue != "user_dot_name" {
 		t.Errorf("test rule place application did not fail, err: %v, ", err)
 	}

--- a/pkg/scheduler/placement/testrule.go
+++ b/pkg/scheduler/placement/testrule.go
@@ -51,8 +51,8 @@ func (tr *testRule) placeApplication(app *objects.Application, queueFn func(stri
 	if app == nil {
 		return "", fmt.Errorf("nil app passed in")
 	}
-	if app.QueuePath != "" {
-		return replaceDot(app.QueuePath), nil
+	if queuePath := app.GetQueuePath(); queuePath != "" {
+		return replaceDot(queuePath), nil
 	}
 	return "test", nil
 }

--- a/pkg/scheduler/tests/recovery_test.go
+++ b/pkg/scheduler/tests/recovery_test.go
@@ -652,7 +652,7 @@ func TestAppRecovery(t *testing.T) {
 		t.Fatal("application not found after recovery")
 	}
 	assert.Equal(t, app.ApplicationID, appID1)
-	assert.Equal(t, app.QueuePath, "root.a")
+	assert.Equal(t, app.GetQueuePath(), "root.a")
 }
 
 // test scheduler recovery that only registers apps

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -320,7 +320,7 @@ func getApplicationJSON(app *objects.Application) *dao.ApplicationDAOInfo {
 		UsedResource:    app.GetAllocatedResource().DAOMap(),
 		MaxUsedResource: app.GetMaxAllocatedResource().DAOMap(),
 		Partition:       common.GetPartitionNameWithoutClusterID(app.Partition),
-		QueueName:       app.QueuePath,
+		QueueName:       app.GetQueuePath(),
 		SubmissionTime:  app.SubmissionTime.UnixNano(),
 		FinishedTime:    common.ZeroTimeInUnixNano(app.FinishedTime()),
 		Allocations:     allocationInfo,


### PR DESCRIPTION
### What is this PR for?
Fixes inconsistent locking in application.go:

* Change QueuePath to queuePath and use accessor methods from external code
* Remove QueuePath from String() as it is accessed from both locked and unlocked contexts
* Introduce RejectApplication() and FailApplication() methods to handle unlocked usage of HandleApplicationWithEventInfo()
* Update timeoutStateTimer() to acquire lock as it is run from a new goroutine
* Ensure getOutstandingRequests() calls sortRequests() under write lock

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1164

### How should this be tested?
Core unit tests as well as k8shim unit and e2e tests compiled against this version.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
