### PR TITLE
[YUNIKORN-957] move doStateDump to new internal REST objects

### DIFF
--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -851,6 +851,7 @@ func getApplicationsDAO(lists map[string]*scheduler.PartitionContext) []*dao.App
 		var appList []*objects.Application
 		appList = append(appList, partition.GetApplications()...)
 		appList = append(appList, partition.GetCompletedApplications()...)
+		appList = append(appList, partition.GetRejectedApplications()...)
 
 		for _, app := range appList {
 			result = append(result, getApplicationJSON(app))
@@ -860,11 +861,11 @@ func getApplicationsDAO(lists map[string]*scheduler.PartitionContext) []*dao.App
 	return result
 }
 
-func getPartitionDAO(lists map[string]*scheduler.PartitionContext) []*dao.PartitionDAOInfo {
-	var result []*dao.PartitionDAOInfo
+func getPartitionQueuesDAO(lists map[string]*scheduler.PartitionContext) []dao.PartitionQueueDAOInfo {
+	var result []dao.PartitionQueueDAOInfo
 
 	for _, partition := range lists {
-		result = append(result, getPartitionJSON(partition))
+		result = append(result, partition.GetPartitionQueues())
 	}
 
 	return result

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1646,7 +1646,6 @@ func verifyStateDumpJSON(t *testing.T, aggregated *AggregatedStateInfo) {
 	assert.Check(t, len(aggregated.Partitions) > 0)
 	assert.Check(t, len(aggregated.Nodes) > 0)
 	assert.Check(t, len(aggregated.ClusterInfo) > 0)
-	assert.Check(t, len(aggregated.ClusterUtilization) > 0)
 	assert.Check(t, len(aggregated.Queues) > 0)
 	assert.Check(t, len(aggregated.LogLevel) > 0)
 }

--- a/pkg/webservice/state_dump.go
+++ b/pkg/webservice/state_dump.go
@@ -53,17 +53,15 @@ var (
 )
 
 type AggregatedStateInfo struct {
-	Timestamp          string
-	Partitions         []*dao.PartitionInfo
-	Applications       []*dao.ApplicationDAOInfo
-	AppHistory         []*dao.ApplicationHistoryDAOInfo
-	Nodes              []*dao.NodesDAOInfo
-	NodesUtilization   []*dao.NodesUtilDAOInfo
-	ClusterInfo        []*dao.ClusterDAOInfo
-	ClusterUtilization []*dao.ClustersUtilDAOInfo
-	ContainerHistory   []*dao.ContainerHistoryDAOInfo
-	Queues             []*dao.PartitionDAOInfo
-	LogLevel           string
+	Timestamp        string
+	Partitions       []*dao.PartitionInfo
+	Applications     []*dao.ApplicationDAOInfo
+	AppHistory       []*dao.ApplicationHistoryDAOInfo
+	Nodes            []*dao.NodesDAOInfo
+	ClusterInfo      []*dao.ClusterDAOInfo
+	ContainerHistory []*dao.ContainerHistoryDAOInfo
+	Queues           []dao.PartitionQueueDAOInfo
+	LogLevel         string
 }
 
 func getFullStateDump(w http.ResponseWriter, r *http.Request) {
@@ -142,17 +140,15 @@ func doStateDump(w io.Writer, periodic bool) error {
 	zapConfig := yunikornLog.GetConfig()
 
 	var aggregated = AggregatedStateInfo{
-		Timestamp:          time.Now().Format(time.RFC3339),
-		Partitions:         getPartitionInfoDAO(partitionContext),
-		Applications:       getApplicationsDAO(partitionContext),
-		AppHistory:         getAppHistoryDAO(records),
-		Nodes:              getNodesDAO(partitionContext),
-		NodesUtilization:   getNodesUtilDAO(partitionContext),
-		ClusterInfo:        getClusterDAO(partitionContext),
-		ClusterUtilization: getClustersUtilDAO(partitionContext),
-		ContainerHistory:   getContainerHistoryDAO(records),
-		Queues:             getPartitionDAO(partitionContext),
-		LogLevel:           zapConfig.Level.Level().String(),
+		Timestamp:        time.Now().Format(time.RFC3339),
+		Partitions:       getPartitionInfoDAO(partitionContext),
+		Applications:     getApplicationsDAO(partitionContext),
+		AppHistory:       getAppHistoryDAO(records),
+		Nodes:            getNodesDAO(partitionContext),
+		ClusterInfo:      getClusterDAO(partitionContext),
+		ContainerHistory: getContainerHistoryDAO(records),
+		Queues:           getPartitionQueuesDAO(partitionContext),
+		LogLevel:         zapConfig.Level.Level().String(),
 	}
 
 	var prettyJSON []byte


### PR DESCRIPTION
### What is this PR for?
Changed items:

1. Remove `NodesUtilization` and `ClusterUtilization` of `AggregatedStateInfo`.
Because `/ws/v1/nodes/utilization` has been Deprecated and replaced with `/ws/v1/partition/{partitionName}/nodes`.
Because `/ws/v1/clusters/utilization `has been Deprecated and replaced with `/ws/v1/partitions`.
2. Remove `getPartitionDAO` and replace it with `getPartitionQueuesDAO`.
3. `getApplicationsDAO` adds information about rejected applications.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-957

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
