### PR TITLE
[YUNIKORN-1440] Cleanup terminated applications once expired

### DIFF
--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1077,6 +1077,18 @@ func (pc *PartitionContext) GetCompletedApplications() []*objects.Application {
 	return appList
 }
 
+func (pc *PartitionContext) GetCompletedAppsByState(state string) map[string]*objects.Application {
+	pc.RLock()
+	defer pc.RUnlock()
+	appMap := make(map[string]*objects.Application)
+	for k, app := range pc.completedApplications {
+		if app.CurrentState() == state {
+			appMap[k] = app
+		}
+	}
+	return appMap
+}
+
 func (pc *PartitionContext) GetRejectedApplications() []*objects.Application {
 	pc.RLock()
 	defer pc.RUnlock()
@@ -1433,7 +1445,7 @@ func (pc *PartitionContext) cleanupExpiredApps() {
 		delete(pc.rejectedApplications, app.ApplicationID)
 		pc.Unlock()
 	}
-	for k, app := range pc.completedApplications {
+	for k, app := range pc.GetCompletedAppsByState(objects.Expired.String()) {
 		pc.Lock()
 		if app.IsExpired() {
 			delete(pc.completedApplications, k)

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1445,11 +1445,9 @@ func (pc *PartitionContext) cleanupExpiredApps() {
 		delete(pc.rejectedApplications, app.ApplicationID)
 		pc.Unlock()
 	}
-	for k, app := range pc.GetCompletedAppsByState(objects.Expired.String()) {
+	for k := range pc.GetCompletedAppsByState(objects.Expired.String()) {
 		pc.Lock()
-		if app.IsExpired() {
-			delete(pc.completedApplications, k)
-		}
+		delete(pc.completedApplications, k)
 		pc.Unlock()
 	}
 }

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1433,6 +1433,13 @@ func (pc *PartitionContext) cleanupExpiredApps() {
 		delete(pc.rejectedApplications, app.ApplicationID)
 		pc.Unlock()
 	}
+	for k, app := range pc.completedApplications {
+		pc.Lock()
+		if app.IsExpired() {
+			delete(pc.completedApplications, k)
+		}
+		pc.Unlock()
+	}
 }
 
 func (pc *PartitionContext) GetCurrentState() string {

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1704,7 +1704,7 @@ func TestCompleteApp(t *testing.T) {
 	assert.Assert(t, len(partition.completedApplications) == 1, "the partition should have 1 completed app")
 }
 
-func TestCleanupApp(t *testing.T) {
+func TestCleanupFailedApps(t *testing.T) {
 	partition, err := newBasePartition()
 	assert.NilError(t, err, "partition create failed")
 	newApp1 := newApplication("newApp1", "default", defQueue)

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1680,9 +1680,8 @@ func completeApplicationAndWait(app *objects.Application, pc *PartitionContext) 
 	}
 
 	err = common.WaitFor(10*time.Millisecond, time.Duration(1000)*time.Millisecond, func() bool {
-		pc.RLock()
-		defer pc.RUnlock()
-		return pc.GetTotalCompletedApplicationCount() == currentCount+1
+		newCount := pc.GetTotalCompletedApplicationCount()
+		return newCount == currentCount+1
 	})
 
 	return err

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1715,6 +1715,7 @@ func TestCleanupCompletedApps(t *testing.T) {
 		defer partition.RUnlock()
 		return len(partition.completedApplications) > 0
 	})
+	assert.NilError(t, err, "the completed application should have been processed")
 
 	// mark the app for removal
 	completedApp.SetState(objects.Expired.String())


### PR DESCRIPTION
### What is this PR for?

Allows terminated applications to be cleaned up once marked as expired. The `completedApplications` map otherwise grows indefinitely and may lead to memory pressure.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-1440

### How should this be tested?
Unit test added

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
