### PR TITLE
[YUNIKORN-1402] add unit test for nil safety of NewResourceFromProto

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -63,6 +63,9 @@ func NewResourceFromProto(proto *si.Resource) *Resource {
 }
 
 func NewResourceFromMap(m map[string]Quantity) *Resource {
+    if m == nil {
+        return NewResource()
+    }
 	return &Resource{Resources: m}
 }
 

--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -63,9 +63,9 @@ func NewResourceFromProto(proto *si.Resource) *Resource {
 }
 
 func NewResourceFromMap(m map[string]Quantity) *Resource {
-    if m == nil {
-        return NewResource()
-    }
+	if m == nil {
+		return NewResource()
+	}
 	return &Resource{Resources: m}
 }
 
@@ -188,17 +188,17 @@ func (r *Resource) MultiplyTo(ratio float64) {
 }
 
 // Calculate how well the receiver fits in "fit"
-// - A score of 0 is a fit (similar to FitIn)
-// - The score is calculated only using resource type defined in the fit resource.
-// - The score has a range between 0..#fit-res (the number of resource types in fit)
-// - Same score means same fit
-// - The lower the score the better the fit (0 is a fit)
-// - Each individual score is calculated as follows: score = (fitVal - resVal) / fitVal
-//   That calculation per type is summed up for all resource types in fit.
-//   example 1: fit memory 1000; resource 100; score = 0.9
-//   example 2: fit memory 150; resource 15; score = 0.9
-//   example 3: fit memory 100, cpu 1; resource memory 10; score = 1.9
-// - A nil receiver gives back the maximum score (number of resources types in fit)
+//   - A score of 0 is a fit (similar to FitIn)
+//   - The score is calculated only using resource type defined in the fit resource.
+//   - The score has a range between 0..#fit-res (the number of resource types in fit)
+//   - Same score means same fit
+//   - The lower the score the better the fit (0 is a fit)
+//   - Each individual score is calculated as follows: score = (fitVal - resVal) / fitVal
+//     That calculation per type is summed up for all resource types in fit.
+//     example 1: fit memory 1000; resource 100; score = 0.9
+//     example 2: fit memory 150; resource 15; score = 0.9
+//     example 3: fit memory 100, cpu 1; resource memory 10; score = 1.9
+//   - A nil receiver gives back the maximum score (number of resources types in fit)
 func (r *Resource) FitInScore(fit *Resource) float64 {
 	var score float64
 	// short cut for a nil receiver and fit

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -560,20 +560,20 @@ func TestNewResourceFromProto(t *testing.T) {
 		{"resource including 0", map[string]Quantity{"first": 5, "second": 0, "third": -5}, 3},
 	}
 	for _, tt := range tests {
-        t.Run(tt.caseName, func(t *testing.T) {
-            res1 := NewResourceFromMap(tt.input)
-            if ok, err := CheckLenOfResource(res1, tt.expected); !ok {
-                t.Error(err)
-            }
-        
-            res2 := NewResourceFromProto(res1.ToProto())
-            if ok, err := CheckLenOfResource(res2, tt.expected); !ok {
-                t.Error(err)
-            }
-            if !reflect.DeepEqual(res1.Resources, res2.Resources) {
-                t.Errorf("resource to proto and back to resource does not give same resources: original %v after %v", res1, res2)
-            }
-        })
+		t.Run(tt.caseName, func(t *testing.T) {
+			res1 := NewResourceFromMap(tt.input)
+			if ok, err := CheckLenOfResource(res1, tt.expected); !ok {
+				t.Error(err)
+			}
+
+			res2 := NewResourceFromProto(res1.ToProto())
+			if ok, err := CheckLenOfResource(res2, tt.expected); !ok {
+				t.Error(err)
+			}
+			if !reflect.DeepEqual(res1.Resources, res2.Resources) {
+				t.Errorf("resource to proto and back to resource does not give same resources: original %v after %v", res1, res2)
+			}
+		})
 	}
 }
 

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -550,14 +550,16 @@ func TestToProto(t *testing.T) {
 
 func TestNewResourceFromProto(t *testing.T) {
 	var tests = []struct {
-		caseName string
-		input    map[string]Quantity
-		expected int
+		caseName   string
+		input      map[string]Quantity
+		expected   int
+		ProtoIsNil bool
 	}{
-		{"nil resource", nil, 0},
-		{"empty resource", map[string]Quantity{}, 0},
-		{"setting resource", map[string]Quantity{"first": 5, "second": -5}, 2},
-		{"resource including 0", map[string]Quantity{"first": 5, "second": 0, "third": -5}, 3},
+		{"Proto is nil", nil, 0, true},
+		{"nil resource", nil, 0, false},
+		{"empty resource", map[string]Quantity{}, 0, false},
+		{"setting resource", map[string]Quantity{"first": 5, "second": -5}, 2, false},
+		{"resource including 0", map[string]Quantity{"first": 5, "second": 0, "third": -5}, 3, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.caseName, func(t *testing.T) {
@@ -567,6 +569,9 @@ func TestNewResourceFromProto(t *testing.T) {
 			}
 
 			res2 := NewResourceFromProto(res1.ToProto())
+			if tt.ProtoIsNil {
+				res2 = NewResourceFromProto(nil)
+			}
 			if ok, err := CheckLenOfResource(res2, tt.expected); !ok {
 				t.Error(err)
 			}


### PR DESCRIPTION
### What is this PR for?
UT of NewResourceFromProto does not include the nil input
res1 := NewResourceFromMap(nil)
res2 := NewResourceFromProto(res1.ToProto())
res1.Resources is not equally to res2.Resources because the front one has address and the last one does not has address.

So, I add the nil case to UT in this commit and NewResourceFromMap would return a default empty resource when the input is nil.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring
* [x] UT

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1402

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
