### PR TITLE
[YUNIKORN-1205] Deletion of pending placeholder moves app from "Accepted" to "Completing"

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -525,7 +525,8 @@ func (sa *Application) removeAsksInternal(allocKey string) int {
 	// 2) if confirmed allocations is zero (no real tasks running)
 	// Change the state to completing.
 	// When the resource trackers are zero we should not expect anything to come in later.
-	if resources.IsZero(sa.pending) && resources.IsZero(sa.allocatedResource) && !sa.IsFailing() && !sa.IsCompleting() {
+	hasPlaceHolderAllocations := len(sa.getPlaceholderAllocations()) > 0
+	if resources.IsZero(sa.pending) && resources.IsZero(sa.allocatedResource) && !sa.IsFailing() && !sa.IsCompleting() && !hasPlaceHolderAllocations {
 		if err := sa.HandleApplicationEvent(CompleteApplication); err != nil {
 			log.Logger().Warn("Application state not changed to Completing while updating ask(s)",
 				zap.String("currentState", sa.CurrentState()),

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -775,14 +775,14 @@ func TestStateChangeOnPlaceholderAdd(t *testing.T) {
 	assert.Assert(t, resources.Equals(app.GetPlaceholderResource(), res), "placeholder allocation not set as expected")
 	assert.Assert(t, resources.IsZero(app.GetAllocatedResource()), "allocated resource should have been zero")
 
+	// first we have to remove the allocation itself
+	alloc := app.RemoveAllocation(uuid)
+	assert.Assert(t, alloc != nil, "Nil allocation was returned")
+	assert.Assert(t, app.IsAccepted(), "Application should have stayed in Accepted, changed unexpectedly: %s", app.CurrentState())
 	// removing the ask should move the application into the waiting state, because the allocation is only a placeholder allocation
 	released = app.RemoveAllocationAsk(askID)
 	assert.Equal(t, released, 0, "allocation ask should not have been reserved")
 	assert.Assert(t, app.IsCompleting(), "Application should have stayed same, changed unexpectedly: %s", app.CurrentState())
-
-	// remove the allocation, ask has been removed so nothing left
-	app.RemoveAllocation(uuid)
-	assert.Assert(t, app.IsCompleting(), "Application did not change as expected: %s", app.CurrentState())
 
 	log := app.GetStateLog()
 	assert.Equal(t, len(log), 2, "wrong number of app events")


### PR DESCRIPTION
### What is this PR for?
If we have a Pending placeholder pod and delete it, the application immediately moves to "Completing" status regardless
of whether it has running placeholders or not.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1205

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
