### PR TITLE
[YUNIKORN-1233] REST api shows negative request time for some allocations

### DIFF
--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -20,6 +20,7 @@ package objects
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/apache/yunikorn-core/pkg/common"
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/log"
+	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
@@ -113,6 +115,12 @@ func NewAllocationFromSI(alloc *si.Allocation) *Allocation {
 		return nil
 	}
 
+	creationTime, err := strconv.ParseInt(alloc.AllocationTags[siCommon.CreationTime], 10, 64)
+	if err != nil {
+		log.Logger().Warn("CreationTime is not set on the Allocation object")
+		creationTime = -1
+	}
+
 	ask := &AllocationAsk{
 		AllocationKey:     alloc.AllocationKey,
 		ApplicationID:     alloc.ApplicationID,
@@ -124,6 +132,7 @@ func NewAllocationFromSI(alloc *si.Allocation) *Allocation {
 		maxAllocations:    1,
 		taskGroupName:     alloc.TaskGroupName,
 		placeholder:       alloc.Placeholder,
+		createTime:        time.Unix(creationTime, 0),
 	}
 	return NewAllocation(alloc.UUID, alloc.NodeID, ask)
 }

--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -76,11 +76,17 @@ type Allocation struct {
 }
 
 func NewAllocation(uuid, nodeID string, ask *AllocationAsk) *Allocation {
+	var createTime time.Time
+	if ask.Tags[siCommon.CreationTime] == "" {
+		createTime = time.Now()
+	} else {
+		createTime = ask.createTime
+	}
 	return &Allocation{
 		Ask:               ask,
 		AllocationKey:     ask.AllocationKey,
 		ApplicationID:     ask.ApplicationID,
-		createTime:        time.Now(),
+		createTime:        createTime,
 		QueueName:         ask.QueueName,
 		NodeID:            nodeID,
 		PartitionName:     common.GetPartitionNameWithoutClusterID(ask.PartitionName),
@@ -117,7 +123,8 @@ func NewAllocationFromSI(alloc *si.Allocation) *Allocation {
 
 	creationTime, err := strconv.ParseInt(alloc.AllocationTags[siCommon.CreationTime], 10, 64)
 	if err != nil {
-		log.Logger().Warn("CreationTime is not set on the Allocation object")
+		log.Logger().Warn("CreationTime is not set on the Allocation object or invalid",
+			zap.String("creationTime", alloc.AllocationTags[siCommon.CreationTime]))
 		creationTime = -1
 	}
 

--- a/pkg/scheduler/objects/allocation_test.go
+++ b/pkg/scheduler/objects/allocation_test.go
@@ -28,6 +28,7 @@ import (
 	"gotest.tools/assert"
 
 	"github.com/apache/yunikorn-core/pkg/common/resources"
+	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
@@ -129,6 +130,8 @@ func TestNewAllocFromNilSI(t *testing.T) {
 func TestNewAllocFromSI(t *testing.T) {
 	res, err := resources.NewResourceFromConf(map[string]string{"first": "1"})
 	assert.NilError(t, err, "Resource creation failed")
+	tags := make(map[string]string)
+	tags[siCommon.CreationTime] = "100"
 	allocSI := &si.Allocation{
 		AllocationKey:    "ask-1",
 		UUID:             "test-uuid",
@@ -137,6 +140,7 @@ func TestNewAllocFromSI(t *testing.T) {
 		ResourcePerAlloc: res.ToProto(),
 		TaskGroupName:    "",
 		Placeholder:      true,
+		AllocationTags:   tags,
 	}
 	var nilAlloc *Allocation
 	alloc := NewAllocationFromSI(allocSI)
@@ -146,4 +150,5 @@ func TestNewAllocFromSI(t *testing.T) {
 	assert.Assert(t, alloc != nilAlloc, "placeholder ask creation failed unexpectedly")
 	assert.Assert(t, alloc.IsPlaceholder(), "ask should have been a placeholder")
 	assert.Equal(t, alloc.getTaskGroup(), "testgroup", "TaskGroupName not set as expected")
+	assert.Equal(t, alloc.Ask.createTime, time.Unix(100, 0)) //nolint:staticcheck
 }


### PR DESCRIPTION
### What is this PR for?
After restarting Yunikorn, negative RequestTime values are shown in the REST API for allocations.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1233

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
