### PR TITLE
[YUNIKORN-1263] Add pending requests to applciation object in REST API

### DIFF
--- a/pkg/scheduler/objects/allocation_ask_test.go
+++ b/pkg/scheduler/objects/allocation_ask_test.go
@@ -96,8 +96,8 @@ func TestPlaceHolder(t *testing.T) {
 		PartitionName: "default",
 	}
 	ask := NewAllocationAsk(siAsk)
-	assert.Assert(t, !ask.isPlaceholder(), "standard ask should not be a placeholder")
-	assert.Equal(t, ask.getTaskGroup(), "", "standard ask should not have a TaskGroupName")
+	assert.Assert(t, !ask.IsPlaceholder(), "standard ask should not be a placeholder")
+	assert.Equal(t, ask.GetTaskGroup(), "", "standard ask should not have a TaskGroupName")
 	siAsk = &si.AllocationAsk{
 		AllocationKey: "ask1",
 		ApplicationID: "app1",
@@ -111,8 +111,8 @@ func TestPlaceHolder(t *testing.T) {
 	siAsk.TaskGroupName = "testgroup"
 	ask = NewAllocationAsk(siAsk)
 	assert.Assert(t, ask != nilAsk, "placeholder ask creation failed unexpectedly")
-	assert.Assert(t, ask.isPlaceholder(), "ask should have been a placeholder")
-	assert.Equal(t, ask.getTaskGroup(), "testgroup", "TaskGroupName not set as expected")
+	assert.Assert(t, ask.IsPlaceholder(), "ask should have been a placeholder")
+	assert.Equal(t, ask.GetTaskGroup(), "testgroup", "TaskGroupName not set as expected")
 }
 
 func TestGetTimeout(t *testing.T) {
@@ -122,7 +122,7 @@ func TestGetTimeout(t *testing.T) {
 		PartitionName: "default",
 	}
 	ask := NewAllocationAsk(siAsk)
-	assert.Equal(t, ask.getTimeout(), time.Duration(0), "standard ask should not have timeout")
+	assert.Equal(t, ask.GetTimeout(), time.Duration(0), "standard ask should not have timeout")
 	siAsk = &si.AllocationAsk{
 		AllocationKey:                "ask1",
 		ApplicationID:                "app1",
@@ -130,7 +130,7 @@ func TestGetTimeout(t *testing.T) {
 		ExecutionTimeoutMilliSeconds: 10,
 	}
 	ask = NewAllocationAsk(siAsk)
-	assert.Equal(t, ask.getTimeout(), 10*time.Millisecond, "ask timeout not set as expected")
+	assert.Equal(t, ask.GetTimeout(), 10*time.Millisecond, "ask timeout not set as expected")
 }
 
 func TestGetRequiredNode(t *testing.T) {
@@ -154,4 +154,45 @@ func TestGetRequiredNode(t *testing.T) {
 	}
 	ask = NewAllocationAsk(siAsk)
 	assert.Equal(t, ask.GetRequiredNode(), "NodeName", "required node should be NodeName")
+}
+
+func TestAllocationLog(t *testing.T) {
+	res := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
+	siAsk := &si.AllocationAsk{
+		AllocationKey:  "ask-1",
+		ApplicationID:  "app-1",
+		MaxAllocations: 1,
+		ResourceAsk:    res.ToProto(),
+	}
+	ask := NewAllocationAsk(siAsk)
+
+	// log a reservation event
+	ask.LogAllocationFailure("reserve1", false)
+	log := ask.GetAllocationLog()
+	assert.Equal(t, 0, len(log), "non-allocation events was logged")
+
+	// log an allocation event
+	ask.LogAllocationFailure("alloc1", true)
+	log = ask.GetAllocationLog()
+	assert.Equal(t, 1, len(log), "allocation event should be logged")
+	assert.Equal(t, "alloc1", log[0].Message, "wrong message for event 1")
+	assert.Equal(t, 1, int(log[0].Count), "wrong count for event 1")
+
+	// add a second allocation event
+	ask.LogAllocationFailure("alloc2", true)
+	log = ask.GetAllocationLog()
+	assert.Equal(t, 2, len(log), "allocation event 2 should be logged")
+	assert.Equal(t, "alloc1", log[0].Message, "wrong message for event 1")
+	assert.Equal(t, "alloc2", log[1].Message, "wrong message for event 2")
+	assert.Equal(t, 1, int(log[0].Count), "wrong count for event 1")
+	assert.Equal(t, 1, int(log[1].Count), "wrong count for event 2")
+
+	// duplicate the first one
+	ask.LogAllocationFailure("alloc1", true)
+	log = ask.GetAllocationLog()
+	assert.Equal(t, 2, len(log), "allocation event alloc1 (#2) should not create a new event")
+	assert.Equal(t, "alloc2", log[0].Message, "wrong message for event 1")
+	assert.Equal(t, "alloc1", log[1].Message, "wrong message for event 2")
+	assert.Equal(t, 1, int(log[0].Count), "wrong count for event 1")
+	assert.Equal(t, 2, int(log[1].Count), "wrong count for event 2")
 }

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -986,7 +986,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 			node := getNodeFn(ph.NodeID)
 			// got the node run same checks as for reservation (all but fits)
 			// resource usage should not change anyway between placeholder and real one at this point
-			if node != nil && node.preReserveConditions(request.AllocationKey) {
+			if node != nil && node.preReserveConditions(request) {
 				alloc := NewAllocation(common.GetNewUUID(), node.NodeID, request)
 				// double link to make it easier to find
 				// alloc (the real one) releases points to the placeholder in the releases list
@@ -1029,7 +1029,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 				continue
 			}
 			// skip the node if conditions can not be satisfied
-			if !node.preAllocateConditions(reqFit.AllocationKey) {
+			if !node.preAllocateConditions(reqFit) {
 				continue
 			}
 			// allocation worked: on a non placeholder node update result and return
@@ -1267,7 +1267,7 @@ func (sa *Application) tryNodes(ask *AllocationAsk, iterator NodeIterator) *Allo
 			zap.Int("reservations", len(reservedAsks)),
 			zap.Int32("pendingRepeats", ask.pendingRepeatAsk))
 		// skip the node if conditions can not be satisfied
-		if !nodeToReserve.preReserveConditions(allocKey) {
+		if !nodeToReserve.preReserveConditions(ask) {
 			return nil
 		}
 		// return reservation allocation and mark it as a reservation
@@ -1280,7 +1280,6 @@ func (sa *Application) tryNodes(ask *AllocationAsk, iterator NodeIterator) *Allo
 
 // Try allocating on one specific node
 func (sa *Application) tryNode(node *Node, ask *AllocationAsk) *Allocation {
-	allocKey := ask.AllocationKey
 	toAllocate := ask.AllocatedResource
 	// create the key for the reservation
 	if err := node.preAllocateCheck(toAllocate, reservationKey(nil, sa, ask), false); err != nil {
@@ -1288,7 +1287,7 @@ func (sa *Application) tryNode(node *Node, ask *AllocationAsk) *Allocation {
 		return nil
 	}
 	// skip the node if conditions can not be satisfied
-	if !node.preAllocateConditions(allocKey) {
+	if !node.preAllocateConditions(ask) {
 		return nil
 	}
 	// everything OK really allocate
@@ -1385,6 +1384,17 @@ func (sa *Application) getPlaceholderAllocations() []*Allocation {
 		}
 	}
 	return allocations
+}
+
+// get a copy of all requests of the application
+func (sa *Application) GetAllRequests() []*AllocationAsk {
+	sa.RLock()
+	defer sa.RUnlock()
+	var requests []*AllocationAsk
+	for _, req := range sa.requests {
+		requests = append(requests, req)
+	}
+	return requests
 }
 
 func (sa *Application) getAllRequests() []*AllocationAsk {

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -405,7 +405,7 @@ func (sa *Application) timeoutPlaceholderProcessing() {
 				zap.String("currentState", sa.CurrentState()),
 				zap.Error(err))
 		}
-		sa.notifyRMAllocationAskReleased(sa.rmID, sa.getAllRequests(), si.TerminationType_TIMEOUT, "releasing placeholders asks on placeholder timeout")
+		sa.notifyRMAllocationAskReleased(sa.rmID, sa.getAllRequestsInternal(), si.TerminationType_TIMEOUT, "releasing placeholders asks on placeholder timeout")
 		sa.removeAsksInternal("")
 		// all allocations are placeholders but GetAllAllocations is locked and cannot be used
 		sa.notifyRMAllocationReleased(sa.rmID, sa.getPlaceholderAllocations(), si.TerminationType_TIMEOUT, "releasing allocated placeholders on placeholder timeout")
@@ -1386,18 +1386,14 @@ func (sa *Application) getPlaceholderAllocations() []*Allocation {
 	return allocations
 }
 
-// get a copy of all requests of the application
+// GetAllRequests returns a copy of all requests of the application
 func (sa *Application) GetAllRequests() []*AllocationAsk {
 	sa.RLock()
 	defer sa.RUnlock()
-	var requests []*AllocationAsk
-	for _, req := range sa.requests {
-		requests = append(requests, req)
-	}
-	return requests
+	return sa.getAllRequestsInternal()
 }
 
-func (sa *Application) getAllRequests() []*AllocationAsk {
+func (sa *Application) getAllRequestsInternal() []*AllocationAsk {
 	var requests []*AllocationAsk
 	for _, req := range sa.requests {
 		requests = append(requests, req)

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -1371,11 +1371,11 @@ func TestGetAllRequests(t *testing.T) {
 	queue, err := createRootQueue(nil)
 	assert.NilError(t, err, "queue create failed")
 	app.queue = queue
-	assert.Assert(t, len(app.getAllRequests()) == 0, "App should have no requests yet")
+	assert.Assert(t, len(app.getAllRequestsInternal()) == 0, "App should have no requests yet")
 	err = app.AddAllocationAsk(ask)
 	assert.NilError(t, err, "No error expected when adding an ask")
-	assert.Assert(t, len(app.getAllRequests()) == 1, "App should have only one request")
-	assert.Equal(t, app.getAllRequests()[0], ask, "Unexpected request found in the app")
+	assert.Assert(t, len(app.getAllRequestsInternal()) == 1, "App should have only one request")
+	assert.Equal(t, app.getAllRequestsInternal()[0], ask, "Unexpected request found in the app")
 }
 
 func TestGetQueueNameAfterUnsetQueue(t *testing.T) {

--- a/pkg/scheduler/objects/node_test.go
+++ b/pkg/scheduler/objects/node_test.go
@@ -96,7 +96,9 @@ func TestCheckConditions(t *testing.T) {
 	}
 
 	// Check if we can allocate on scheduling node (no plugins)
-	if !node.preAllocateConditions("test") {
+	res := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1})
+	ask := newAllocationAsk("test", "app001", res)
+	if !node.preAllocateConditions(ask) {
 		t.Error("node with scheduling set to true no plugins should allow allocation")
 	}
 

--- a/pkg/webservice/dao/allocation_ask_info.go
+++ b/pkg/webservice/dao/allocation_ask_info.go
@@ -1,0 +1,42 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package dao
+
+type AllocationAskLogDAOInfo struct {
+	Message   string `json:"message"`
+	Timestamp int64  `json:"timestamp"`
+	Count     int32  `json:"count"`
+}
+
+type AllocationAskDAOInfo struct {
+	AllocationKey      string                    `json:"allocationKey"`
+	AllocationTags     map[string]string         `json:"allocationTags"`
+	RequestTime        int64                     `json:"requestTime"`
+	ResourcePerAlloc   map[string]int64          `json:"resource"`
+	PendingCount       int32                     `json:"pendingCount"`
+	Priority           string                    `json:"priority"`
+	QueueName          string                    `json:"queueName"`
+	RequiredNodeID     *string                   `json:"requiredNodeId"`
+	ApplicationID      string                    `json:"applicationId"`
+	Partition          string                    `json:"partition"`
+	Placeholder        bool                      `json:"placeholder"`
+	PlaceholderTimeout int64                     `json:"placeholderTimeout"`
+	TaskGroupName      string                    `json:"taskGroupName"`
+	AllocationLog      []AllocationAskLogDAOInfo `json:"allocationLog"`
+}

--- a/pkg/webservice/dao/allocation_ask_info.go
+++ b/pkg/webservice/dao/allocation_ask_info.go
@@ -19,9 +19,9 @@
 package dao
 
 type AllocationAskLogDAOInfo struct {
-	Message   string `json:"message"`
-	Timestamp int64  `json:"timestamp"`
-	Count     int32  `json:"count"`
+	Message        string `json:"message"`
+	LastOccurrence int64  `json:"lastOccurrence"`
+	Count          int32  `json:"count"`
 }
 
 type AllocationAskDAOInfo struct {
@@ -32,7 +32,7 @@ type AllocationAskDAOInfo struct {
 	PendingCount       int32                     `json:"pendingCount"`
 	Priority           string                    `json:"priority"`
 	QueueName          string                    `json:"queueName"`
-	RequiredNodeID     *string                   `json:"requiredNodeId"`
+	RequiredNodeID     string                    `json:"requiredNodeId"`
 	ApplicationID      string                    `json:"applicationId"`
 	Partition          string                    `json:"partition"`
 	Placeholder        bool                      `json:"placeholder"`

--- a/pkg/webservice/dao/application_info.go
+++ b/pkg/webservice/dao/application_info.go
@@ -23,19 +23,20 @@ type ApplicationsDAOInfo struct {
 }
 
 type ApplicationDAOInfo struct {
-	ApplicationID   string               `json:"applicationID"`
-	UsedResource    map[string]int64     `json:"usedResource"`
-	MaxUsedResource map[string]int64     `json:"maxUsedResource"`
-	Partition       string               `json:"partition"`
-	QueueName       string               `json:"queueName"`
-	SubmissionTime  int64                `json:"submissionTime"`
-	FinishedTime    *int64               `json:"finishedTime"`
-	Allocations     []AllocationDAOInfo  `json:"allocations"`
-	State           string               `json:"applicationState"`
-	User            string               `json:"user"`
-	RejectedMessage string               `json:"rejectedMessage"`
-	StateLog        []StateDAOInfo       `json:"stateLog"`
-	PlaceholderData []PlaceholderDAOInfo `json:"placeholderData"`
+	ApplicationID   string                 `json:"applicationID"`
+	UsedResource    map[string]int64       `json:"usedResource"`
+	MaxUsedResource map[string]int64       `json:"maxUsedResource"`
+	Partition       string                 `json:"partition"`
+	QueueName       string                 `json:"queueName"`
+	SubmissionTime  int64                  `json:"submissionTime"`
+	FinishedTime    *int64                 `json:"finishedTime"`
+	Requests        []AllocationAskDAOInfo `json:"requests"`
+	Allocations     []AllocationDAOInfo    `json:"allocations"`
+	State           string                 `json:"applicationState"`
+	User            string                 `json:"user"`
+	RejectedMessage string                 `json:"rejectedMessage"`
+	StateLog        []StateDAOInfo         `json:"stateLog"`
+	PlaceholderData []PlaceholderDAOInfo   `json:"placeholderData"`
 }
 
 type StateDAOInfo struct {

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"net/http"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -194,8 +195,6 @@ func getPartitionJSON(partition *scheduler.PartitionContext) *dao.PartitionDAOIn
 }
 
 func getApplicationJSON(app *objects.Application) *dao.ApplicationDAOInfo {
-	requests := app.GetAllRequests()
-	requestInfo := make([]dao.AllocationAskDAOInfo, 0)
 	allocations := app.GetAllAllocations()
 	allocationInfo := make([]dao.AllocationDAOInfo, 0, len(allocations))
 	placeholders := app.GetAllPlaceholderData()
@@ -226,42 +225,6 @@ func getApplicationJSON(app *objects.Application) *dao.ApplicationDAOInfo {
 		}
 		allocationInfo = append(allocationInfo, allocInfo)
 	}
-	for _, req := range requests {
-		count := req.GetPendingAskRepeat()
-		if count > 0 {
-			nodeID := req.GetRequiredNode()
-			nodePtr := &nodeID
-			if nodeID == "" {
-				nodePtr = nil
-			}
-			allocLog := req.GetAllocationLog()
-			allocLogInfo := make([]dao.AllocationAskLogDAOInfo, len(allocLog))
-			for i, log := range allocLog {
-				allocLogInfo[i] = dao.AllocationAskLogDAOInfo{
-					Message:   log.Message,
-					Timestamp: log.Timestamp.UnixNano(),
-					Count:     log.Count,
-				}
-			}
-			reqInfo := dao.AllocationAskDAOInfo{
-				AllocationKey:      req.AllocationKey,
-				AllocationTags:     req.Tags,
-				RequestTime:        req.GetCreateTime().UnixNano(),
-				ResourcePerAlloc:   req.AllocatedResource.DAOMap(),
-				PendingCount:       count,
-				Priority:           strconv.Itoa(int(req.GetPriority())),
-				QueueName:          req.QueueName,
-				RequiredNodeID:     nodePtr,
-				ApplicationID:      req.ApplicationID,
-				Partition:          common.GetPartitionNameWithoutClusterID(req.PartitionName),
-				Placeholder:        req.IsPlaceholder(),
-				PlaceholderTimeout: req.GetTimeout().Nanoseconds(),
-				TaskGroupName:      req.GetTaskGroup(),
-				AllocationLog:      allocLogInfo,
-			}
-			requestInfo = append(requestInfo, reqInfo)
-		}
-	}
 	stateLog := app.GetStateLog()
 	stateLogInfo := make([]dao.StateDAOInfo, 0, len(stateLog))
 	for _, state := range stateLog {
@@ -291,7 +254,7 @@ func getApplicationJSON(app *objects.Application) *dao.ApplicationDAOInfo {
 		QueueName:       app.GetQueuePath(),
 		SubmissionTime:  app.SubmissionTime.UnixNano(),
 		FinishedTime:    common.ZeroTimeInUnixNano(app.FinishedTime()),
-		Requests:        requestInfo,
+		Requests:        getApplicationRequests(app),
 		Allocations:     allocationInfo,
 		State:           app.CurrentState(),
 		User:            app.GetUser().User,
@@ -299,6 +262,46 @@ func getApplicationJSON(app *objects.Application) *dao.ApplicationDAOInfo {
 		PlaceholderData: placeholderInfo,
 		StateLog:        stateLogInfo,
 	}
+}
+
+func getApplicationRequests(app *objects.Application) []dao.AllocationAskDAOInfo {
+	requests := app.GetAllRequests()
+	requestInfo := make([]dao.AllocationAskDAOInfo, 0)
+	for _, req := range requests {
+		count := req.GetPendingAskRepeat()
+		if count > 0 {
+			allocLog := req.GetAllocationLog()
+			sort.SliceStable(allocLog, func(i, j int) bool {
+				return allocLog[i].LastOccurrence.Before(allocLog[j].LastOccurrence)
+			})
+			allocLogInfo := make([]dao.AllocationAskLogDAOInfo, len(allocLog))
+			for i, log := range allocLog {
+				allocLogInfo[i] = dao.AllocationAskLogDAOInfo{
+					Message:        log.Message,
+					LastOccurrence: log.LastOccurrence.UnixNano(),
+					Count:          log.Count,
+				}
+			}
+			reqInfo := dao.AllocationAskDAOInfo{
+				AllocationKey:      req.AllocationKey,
+				AllocationTags:     req.Tags,
+				RequestTime:        req.GetCreateTime().UnixNano(),
+				ResourcePerAlloc:   req.AllocatedResource.DAOMap(),
+				PendingCount:       count,
+				Priority:           strconv.Itoa(int(req.GetPriority())),
+				QueueName:          req.QueueName,
+				RequiredNodeID:     req.GetRequiredNode(),
+				ApplicationID:      req.ApplicationID,
+				Partition:          common.GetPartitionNameWithoutClusterID(req.PartitionName),
+				Placeholder:        req.IsPlaceholder(),
+				PlaceholderTimeout: req.GetTimeout().Nanoseconds(),
+				TaskGroupName:      req.GetTaskGroup(),
+				AllocationLog:      allocLogInfo,
+			}
+			requestInfo = append(requestInfo, reqInfo)
+		}
+	}
+	return requestInfo
 }
 
 func getNodeJSON(node *objects.Node) *dao.NodeDAOInfo {


### PR DESCRIPTION
### What is this PR for?
The REST API responses for application objects include allocations, but not requests. Pending requests (along with diagnostic information related to predicate failure) would be very useful.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1263

### How should this be tested?
Added unit tests for log functionality, verified that new response objects appear as expected.

### Screenshots (if appropriate)

Example addition to the application object:

```
"requests": [
      {
        "allocationKey": "f137fab6-3cfa-4536-93f7-bfff92689382",
        "allocationTags": {
          "kubernetes.io/label/app": "pause",
          "kubernetes.io/label/applicationId": "pod-with-node-affinity-01",
          "kubernetes.io/label/queue": "root.sandbox",
          "kubernetes.io/meta/namespace": "default",
          "kubernetes.io/meta/podName": "with-node-affinity"
        },
        "requestTime": 1657917851845743911,
        "resource": {
          "memory": 500000000,
          "vcore": 100
        },
        "pendingCount": 1,
        "priority": "0",
        "queueName": "root.default",
        "requiredNodeId": "",
        "applicationId": "pod-with-node-affinity-01",
        "partition": "default",
        "placeholder": false,
        "placeholderTimeout": 0,
        "taskGroupName": "",
        "allocationLog": [
          {
            "message": "node(s) didn't match Pod's node affinity, node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate",
            "lastOccurrence": 1657917910919138494,
            "count": 81
          },
          {
            "message": "node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, node(s) didn't match Pod's node affinity",
            "lastOccurrence": 1657917911531769848,
            "count": 504
          },
          {
            "message": "node(s) didn't match Pod's node affinity",
            "lastOccurrence": 1657917911532076451,
            "count": 1170
          }
        ]
      }
    ],
```
### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [x] - It needs documentation.
