### PR TITLE
[YUNIKORN-1430] change go version check in Makefile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - name: Check license
-        run: make license-check
-        if: ${{ github.event_name == 'pull_request' }}
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version-file: .go_version
+      - name: Check license
+        run: make license-check
+        if: ${{ github.event_name == 'pull_request' }}
       - name: Go lint
         run: make lint
         if: ${{ github.event_name == 'pull_request' }}

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Check if this GO tools version used is at least the version of go specified in
 # the go.mod file. The version in go.mod should be in sync with other repos.
 GO_VERSION := $(shell go version | awk '{print substr($$3, 3, 10)}')
-MOD_VERSION := $(shell awk '/^go/ {print $$2}' go.mod)
+MOD_VERSION := $(shell cat .go_version) 
 
 GM := $(word 1,$(subst ., ,$(GO_VERSION)))
 MM := $(word 1,$(subst ., ,$(MOD_VERSION)))


### PR DESCRIPTION
### What is this PR for?
Point `MOD_VERSION` to `.go_version`, which will cause the make to fail if go is too old
I am going to update to all repos
[yunikorn-core #457](https://github.com/apache/yunikorn-core/pull/457)
[yunikorn-k8shim #491](https://github.com/apache/yunikorn-k8shim/pull/491)
[yunikorn-scheduler-interface #78](https://github.com/apache/yunikorn-scheduler-interface/pull/78)

### What type of PR is it?
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-1430

### How should this be tested?
`make`
### Screenshots (if appropriate)
Here is the result I use go1.16
![image](https://user-images.githubusercontent.com/48400525/204229798-55328a95-f493-4213-bedd-8dcdd7d64315.png)

Here is the result I use go1.18
![image](https://user-images.githubusercontent.com/48400525/204229831-ffc8842b-d674-49ae-9599-4e0486824463.png)

