### PR TITLE
[YUNIKORN-1439] expose user and group endpoints

### DIFF
--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -221,7 +221,7 @@ func (m *Manager) GetUsersResources() []*UserTracker {
 	return userTrackers
 }
 
-func (m *Manager) GetUserResourcesByUserName(user string) *UserTracker {
+func (m *Manager) GetUserTracker(user string) *UserTracker {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	if m.userTrackers[user] != nil {
@@ -240,7 +240,7 @@ func (m *Manager) GetGroupsResources() []*GroupTracker {
 	return groupTrackers
 }
 
-func (m *Manager) GetGroupResourcesByGroupName(group string) *GroupTracker {
+func (m *Manager) GetGroupTracker(group string) *GroupTracker {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	if m.groupTrackers[group] != nil {

--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -221,6 +221,15 @@ func (m *Manager) GetUsersResources() []*UserTracker {
 	return userTrackers
 }
 
+func (m *Manager) GetUserResourcesByUserName(user string) *UserTracker {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	if m.userTrackers[user] != nil {
+		return m.userTrackers[user]
+	}
+	return nil
+}
+
 func (m *Manager) GetGroupsResources() []*GroupTracker {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
@@ -229,6 +238,15 @@ func (m *Manager) GetGroupsResources() []*GroupTracker {
 		groupTrackers = append(groupTrackers, tracker)
 	}
 	return groupTrackers
+}
+
+func (m *Manager) GetGroupResourcesByGroupName(group string) *GroupTracker {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	if m.groupTrackers[group] != nil {
+		return m.groupTrackers[group]
+	}
+	return nil
 }
 
 func (m *Manager) ensureGroupTrackerForApp(queuePath string, applicationID string, user security.UserGroup) error {

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -73,8 +73,8 @@ func TestAddRemoveUserAndGroups(t *testing.T) {
 	assert.Equal(t, false, manager.isUserRemovable(userTracker))
 	assert.Equal(t, false, manager.isGroupRemovable(groupTracker))
 	assertUGM(t, user, usage1, 1)
-	assert.Equal(t, user.User, manager.GetUserResourcesByUserName(user.User).userName)
-	assert.Equal(t, user.Groups[0], manager.GetGroupResourcesByGroupName(user.Groups[0]).groupName)
+	assert.Equal(t, user.User, manager.GetUserTracker(user.User).userName)
+	assert.Equal(t, user.Groups[0], manager.GetGroupTracker(user.Groups[0]).groupName)
 
 	err = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage1, user)
 	if err != nil {
@@ -92,10 +92,10 @@ func TestAddRemoveUserAndGroups(t *testing.T) {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage2, err)
 	}
 	assertUGM(t, user1, usage2, 2)
-	assert.Equal(t, user.User, manager.GetUserResourcesByUserName(user.User).userName)
-	assert.Equal(t, user.Groups[0], manager.GetGroupResourcesByGroupName(user.Groups[0]).groupName)
-	assert.Equal(t, user1.User, manager.GetUserResourcesByUserName(user1.User).userName)
-	assert.Equal(t, user1.Groups[0], manager.GetGroupResourcesByGroupName(user1.Groups[0]).groupName)
+	assert.Equal(t, user.User, manager.GetUserTracker(user.User).userName)
+	assert.Equal(t, user.Groups[0], manager.GetGroupTracker(user.Groups[0]).groupName)
+	assert.Equal(t, user1.User, manager.GetUserTracker(user1.User).userName)
+	assert.Equal(t, user1.Groups[0], manager.GetGroupTracker(user1.Groups[0]).groupName)
 
 	usage3, err := resources.NewResourceFromConf(map[string]string{"mem": "5M", "vcore": "5"})
 	if err != nil {
@@ -125,8 +125,8 @@ func TestAddRemoveUserAndGroups(t *testing.T) {
 	assert.Equal(t, 0, len(manager.GetUsersResources()), "userTrackers count should be 0")
 	assert.Equal(t, 0, len(manager.GetGroupsResources()), "groupTrackers count should be 0")
 
-	assert.Assert(t, manager.GetUserResourcesByUserName(user.User) == nil)
-	assert.Assert(t, manager.GetGroupResourcesByGroupName(user.Groups[0]) == nil)
+	assert.Assert(t, manager.GetUserTracker(user.User) == nil)
+	assert.Assert(t, manager.GetGroupTracker(user.Groups[0]) == nil)
 }
 
 func assertUGM(t *testing.T, userGroup security.UserGroup, expected *resources.Resource, usersCount int) {

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -124,6 +124,9 @@ func TestAddRemoveUserAndGroups(t *testing.T) {
 	}
 	assert.Equal(t, 0, len(manager.GetUsersResources()), "userTrackers count should be 0")
 	assert.Equal(t, 0, len(manager.GetGroupsResources()), "groupTrackers count should be 0")
+
+	assert.Equal(t, nil, manager.GetUserResourcesByUserName(user.User), "userTracker for user: "+user.User+" should be nil")
+	assert.Equal(t, nil, manager.GetGroupResourcesByGroupName(user.Groups[0]).groupName, "groupTracker for group: "+user.Groups[0]+" should be nil")
 }
 
 func assertUGM(t *testing.T, userGroup security.UserGroup, expected *resources.Resource, usersCount int) {

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -73,8 +73,8 @@ func TestAddRemoveUserAndGroups(t *testing.T) {
 	assert.Equal(t, false, manager.isUserRemovable(userTracker))
 	assert.Equal(t, false, manager.isGroupRemovable(groupTracker))
 	assertUGM(t, user, usage1, 1)
-	assert.Equal(t, user.User, manager.GetUserResourcesByUserName(user.User).userName, "userTracker for user: "+user.User+" should not be nil")
-	assert.Equal(t, user.Groups[0], manager.GetGroupResourcesByGroupName(user.Groups[0]).groupName, "groupTracker for group: "+user.Groups[0]+" should not be nil")
+	assert.Equal(t, user.User, manager.GetUserResourcesByUserName(user.User).userName)
+	assert.Equal(t, user.Groups[0], manager.GetGroupResourcesByGroupName(user.Groups[0]).groupName)
 
 	err = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage1, user)
 	if err != nil {
@@ -92,10 +92,10 @@ func TestAddRemoveUserAndGroups(t *testing.T) {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage2, err)
 	}
 	assertUGM(t, user1, usage2, 2)
-	assert.Equal(t, user.User, manager.GetUserResourcesByUserName(user.User).userName, "userTracker for user: "+user.User+" should not be nil")
-	assert.Equal(t, user.Groups[0], manager.GetGroupResourcesByGroupName(user.Groups[0]).groupName, "groupTracker for group: "+user.Groups[0]+" should not be nil")
-	assert.Equal(t, user1.User, manager.GetUserResourcesByUserName(user1.User).userName, "userTracker for user: "+user1.User+" should not be nil")
-	assert.Equal(t, user1.Groups[0], manager.GetGroupResourcesByGroupName(user1.Groups[0]).groupName, "groupTracker for group: "+user1.Groups[0]+" should not be nil")
+	assert.Equal(t, user.User, manager.GetUserResourcesByUserName(user.User).userName)
+	assert.Equal(t, user.Groups[0], manager.GetGroupResourcesByGroupName(user.Groups[0]).groupName)
+	assert.Equal(t, user1.User, manager.GetUserResourcesByUserName(user1.User).userName)
+	assert.Equal(t, user1.Groups[0], manager.GetGroupResourcesByGroupName(user1.Groups[0]).groupName)
 
 	usage3, err := resources.NewResourceFromConf(map[string]string{"mem": "5M", "vcore": "5"})
 	if err != nil {
@@ -125,10 +125,8 @@ func TestAddRemoveUserAndGroups(t *testing.T) {
 	assert.Equal(t, 0, len(manager.GetUsersResources()), "userTrackers count should be 0")
 	assert.Equal(t, 0, len(manager.GetGroupsResources()), "groupTrackers count should be 0")
 
-	var nilUserTracker *UserTracker
-	var nilGroupTracker *GroupTracker
-	assert.Equal(t, nilUserTracker, manager.GetUserResourcesByUserName(user.User), "userTracker for user: "+user.User+" should be nil")
-	assert.Equal(t, nilGroupTracker, manager.GetGroupResourcesByGroupName(user.Groups[0]), "groupTracker for group: "+user.Groups[0]+" should be nil")
+	assert.Assert(t, manager.GetUserResourcesByUserName(user.User) == nil)
+	assert.Assert(t, manager.GetGroupResourcesByGroupName(user.Groups[0]) == nil)
 }
 
 func assertUGM(t *testing.T, userGroup security.UserGroup, expected *resources.Resource, usersCount int) {

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -125,8 +125,10 @@ func TestAddRemoveUserAndGroups(t *testing.T) {
 	assert.Equal(t, 0, len(manager.GetUsersResources()), "userTrackers count should be 0")
 	assert.Equal(t, 0, len(manager.GetGroupsResources()), "groupTrackers count should be 0")
 
-	assert.Equal(t, nil, manager.GetUserResourcesByUserName(user.User), "userTracker for user: "+user.User+" should be nil")
-	assert.Equal(t, nil, manager.GetGroupResourcesByGroupName(user.Groups[0]).groupName, "groupTracker for group: "+user.Groups[0]+" should be nil")
+	var nilUserTracker *UserTracker
+	var nilGroupTracker *GroupTracker
+	assert.Equal(t, nilUserTracker, manager.GetUserResourcesByUserName(user.User), "userTracker for user: "+user.User+" should be nil")
+	assert.Equal(t, nilGroupTracker, manager.GetGroupResourcesByGroupName(user.Groups[0]), "groupTracker for group: "+user.Groups[0]+" should be nil")
 }
 
 func assertUGM(t *testing.T, userGroup security.UserGroup, expected *resources.Resource, usersCount int) {

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -73,6 +73,8 @@ func TestAddRemoveUserAndGroups(t *testing.T) {
 	assert.Equal(t, false, manager.isUserRemovable(userTracker))
 	assert.Equal(t, false, manager.isGroupRemovable(groupTracker))
 	assertUGM(t, user, usage1, 1)
+	assert.Equal(t, user.User, manager.GetUserResourcesByUserName(user.User).userName, "userTracker for user: "+user.User+" should not be nil")
+	assert.Equal(t, user.Groups[0], manager.GetGroupResourcesByGroupName(user.Groups[0]).groupName, "groupTracker for group: "+user.Groups[0]+" should not be nil")
 
 	err = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage1, user)
 	if err != nil {
@@ -90,6 +92,10 @@ func TestAddRemoveUserAndGroups(t *testing.T) {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage2, err)
 	}
 	assertUGM(t, user1, usage2, 2)
+	assert.Equal(t, user.User, manager.GetUserResourcesByUserName(user.User).userName, "userTracker for user: "+user.User+" should not be nil")
+	assert.Equal(t, user.Groups[0], manager.GetGroupResourcesByGroupName(user.Groups[0]).groupName, "groupTracker for group: "+user.Groups[0]+" should not be nil")
+	assert.Equal(t, user1.User, manager.GetUserResourcesByUserName(user1.User).userName, "userTracker for user: "+user1.User+" should not be nil")
+	assert.Equal(t, user1.Groups[0], manager.GetGroupResourcesByGroupName(user1.Groups[0]).groupName, "groupTracker for group: "+user1.Groups[0]+" should not be nil")
 
 	usage3, err := resources.NewResourceFromConf(map[string]string{"mem": "5M", "vcore": "5"})
 	if err != nil {

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -48,6 +48,8 @@ import (
 
 const PartitionDoesNotExists = "Partition not found"
 const QueueDoesNotExists = "Queue not found"
+const UserDoesNotExists = "User not found"
+const GroupDoesNotExists = "Group not found"
 
 func getStackInfo(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
@@ -751,6 +753,10 @@ func getUserResourceUsage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	user := vars["user"]
 	userTracker := userManager.GetUserResourcesByUserName(user)
+	if userTracker == nil {
+		buildJSONErrorResponse(w, UserDoesNotExists, http.StatusBadRequest)
+		return
+	}
 	var result = userTracker.GetUserResourceUsageDAOInfo()
 	if err := json.NewEncoder(w).Encode(result); err != nil {
 		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
@@ -774,6 +780,10 @@ func getGroupResourceUsage(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	group := vars["group"]
 	groupTracker := userManager.GetGroupResourcesByGroupName(group)
+	if groupTracker == nil {
+		buildJSONErrorResponse(w, GroupDoesNotExists, http.StatusBadRequest)
+		return
+	}
 	var result = groupTracker.GetGroupResourceUsageDAOInfo()
 	if err := json.NewEncoder(w).Encode(result); err != nil {
 		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -746,6 +746,17 @@ func getUsersResourceUsage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func getUserResourceUsage(w http.ResponseWriter, r *http.Request) {
+	userManager := ugm.GetUserManager()
+	vars := mux.Vars(r)
+	user := vars["user"]
+	userTracker := userManager.GetUserResourcesByUserName(user)
+	var result = userTracker.GetUserResourceUsageDAOInfo()
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
 func getGroupsResourceUsage(w http.ResponseWriter, r *http.Request) {
 	userManager := ugm.GetUserManager()
 	groupsResources := userManager.GetGroupsResources()
@@ -753,6 +764,17 @@ func getGroupsResourceUsage(w http.ResponseWriter, r *http.Request) {
 	for _, tracker := range groupsResources {
 		result = append(result, tracker.GetGroupResourceUsageDAOInfo())
 	}
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func getGroupResourceUsage(w http.ResponseWriter, r *http.Request) {
+	userManager := ugm.GetUserManager()
+	vars := mux.Vars(r)
+	group := vars["group"]
+	groupTracker := userManager.GetGroupResourcesByGroupName(group)
+	var result = groupTracker.GetGroupResourceUsageDAOInfo()
 	if err := json.NewEncoder(w).Encode(result); err != nil {
 		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -50,6 +50,8 @@ const PartitionDoesNotExists = "Partition not found"
 const QueueDoesNotExists = "Queue not found"
 const UserDoesNotExists = "User not found"
 const GroupDoesNotExists = "Group not found"
+const UserNameMissing = "User name is missing"
+const GroupNameMissing = "Group name is missing"
 
 func getStackInfo(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
@@ -752,6 +754,10 @@ func getUserResourceUsage(w http.ResponseWriter, r *http.Request) {
 	userManager := ugm.GetUserManager()
 	vars := mux.Vars(r)
 	user := vars["user"]
+	if user == "" {
+		buildJSONErrorResponse(w, UserNameMissing, http.StatusBadRequest)
+		return
+	}
 	userTracker := userManager.GetUserTracker(user)
 	if userTracker == nil {
 		buildJSONErrorResponse(w, UserDoesNotExists, http.StatusBadRequest)
@@ -779,6 +785,10 @@ func getGroupResourceUsage(w http.ResponseWriter, r *http.Request) {
 	userManager := ugm.GetUserManager()
 	vars := mux.Vars(r)
 	group := vars["group"]
+	if group == "" {
+		buildJSONErrorResponse(w, GroupNameMissing, http.StatusBadRequest)
+		return
+	}
 	groupTracker := userManager.GetGroupTracker(group)
 	if groupTracker == nil {
 		buildJSONErrorResponse(w, GroupDoesNotExists, http.StatusBadRequest)

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -752,7 +752,7 @@ func getUserResourceUsage(w http.ResponseWriter, r *http.Request) {
 	userManager := ugm.GetUserManager()
 	vars := mux.Vars(r)
 	user := vars["user"]
-	userTracker := userManager.GetUserResourcesByUserName(user)
+	userTracker := userManager.GetUserTracker(user)
 	if userTracker == nil {
 		buildJSONErrorResponse(w, UserDoesNotExists, http.StatusBadRequest)
 		return
@@ -779,7 +779,7 @@ func getGroupResourceUsage(w http.ResponseWriter, r *http.Request) {
 	userManager := ugm.GetUserManager()
 	vars := mux.Vars(r)
 	group := vars["group"]
-	groupTracker := userManager.GetGroupResourcesByGroupName(group)
+	groupTracker := userManager.GetGroupTracker(group)
 	if groupTracker == nil {
 		buildJSONErrorResponse(w, GroupDoesNotExists, http.StatusBadRequest)
 		return

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -751,14 +751,13 @@ func getUsersResourceUsage(w http.ResponseWriter, r *http.Request) {
 }
 
 func getUserResourceUsage(w http.ResponseWriter, r *http.Request) {
-	userManager := ugm.GetUserManager()
 	vars := mux.Vars(r)
 	user := vars["user"]
 	if user == "" {
 		buildJSONErrorResponse(w, UserNameMissing, http.StatusBadRequest)
 		return
 	}
-	userTracker := userManager.GetUserTracker(user)
+	userTracker := ugm.GetUserManager().GetUserTracker(user)
 	if userTracker == nil {
 		buildJSONErrorResponse(w, UserDoesNotExists, http.StatusBadRequest)
 		return
@@ -782,14 +781,13 @@ func getGroupsResourceUsage(w http.ResponseWriter, r *http.Request) {
 }
 
 func getGroupResourceUsage(w http.ResponseWriter, r *http.Request) {
-	userManager := ugm.GetUserManager()
 	vars := mux.Vars(r)
 	group := vars["group"]
 	if group == "" {
 		buildJSONErrorResponse(w, GroupNameMissing, http.StatusBadRequest)
 		return
 	}
-	groupTracker := userManager.GetGroupTracker(group)
+	groupTracker := ugm.GetUserManager().GetGroupTracker(group)
 	if groupTracker == nil {
 		buildJSONErrorResponse(w, GroupDoesNotExists, http.StatusBadRequest)
 		return

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1392,10 +1392,10 @@ func TestUsersAndGroupsResourceUsage(t *testing.T) {
 	assert.Equal(t, userResourceUsageDao.Queues.ResourceUsage.String(),
 		resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1}).String())
 
-	// Test not existed user query
-	req, err = http.NewRequest("GET", "/ws/v1/partition/default/usage/user/testNotExistUser", strings.NewReader(""))
+	// Test non-existing user query
+	req, err = http.NewRequest("GET", "/ws/v1/partition/default/usage/user/testNonExistingUser", strings.NewReader(""))
 	vars = map[string]string{
-		"user":  "testNotExistUser",
+		"user":  "testNonExistingUser",
 		"group": "testgroup",
 	}
 	req = mux.SetURLVars(req, vars)
@@ -1429,12 +1429,12 @@ func TestUsersAndGroupsResourceUsage(t *testing.T) {
 	assert.Equal(t, groupResourceUsageDao.Queues.ResourceUsage.String(),
 		resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1}).String())
 
-	// Test not existed group query
-	req, err = http.NewRequest("GET", "/ws/v1/partition/default/usage/group/testNotExistedGroup", strings.NewReader(""))
+	// Test non-existing group query
+	req, err = http.NewRequest("GET", "/ws/v1/partition/default/usage/group/testNonExistingGroup", strings.NewReader(""))
 	assert.NilError(t, err, "Get Group Resource Usage Handler request failed")
 	vars = map[string]string{
 		"user":  "testuser",
-		"group": "testNotExistedGroup",
+		"group": "testNonExistingGroup",
 	}
 	req = mux.SetURLVars(req, vars)
 	getGroupResourceUsage(resp, req)

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1438,7 +1438,6 @@ func TestUsersAndGroupsResourceUsage(t *testing.T) {
 	}
 	req = mux.SetURLVars(req, vars)
 	getGroupResourceUsage(resp, req)
-	err = json.Unmarshal(resp.outputBytes, &groupResourceUsageDao)
 	assertGroupExists(t, resp)
 }
 

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1389,10 +1389,9 @@ func TestSpecificUserAndGroupResourceUsage(t *testing.T) {
 		"user":  "",
 		"group": "testgroup",
 	}
-	resp := &MockResponseWriter{}
 	req = mux.SetURLVars(req, vars)
 	assert.NilError(t, err, "Get User Resource Usage Handler request failed")
-	resp = &MockResponseWriter{}
+	resp := &MockResponseWriter{}
 	getUserResourceUsage(resp, req)
 	assertUserNameExists(t, resp)
 
@@ -1402,7 +1401,6 @@ func TestSpecificUserAndGroupResourceUsage(t *testing.T) {
 		"user":  "testuser",
 		"group": "",
 	}
-	resp = &MockResponseWriter{}
 	req = mux.SetURLVars(req, vars)
 	assert.NilError(t, err, "Get Group Resource Usage Handler request failed")
 	resp = &MockResponseWriter{}

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -137,8 +137,20 @@ var webRoutes = routes{
 	route{
 		"Scheduler",
 		"GET",
+		"/ws/v1/partition/{partition}/usage/user/{user}",
+		getUserResourceUsage,
+	},
+	route{
+		"Scheduler",
+		"GET",
 		"/ws/v1/partition/{partition}/usage/groups",
 		getGroupsResourceUsage,
+	},
+	route{
+		"Scheduler",
+		"GET",
+		"/ws/v1/partition/{partition}/usage/group/{group}",
+		getGroupResourceUsage,
 	},
 	route{
 		"Scheduler",


### PR DESCRIPTION
### What is this PR for?
In the REST interface we currently only expose users and groups.

Like we do with applications we should add individual user and group endpoints for usage information:

/ws/v1/partition/{partition}/usage/user/{user}
/ws/v1/partition/{partition}/usage/group/{group}


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1439
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
