### PR TITLE
[YUNIKORN-1183] pre-select node for daemon set pod

### DIFF
--- a/pkg/scheduler/objects/allocation_ask.go
+++ b/pkg/scheduler/objects/allocation_ask.go
@@ -167,3 +167,9 @@ func (aa *AllocationAsk) GetRequiredNode() string {
 	defer aa.RUnlock()
 	return aa.requiredNode
 }
+
+func (aa *AllocationAsk) SetRequiredNode(node string) {
+	aa.Lock()
+	defer aa.Unlock()
+	aa.requiredNode = node
+}

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -664,8 +664,6 @@ func (sa *Application) IsReservedOnNode(nodeID string) bool {
 // If the reservation fails the function returns false, if the reservation is made it returns true.
 // If the node and ask combination was already reserved for the application this is a noop and returns true.
 func (sa *Application) Reserve(node *Node, ask *AllocationAsk) error {
-	sa.Lock()
-	defer sa.Unlock()
 	// create the reservation (includes nil checks)
 	nodeReservation := newReservation(node, sa, ask, true)
 	if nodeReservation == nil {
@@ -817,7 +815,7 @@ func (sa *Application) getOutstandingRequests(headRoom *resources.Resource, tota
 
 // Try a regular allocation of the pending requests
 // This includes placeholders
-func (sa *Application) tryAllocate(headRoom *resources.Resource, nodeIterator func() NodeIterator) *Allocation {
+func (sa *Application) tryAllocate(headRoom *resources.Resource, nodeIterator func() NodeIterator, getnode func(string) *Node) *Allocation {
 	sa.Lock()
 	defer sa.Unlock()
 	// make sure the request are sorted
@@ -845,6 +843,27 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, nodeIterator fu
 			}
 			continue
 		}
+
+		requiredNode := request.GetRequiredNode()
+		// does request (daemon set pods?) has any constraint to run on specific node?
+		if requiredNode != "" {
+			node := getnode(requiredNode)
+			alloc := sa.tryNode(node, request)
+			if alloc != nil {
+				log.Logger().Debug("allocation on required node is completed",
+					zap.String("required node", node.NodeID),
+					zap.String("allocation key", request.AllocationKey))
+				return alloc
+			}
+			if err := sa.Reserve(node, request); err != nil {
+				log.Logger().Warn("Failed to reserve the required node",
+					zap.String("required node", node.NodeID),
+					zap.String("allocation key", request.AllocationKey),
+					zap.String("reason", err.Error()))
+			}
+			continue
+		}
+
 		iterator := nodeIterator()
 		if iterator != nil {
 			alloc := sa.tryNodes(request, iterator)

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -666,12 +666,12 @@ func (sa *Application) IsReservedOnNode(nodeID string) bool {
 func (sa *Application) Reserve(node *Node, ask *AllocationAsk) error {
 	sa.Lock()
 	defer sa.Unlock()
-	return sa.ReserveInternal(node, ask)
+	return sa.reserveInternal(node, ask)
 }
 
 // Unlocked version for Reserve that really does the work.
 // Must only be called while holding the application lock.
-func (sa *Application) ReserveInternal(node *Node, ask *AllocationAsk) error {
+func (sa *Application) reserveInternal(node *Node, ask *AllocationAsk) error {
 	// create the reservation (includes nil checks)
 	nodeReservation := newReservation(node, sa, ask, true)
 	if nodeReservation == nil {
@@ -823,7 +823,7 @@ func (sa *Application) getOutstandingRequests(headRoom *resources.Resource, tota
 
 // Try a regular allocation of the pending requests
 // This includes placeholders
-func (sa *Application) tryAllocate(headRoom *resources.Resource, nodeIterator func() NodeIterator, getnode func(string) *Node) *Allocation {
+func (sa *Application) tryAllocate(headRoom *resources.Resource, nodeIterator func() NodeIterator, getNodeFn func(string) *Node) *Allocation {
 	sa.Lock()
 	defer sa.Unlock()
 	// make sure the request are sorted
@@ -855,7 +855,7 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, nodeIterator fu
 		requiredNode := request.GetRequiredNode()
 		// does request (daemon set pods?) has any constraint to run on specific node?
 		if requiredNode != "" {
-			node := getnode(requiredNode)
+			node := getNodeFn(requiredNode)
 			alloc := sa.tryNode(node, request)
 			if alloc != nil {
 				log.Logger().Debug("allocation on required node is completed",
@@ -863,7 +863,7 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, nodeIterator fu
 					zap.String("allocation key", request.AllocationKey))
 				return alloc
 			}
-			if err := sa.ReserveInternal(node, request); err != nil {
+			if err := sa.reserveInternal(node, request); err != nil {
 				log.Logger().Warn("Failed to reserve the required node",
 					zap.String("required node", node.NodeID),
 					zap.String("allocation key", request.AllocationKey),
@@ -887,7 +887,7 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, nodeIterator fu
 
 // tryPlaceholderAllocate tries to replace a placeholder that is allocated with a real allocation
 //nolint:funlen
-func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, getnode func(string) *Node) *Allocation {
+func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, getNodeFn func(string) *Node) *Allocation {
 	sa.Lock()
 	defer sa.Unlock()
 	// nothing to do if we have no placeholders allocated
@@ -947,7 +947,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 				phFit = ph
 				reqFit = request
 			}
-			node := getnode(ph.NodeID)
+			node := getNodeFn(ph.NodeID)
 			// got the node run same checks as for reservation (all but fits)
 			// resource usage should not change anyway between placeholder and real one at this point
 			if node != nil && node.preReserveConditions(request.AllocationKey) {

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -412,12 +412,6 @@ func (sn *Node) IsValidFor(ask *AllocationAsk) error {
 		}
 		return nil
 	}
-	// ask has required node, just check if the node is with the expected ID
-	// ignore the unschedulable flag in this case
-	if ask.requiredNode != sn.NodeID {
-		return fmt.Errorf("ask %s is restricted to node %s, skipping node %s",
-			ask.AllocationKey, ask.requiredNode, sn.NodeID)
-	}
 	return nil
 }
 

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -401,20 +401,6 @@ func (sn *Node) preConditions(allocID string, allocate bool) bool {
 	return true
 }
 
-// IsValidFor checks if the node is valid for this allocationAsk
-func (sn *Node) IsValidFor(ask *AllocationAsk) error {
-	if ask.GetRequiredNode() == "" {
-		// ask can be allocated to any node
-		// just check if the node is unschedulable
-		if !sn.IsSchedulable() {
-			return fmt.Errorf("skip ask %s on unschedulable node %s",
-				ask.AllocationKey, sn.NodeID)
-		}
-		return nil
-	}
-	return nil
-}
-
 // Check if the node should be considered as a possible node to allocate on.
 //
 // This is a lock free call. No updates are made this only performs a pre allocate checks

--- a/pkg/scheduler/objects/node_test.go
+++ b/pkg/scheduler/objects/node_test.go
@@ -21,8 +21,6 @@ package objects
 import (
 	"testing"
 
-	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
-
 	"gotest.tools/assert"
 
 	"github.com/apache/yunikorn-core/pkg/common/resources"
@@ -648,55 +646,6 @@ func TestUpdateResources(t *testing.T) {
 	available.SubFrom(occupied)
 	if !resources.Equals(available, node.GetAvailableResource()) {
 		t.Errorf("available resources should have been updated to: %s, got %s", available, node.GetAvailableResource())
-	}
-}
-
-func TestIsValidFor(t *testing.T) {
-	resource := resources.NewResourceFromMap(map[string]resources.Quantity{resources.MEMORY: 10})
-
-	// ask 1 is a normal ask
-	ask1 := newAllocationAsk("key", "appID", resource)
-
-	// node 1: schedulable
-	node1 := NewNode(&si.NodeInfo{
-		NodeID: "node-1",
-	})
-	// node 1: unschedulable
-	node1Unschedulable := NewNode(&si.NodeInfo{
-		NodeID: "node-1",
-	})
-	node1Unschedulable.SetSchedulable(false)
-	// node 2: schedulable
-	node2 := NewNode(&si.NodeInfo{
-		NodeID: "node-2",
-	})
-	// node 2: unschedulable
-	node2Unschedulable := NewNode(&si.NodeInfo{
-		NodeID: "node-2",
-	})
-	node2Unschedulable.SetSchedulable(false)
-
-	var tests = []struct {
-		name    string
-		ask     *AllocationAsk
-		node    *Node
-		isValid bool
-	}{
-		{"normal ask1 on schedulable node1", ask1, node1, true},
-		{"normal ask1 on schedulable node2", ask1, node2, true},
-		{"normal ask1 on unschedulable node1", ask1, node1Unschedulable, false},
-		{"normal ask1 on unschedulable node2", ask1, node2Unschedulable, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.node.IsValidFor(tt.ask)
-			if got == nil && !tt.isValid {
-				t.Error("expected node is not valid for the ask")
-			} else if got != nil && tt.isValid {
-				t.Error("expected node is valid for the ask")
-			}
-		})
 	}
 }
 

--- a/pkg/scheduler/objects/node_test.go
+++ b/pkg/scheduler/objects/node_test.go
@@ -656,9 +656,6 @@ func TestIsValidFor(t *testing.T) {
 
 	// ask 1 is a normal ask
 	ask1 := newAllocationAsk("key", "appID", resource)
-	// ask 2 is a ask that has requiredNode set
-	ask2 := newAllocationAsk("key", "appID", resource)
-	ask2.requiredNode = "node-1"
 
 	// node 1: schedulable
 	node1 := NewNode(&si.NodeInfo{
@@ -689,10 +686,6 @@ func TestIsValidFor(t *testing.T) {
 		{"normal ask1 on schedulable node2", ask1, node2, true},
 		{"normal ask1 on unschedulable node1", ask1, node1Unschedulable, false},
 		{"normal ask1 on unschedulable node2", ask1, node2Unschedulable, false},
-		{"ask2 required node1 on schedulable node1", ask2, node1, true},
-		{"ask2 required node1 on unschedulable node1", ask2, node1Unschedulable, true},
-		{"ask2 required node1 on schedulable node2", ask2, node2, false},
-		{"ask2 required node1 on unschedulable node2", ask2, node2Unschedulable, false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -828,7 +828,7 @@ func (pc *PartitionContext) tryAllocate() *objects.Allocation {
 		return nil
 	}
 	// try allocating from the root down
-	alloc := pc.root.TryAllocate(pc.GetNodeIterator)
+	alloc := pc.root.TryAllocate(pc.GetNodeIterator, pc.GetNode)
 	if alloc != nil {
 		return pc.allocate(alloc)
 	}

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1002,6 +1002,61 @@ func TestTryAllocate(t *testing.T) {
 	assert.Assert(t, resources.IsZero(partition.root.GetPendingResource()), "pending resources should be set to zero")
 }
 
+// allocate ask request with required node
+func TestTryAllocateWithRequiredNode(t *testing.T) {
+	partition := createQueuesNodes(t)
+	if partition == nil {
+		t.Fatal("partition create failed")
+	}
+	if alloc := partition.tryAllocate(); alloc != nil {
+		t.Fatalf("empty cluster allocate returned allocation: %v", alloc.String())
+	}
+
+	app := newApplication(appID1, "default", "root.parent.sub-leaf")
+	res, err := resources.NewResourceFromConf(map[string]string{"vcore": "8"})
+	assert.NilError(t, err, "failed to create resource")
+
+	// add to the partition
+	err = partition.AddApplication(app)
+	assert.NilError(t, err, "failed to add app-1 to partition")
+	ask := newAllocationAsk("alloc-1", appID1, res)
+	ask.SetRequiredNode("node-1")
+	err = app.AddAllocationAsk(ask)
+	assert.NilError(t, err, "failed to add ask alloc-1 to app-1")
+
+	// first allocation should be app-1 and alloc-2
+	alloc := partition.tryAllocate()
+
+	if alloc == nil {
+		t.Fatal("allocation did not return any allocation")
+	}
+	assert.Equal(t, alloc.Result, objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, len(alloc.Releases), 0, "released allocations should have been 0")
+	assert.Equal(t, alloc.ApplicationID, appID1, "expected application app-1 to be allocated")
+	assert.Equal(t, alloc.AllocationKey, "alloc-1", "expected ask alloc-2 to be allocated")
+
+	res2, err := resources.NewResourceFromConf(map[string]string{"vcore": "10"})
+	assert.NilError(t, err, "failed to create resource")
+
+	ask2 := newAllocationAsk("alloc-2", appID1, res2)
+	ask2.SetRequiredNode("node-1")
+	err = app.AddAllocationAsk(ask2)
+	assert.NilError(t, err, "failed to add ask alloc-2 to app-1")
+	partition.tryAllocate()
+
+	// check if updated (must be after allocate call)
+	assert.Equal(t, 1, len(app.GetReservations()), "ask should have been reserved")
+
+	ask3 := newAllocationAsk("alloc-2", appID1, res2)
+	ask3.SetRequiredNode("node-1")
+	err = app.AddAllocationAsk(ask3)
+	assert.NilError(t, err, "failed to add ask alloc-3 to app-1")
+	partition.tryAllocate()
+
+	// reservation count remains same as last try allocate should have failed to find a reservation
+	assert.Equal(t, 1, len(app.GetReservations()), "ask should have been reserved")
+}
+
 func TestTryAllocateLarge(t *testing.T) {
 	partition := createQueuesNodes(t)
 	if partition == nil {


### PR DESCRIPTION
### What is this PR for?

Use the "required node" being sent as part of daemonset pod spec straight away to avoid traversing all nodes for allocation. Do the allocation if there is a fit in the node otherwise reserve the same straight away. This change improves the allocation cycle significantly for daemon set pods.


### What type of PR is it?
* [ ] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1183

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
