### PR TITLE
[YUNIKORN-1218] Scheduler crashed with concurrent map access error in…

### DIFF
--- a/pkg/scheduler/health_checker.go
+++ b/pkg/scheduler/health_checker.go
@@ -195,7 +195,7 @@ func checkSchedulingContext(schedulerContext *ClusterContext) []dao.HealthCheckI
 			if !resources.StrictlyGreaterThanOrEquals(node.GetCapacity(), node.GetAllocatedResource()) {
 				nodeCapacityMismatch = append(nodeCapacityMismatch, node.NodeID)
 			}
-			orphanAllocationsOnNode = append(orphanAllocationsOnNode, checkNodeAllocations(node, part.applications)...)
+			orphanAllocationsOnNode = append(orphanAllocationsOnNode, checkNodeAllocations(node, part)...)
 		}
 		// check if there are allocations assigned to an app but there are missing from the nodes
 		for _, app := range part.GetApplications() {
@@ -255,10 +255,10 @@ func checkAppAllocations(app *objects.Application, nodes objects.NodeCollection)
 	return orphanAllocationsOnApp
 }
 
-func checkNodeAllocations(node *objects.Node, applications map[string]*objects.Application) []*objects.Allocation {
+func checkNodeAllocations(node *objects.Node, partitionContext *PartitionContext) []*objects.Allocation {
 	orphanAllocationsOnNode := make([]*objects.Allocation, 0)
 	for _, alloc := range node.GetAllAllocations() {
-		if app, ok := applications[alloc.ApplicationID]; ok {
+		if app := partitionContext.getApplication(alloc.ApplicationID); app != nil {
 			if !app.IsAllocationAssignedToApp(alloc) {
 				orphanAllocationsOnNode = append(orphanAllocationsOnNode, alloc)
 			}


### PR DESCRIPTION
With the latest 1.0 version, we observed that occasionally scheduler crashed and restarted. This was due to the health checker having unsafe access to the application map of the partition context, a concurrent read/write error may occur when an app gets added or deleted in/from the partition at the same time. We need to use a read lock to access the map.

### What is this PR for?
Fix a bug in the health checker code.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-1218

### How should this be tested?
A patch to reproduce this issue has been attached in JIRA https://issues.apache.org/jira/browse/YUNIKORN-1218. Without the patch, it panics after running a while; with the patch, the crash won't happen. 
