### PR TITLE
[YUNIKORN-1242] gang: delay in scheduling after using all placeholders

### DIFF
--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -1431,10 +1431,14 @@ func TestCanReplace(t *testing.T) {
 	// add the placeholder data
 	// available tg has one replacement open
 	app.addPlaceholderData(newAllocationAskTG(aKey, appID1, tg1, res, 1))
-	// unavailable tg has NO replacement open
+	// unavailable tg has NO replacement open (replaced)
 	tg2 := "unavailable"
 	app.addPlaceholderData(newAllocationAskTG(aKey, appID1, tg2, res, 1))
 	app.placeholderData[tg2].Replaced++
+	// unavailable tg has NO replacement open (timedout)
+	tg3 := "timedout"
+	app.addPlaceholderData(newAllocationAskTG(aKey, appID1, tg3, res, 1))
+	app.placeholderData[tg3].Timedout++
 	tests = []struct {
 		name string
 		ask  *AllocationAsk
@@ -1442,8 +1446,9 @@ func TestCanReplace(t *testing.T) {
 	}{
 		{"no TG", newAllocationAsk(aKey, appID1, res), false},
 		{"TG mismatch", newAllocationAskAll(aKey, appID1, "unknown", res, 1, false), false},
-		{"TG placeholders used", newAllocationAskAll(aKey, appID1, tg2, res, 1, false), false},
-		{"TG placeholder available ", newAllocationAskAll(aKey, appID1, tg1, res, 1, false), true},
+		{"TG placeholder used", newAllocationAskAll(aKey, appID1, tg2, res, 1, false), false},
+		{"TG placeholder timed out", newAllocationAskAll(aKey, appID1, tg3, res, 1, false), false},
+		{"TG placeholder available", newAllocationAskAll(aKey, appID1, tg1, res, 1, false), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -198,13 +198,18 @@ func newPlaceholderAlloc(appID, uuid, nodeID, queueName string, res *resources.R
 }
 
 func newAllocationAsk(allocKey, appID string, res *resources.Resource) *AllocationAsk {
-	return newAllocationAskTG(allocKey, appID, "", res, 1)
+	return newAllocationAskAll(allocKey, appID, "", res, 1, false)
 }
 
 func newAllocationAskRepeat(allocKey, appID string, res *resources.Resource, repeat int) *AllocationAsk {
-	return newAllocationAskTG(allocKey, appID, "", res, repeat)
+	return newAllocationAskAll(allocKey, appID, "", res, repeat, false)
 }
+
 func newAllocationAskTG(allocKey, appID, taskGroup string, res *resources.Resource, repeat int) *AllocationAsk {
+	return newAllocationAskAll(allocKey, appID, taskGroup, res, repeat, taskGroup != "")
+}
+
+func newAllocationAskAll(allocKey, appID, taskGroup string, res *resources.Resource, repeat int, placeholder bool) *AllocationAsk {
 	ask := &si.AllocationAsk{
 		AllocationKey:  allocKey,
 		ApplicationID:  appID,
@@ -212,7 +217,7 @@ func newAllocationAskTG(allocKey, appID, taskGroup string, res *resources.Resour
 		ResourceAsk:    res.ToProto(),
 		MaxAllocations: int32(repeat),
 		TaskGroupName:  taskGroup,
-		Placeholder:    taskGroup != "",
+		Placeholder:    placeholder,
 	}
 	return NewAllocationAsk(ask)
 }


### PR DESCRIPTION
### What is this PR for?
In the tryAllocate a check fails to take into account that an
application could request more real allocations than defined in the gang
request.
If multiple gang types are used this could cause a delay in scheduling
the "extra" requests for that gang type. Worst case scenario that could
be the placeholder timeout.

### What type of PR is it?
* [X ] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1242

### How should this be tested?
unit tests are added