### PR TITLE
[YUNIKORN-1363] Dividing TestResourceProto to TestToProto and TestNewResourceFromProto

### DIFF
--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -563,6 +563,22 @@ func TestToProto(t *testing.T) {
 			if got := len(toProto.Resources); got != tt.expected {
 				t.Errorf("Number of resource type: got %d, expected %d", got, tt.expected)
 			}
+
+			// Unexpected resource type
+			for key := range toProto.Resources {
+				if _, ok := tt.input[key]; !ok {
+					t.Errorf("Resource type %s is not expected", key)
+				}
+			}
+
+			// Checking the number of the resource
+			for key, expected := range tt.input {
+				if got, ok := toProto.Resources[key]; ok {
+					if int64(expected) != got.Value {
+						t.Errorf("%s value: got %d, expected %d", key, got.Value, int64(expected))
+					}
+				}
+			}
 		})
 	}
 }

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -588,13 +588,17 @@ func TestNewResourceFromProto(t *testing.T) {
 	var tests = []struct {
 		caseName string
 		input    map[string]Quantity
+		expected int
 	}{
-		{"empty resource", map[string]Quantity{}},
-		{"setting resource", map[string]Quantity{"first": 5, "second": -5}},
-		{"resource including 0", map[string]Quantity{"first": 5, "second": 0, "third": -5}},
+		{"empty resource", map[string]Quantity{}, 0},
+		{"setting resource", map[string]Quantity{"first": 5, "second": -5}, 2},
+		{"resource including 0", map[string]Quantity{"first": 5, "second": 0, "third": -5}, 3},
 	}
 	for _, tt := range tests {
 		res1 := NewResourceFromMap(tt.input)
+		if len(res1.Resources) != tt.expected {
+			t.Errorf("Number of resource type: got %d, expected %d", len(res1.Resources), tt.expected)
+		}
 		res2 := NewResourceFromProto(res1.ToProto())
 		if !reflect.DeepEqual(res1.Resources, res2.Resources) {
 			t.Errorf("resource to proto and back to resource does not give same resources: original %v after %v", res1, res2)

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -559,24 +559,24 @@ func TestToProto(t *testing.T) {
 			toProto := NewResourceFromMap(tt.input).ToProto()
 			if toProto == nil {
 				t.Error("ToProto should return a empty resource instead of nil")
-				continue
-			}
-			if got := len(toProto.Resources); got != tt.expected {
-				t.Errorf("Number of resource type: got %d, expected %d", got, tt.expected)
-			}
-
-			// Unexpected resource type
-			for key := range toProto.Resources {
-				if _, ok := tt.input[key]; !ok {
-					t.Errorf("Resource type %s is not expected", key)
+			} else {
+				if got := len(toProto.Resources); got != tt.expected {
+					t.Errorf("Number of resource type: got %d, expected %d", got, tt.expected)
 				}
-			}
 
-			// Checking the number of the resource
-			for key, expected := range tt.input {
-				if got, ok := toProto.Resources[key]; ok {
-					if int64(expected) != got.Value {
-						t.Errorf("%s value: got %d, expected %d", key, got.Value, int64(expected))
+				// Unexpected resource type
+				for key := range toProto.Resources {
+					if _, ok := tt.input[key]; !ok {
+						t.Errorf("Resource type %s is not expected", key)
+					}
+				}
+
+				// Checking the number of the resource
+				for key, expected := range tt.input {
+					if got, ok := toProto.Resources[key]; ok {
+						if int64(expected) != got.Value {
+							t.Errorf("%s value: got %d, expected %d", key, got.Value, int64(expected))
+						}
 					}
 				}
 			}

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -543,48 +543,45 @@ func TestToProtoNil(t *testing.T) {
 	}
 }
 
-func TestResourceProto(t *testing.T) {
-	empty := NewResourceFromProto(nil)
-	if empty == nil || len(empty.Resources) != 0 {
-		t.Errorf("nil proto gave non empty resource: %v", empty)
+func TestToProto(t *testing.T) {
+	var tests = []struct {
+		caseName string
+		input    map[string]Quantity
+		expected int
+	}{
+		{"nil", nil, 0},
+		{"empty resource", map[string]Quantity{}, 0},
+		{"setting resource", map[string]Quantity{"first": 5, "second": -5}, 2},
+		{"resource including 0", map[string]Quantity{"first": 5, "second": 0, "third": -5}, 3},
 	}
-	// simple resource with no values to proto
-	res1 := NewResourceFromMap(map[string]Quantity{})
-	toProto := res1.ToProto()
-	if len(toProto.Resources) != 0 {
-		t.Fatalf("empty resource to proto conversion failed: %v", toProto)
+	for _, tt := range tests {
+		t.Run(tt.caseName, func(t *testing.T) {
+			toProto := NewResourceFromMap(tt.input).ToProto()
+			if toProto == nil {
+				t.Error("ToProto should return a empty resource instead of nil")
+			}
+			if got := len(toProto.Resources); got != tt.expected {
+				t.Errorf("Number of resource type: got %d, expected %d", got, tt.expected)
+			}
+		})
 	}
-	// convert back to resource
-	res2 := NewResourceFromProto(toProto)
-	// res1 and res2 content must be equal
-	if !reflect.DeepEqual(res1.Resources, res2.Resources) {
-		t.Errorf("resource to proto and back to resource does not give same resources: original %v after %v", res1, res2)
-	}
+}
 
-	// simple resource with values to proto
-	res1 = NewResourceFromMap(map[string]Quantity{"first": 5, "second": -5})
-	toProto = res1.ToProto()
-	if len(toProto.Resources) != 2 {
-		t.Fatalf("resource to proto conversion failed: %v", toProto)
+func TestNewResourceFromProto(t *testing.T) {
+	var tests = []struct {
+		caseName string
+		input    map[string]Quantity
+	}{
+		{"empty resource", map[string]Quantity{}},
+		{"setting resource", map[string]Quantity{"first": 5, "second": -5}},
+		{"resource including 0", map[string]Quantity{"first": 5, "second": 0, "third": -5}},
 	}
-	// convert back to resource
-	res2 = NewResourceFromProto(toProto)
-	// res1 and res2 content must be equal
-	if !reflect.DeepEqual(res1.Resources, res2.Resources) {
-		t.Errorf("resource to proto and back to resource does not give same resources: original %v after %v", res1, res2)
-	}
-
-	// resource with zero set values to proto
-	res1 = NewResourceFromMap(map[string]Quantity{"first": 5, "second": 0, "third": -5})
-	toProto = res1.ToProto()
-	if len(toProto.Resources) != 3 {
-		t.Fatalf("resource to proto conversion failed: %v", toProto)
-	}
-	// convert back to resource
-	res2 = NewResourceFromProto(toProto)
-	// res1 and res2 content must be equal
-	if !reflect.DeepEqual(res1.Resources, res2.Resources) {
-		t.Errorf("resource to proto and back to resource does not give same resources: original %v after %v", res1, res2)
+	for _, tt := range tests {
+		res1 := NewResourceFromMap(tt.input)
+		res2 := NewResourceFromProto(res1.ToProto())
+		if !reflect.DeepEqual(res1.Resources, res2.Resources) {
+			t.Errorf("resource to proto and back to resource does not give same resources: original %v after %v", res1, res2)
+		}
 	}
 }
 

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -559,6 +559,7 @@ func TestToProto(t *testing.T) {
 			toProto := NewResourceFromMap(tt.input).ToProto()
 			if toProto == nil {
 				t.Error("ToProto should return a empty resource instead of nil")
+				continue
 			}
 			if got := len(toProto.Resources); got != tt.expected {
 				t.Errorf("Number of resource type: got %d, expected %d", got, tt.expected)


### PR DESCRIPTION
### What is this PR for?
Adopting table-driven style and dividing TestResourceProto to TestToProto and TestNewResourceFromProto.
TestToProto focuses the correctness of resource.
TestNewResourceFromProto checks the equality between original resource and a copy from Proto. 

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1363

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
