### PR TITLE
[YUNIKORN-1282] Resource metrics are not tracked correctly for all queue types

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -266,17 +266,17 @@ func (sq *Queue) setResources(resource configs.Resources) error {
 
 	if resources.StrictlyGreaterThanZero(maxResource) {
 		sq.maxResource = maxResource
+		sq.updateMaxResourceMetrics()
 	} else {
 		log.Logger().Debug("max resources setting ignored: cannot set zero max resources")
 	}
-	sq.updateMaxResourceMetrics()
 
 	if resources.StrictlyGreaterThanZero(guaranteedResource) {
 		sq.guaranteedResource = guaranteedResource
+		sq.updateGuaranteedResourceMetrics()
 	} else {
 		log.Logger().Debug("guaranteed resources setting ignored: cannot set zero max resources")
 	}
-	sq.updateGuaranteedResourceMetrics()
 
 	return nil
 }
@@ -1019,7 +1019,6 @@ func (sq *Queue) SetMaxResource(max *resources.Resource) {
 		zap.String("current max", sq.maxResource.String()),
 		zap.String("new max", max.String()))
 	sq.maxResource = max.Clone()
-	sq.updateGuaranteedResourceMetrics()
 	sq.updateMaxResourceMetrics()
 }
 

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -269,12 +269,14 @@ func (sq *Queue) setResources(resource configs.Resources) error {
 	} else {
 		log.Logger().Debug("max resources setting ignored: cannot set zero max resources")
 	}
+	sq.updateMaxResourceMetrics()
 
 	if resources.StrictlyGreaterThanZero(guaranteedResource) {
 		sq.guaranteedResource = guaranteedResource
 	} else {
 		log.Logger().Debug("guaranteed resources setting ignored: cannot set zero max resources")
 	}
+	sq.updateGuaranteedResourceMetrics()
 
 	return nil
 }
@@ -1002,7 +1004,7 @@ func (sq *Queue) internalGetMax(parentLimit *resources.Resource) *resources.Reso
 	return resources.ComponentWiseMin(parentLimit, sq.maxResource)
 }
 
-// SetMaxResource sets the max resource for root the queue. Called as part of adding or removing a node.
+// SetMaxResource sets the max resource for the root queue. Called as part of adding or removing a node.
 // Should only happen on the root, all other queues get it from the config via properties.
 func (sq *Queue) SetMaxResource(max *resources.Resource) {
 	sq.Lock()
@@ -1017,6 +1019,8 @@ func (sq *Queue) SetMaxResource(max *resources.Resource) {
 		zap.String("current max", sq.maxResource.String()),
 		zap.String("new max", max.String()))
 	sq.maxResource = max.Clone()
+	sq.updateGuaranteedResourceMetrics()
+	sq.updateMaxResourceMetrics()
 }
 
 // TryAllocate tries to allocate a pending requests. This only gets called if there is a pending request
@@ -1216,24 +1220,20 @@ func (sq *Queue) SupportTaskGroup() bool {
 	return sq.sortType == policies.FifoSortPolicy || sq.sortType == policies.StateAwarePolicy
 }
 
-// updateGuaranteedResourceMetrics updates guaranteed resource metrics if this is a leaf queue.
+// updateGuaranteedResourceMetrics updates guaranteed resource metrics.
 func (sq *Queue) updateGuaranteedResourceMetrics() {
-	if sq.isLeaf {
-		if sq.guaranteedResource != nil {
-			for k, v := range sq.guaranteedResource.Resources {
-				metrics.GetQueueMetrics(sq.QueuePath).SetQueueGuaranteedResourceMetrics(k, float64(v))
-			}
+	if sq.guaranteedResource != nil {
+		for k, v := range sq.guaranteedResource.Resources {
+			metrics.GetQueueMetrics(sq.QueuePath).SetQueueGuaranteedResourceMetrics(k, float64(v))
 		}
 	}
 }
 
-// updateMaxResourceMetrics updates max resource metrics if this is a leaf queue.
+// updateMaxResourceMetrics updates max resource metrics.
 func (sq *Queue) updateMaxResourceMetrics() {
-	if sq.isLeaf {
-		if sq.maxResource != nil {
-			for k, v := range sq.maxResource.Resources {
-				metrics.GetQueueMetrics(sq.QueuePath).SetQueueMaxResourceMetrics(k, float64(v))
-			}
+	if sq.maxResource != nil {
+		for k, v := range sq.maxResource.Resources {
+			metrics.GetQueueMetrics(sq.QueuePath).SetQueueMaxResourceMetrics(k, float64(v))
 		}
 	}
 }


### PR DESCRIPTION
### What is this PR for?
* Track resource usage in metrics for non-leaf queues
* Update resource metrics during config and node updates

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1282

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
