### PR TITLE
[YUNIKORN-1395] Account for preemptions in the placeholder data

### DIFF
--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -645,7 +645,7 @@ func TestRemovePlaceholderAllocationWithNoRealAllocation(t *testing.T) {
 	err := app.HandleApplicationEvent(RunApplication)
 	assert.NilError(t, err, "no error expected new to accepted")
 
-	app.RemoveAllocation("uuid-1")
+	app.RemoveAllocation("uuid-1", si.TerminationType_UNKNOWN_TERMINATION_TYPE)
 	assert.Equal(t, app.stateMachine.Current(), Completing.String())
 }
 
@@ -735,7 +735,7 @@ func TestStateChangeOnUpdate(t *testing.T) {
 	assert.Assert(t, app.IsStarting(), "Application should have stayed same, changed unexpectedly: %s", app.CurrentState())
 
 	// remove the allocation, ask has been removed so nothing left
-	app.RemoveAllocation(uuid)
+	app.RemoveAllocation(uuid, si.TerminationType_UNKNOWN_TERMINATION_TYPE)
 	assert.Assert(t, app.IsCompleting(), "Application did not change as expected: %s", app.CurrentState())
 
 	log := app.GetStateLog()
@@ -794,7 +794,7 @@ func TestStateChangeOnPlaceholderAdd(t *testing.T) {
 	assert.Assert(t, resources.IsZero(app.GetAllocatedResource()), "allocated resource should have been zero")
 
 	// first we have to remove the allocation itself
-	alloc := app.RemoveAllocation(uuid)
+	alloc := app.RemoveAllocation(uuid, si.TerminationType_UNKNOWN_TERMINATION_TYPE)
 	assert.Assert(t, alloc != nil, "Nil allocation was returned")
 	assert.Assert(t, app.IsAccepted(), "Application should have stayed in Accepted, changed unexpectedly: %s", app.CurrentState())
 	// removing the ask should move the application into the waiting state, because the allocation is only a placeholder allocation
@@ -836,11 +836,11 @@ func TestAllocations(t *testing.T) {
 	allocs = app.GetAllAllocations()
 	assert.Equal(t, len(allocs), 3)
 	// remove one of the 3
-	if alloc = app.RemoveAllocation("uuid-2"); alloc == nil {
+	if alloc = app.RemoveAllocation("uuid-2", si.TerminationType_UNKNOWN_TERMINATION_TYPE); alloc == nil {
 		t.Error("returned allocations was nil allocation was not removed")
 	}
 	// try to remove a non existing alloc
-	if alloc = app.RemoveAllocation("does-not-exist"); alloc != nil {
+	if alloc = app.RemoveAllocation("does-not-exist", si.TerminationType_UNKNOWN_TERMINATION_TYPE); alloc != nil {
 		t.Errorf("returned allocations was not allocation was incorrectly removed: %v", alloc)
 	}
 	// remove all left over allocations
@@ -1329,7 +1329,7 @@ func TestTimeoutPlaceholderCompleting(t *testing.T) {
 	// move on to running
 	app.SetState(Running.String())
 	// remove allocation to trigger state change
-	app.RemoveAllocation("uuid-1")
+	app.RemoveAllocation("uuid-1", si.TerminationType_UNKNOWN_TERMINATION_TYPE)
 	assert.Assert(t, app.IsCompleting(), "App should be in completing state all allocs have been removed")
 	// make sure the placeholders time out
 	err = common.WaitFor(10*time.Millisecond, 1*time.Second, func() bool {

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -785,7 +785,7 @@ func (pc *PartitionContext) removeNodeAllocations(node *objects.Node) ([]*object
 			}
 		}
 		// check allocations on the app
-		if app.RemoveAllocation(allocID) == nil {
+		if app.RemoveAllocation(allocID, si.TerminationType_UNKNOWN_TERMINATION_TYPE) == nil {
 			log.Logger().Info("allocation is not found, skipping while removing the node",
 				zap.String("allocationId", allocID),
 				zap.String("appID", app.ApplicationID),
@@ -1296,7 +1296,7 @@ func (pc *PartitionContext) removeAllocation(release *si.AllocationRelease) ([]*
 				zap.String("appID", appID),
 				zap.String("allocationId", uuid),
 				zap.String("terminationType", release.TerminationType.String()))
-			if alloc := app.RemoveAllocation(uuid); alloc != nil {
+			if alloc := app.RemoveAllocation(uuid, release.TerminationType); alloc != nil {
 				released = append(released, alloc)
 			}
 		}


### PR DESCRIPTION
### What is this PR for?
If we preempt a placeholder to make room for a daemon set pod we do not update the counter inside the application placeholder data object. This causes the scheduler to think it needs to replace a placeholder but never finds one to replace causing the real allocation to never succeed

Same fix for placeholders that get removed as part of a node removal.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1395

### How should this be tested?
manual testing, unit tests will follow
