### PR TITLE
[YUNIKORN-1246] release reservation of required node in tryAllocate

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -853,14 +853,32 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, nodeIterator fu
 		}
 
 		requiredNode := request.GetRequiredNode()
-		// does request (daemon set pods?) has any constraint to run on specific node?
+		// does request have any constraint to run on specific node?
 		if requiredNode != "" {
+			// the iterator might not have the node we need as it could be reserved, or we have not added it yet
 			node := getNodeFn(requiredNode)
+			if node == nil {
+				log.Logger().Warn("required node is not found (could be transient)",
+					zap.String("application ID", sa.ApplicationID),
+					zap.String("allocationKey", request.AllocationKey),
+					zap.String("required node", requiredNode))
+				return nil
+			}
 			alloc := sa.tryNode(node, request)
 			if alloc != nil {
+				// check if the node was reserved and we allocated after a release
+				if _, ok := sa.reservations[reservationKey(node, nil, request)]; ok {
+					log.Logger().Debug("allocation on required node after release",
+						zap.String("appID", sa.ApplicationID),
+						zap.String("nodeID", requiredNode),
+						zap.String("allocationKey", request.AllocationKey))
+					alloc.Result = AllocatedReserved
+					return alloc
+				}
 				log.Logger().Debug("allocation on required node is completed",
-					zap.String("required node", node.NodeID),
-					zap.String("allocation key", request.AllocationKey))
+					zap.String("nodeID", node.NodeID),
+					zap.String("allocationKey", request.AllocationKey),
+					zap.String("allocationResult", alloc.Result.String()))
 				return alloc
 			}
 			return newReservedAllocation(Reserved, node.NodeID, request)
@@ -1050,7 +1068,7 @@ func (sa *Application) tryReservedAllocate(headRoom *resources.Resource, nodeIte
 			continue
 		}
 
-		// Is it daemon set?
+		// Do we need a specific node?
 		if ask.GetRequiredNode() != "" {
 			if !reserve.node.CanAllocate(ask.GetAllocatedResource()) {
 				sa.tryPreemption(reserve, ask)
@@ -1069,7 +1087,7 @@ func (sa *Application) tryReservedAllocate(headRoom *resources.Resource, nodeIte
 
 	// lets try this on all other nodes
 	for _, reserve := range sa.reservations {
-		// Other nodes cannot be tried for daemon set asks
+		// Other nodes cannot be tried if the ask has a required node
 		if reserve.ask.GetRequiredNode() != "" {
 			continue
 		}


### PR DESCRIPTION
### What is this PR for?
In the tryAllocate release the reservation if an ask with a requiredNode
specified is allocated after being reserved on the node.
Handle the case that the specified node is not known in the core.

Cleanup: required node tests

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1246

### How should this be tested?
unit tests cover the use case
