### PR TITLE
[YUNIKORN-1398] Remove non daemonset reservation from node before allocating daemonset pod

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -943,7 +943,7 @@ func (sa *Application) cancelReservations(reservations []*reservation) bool {
 	// un reserve all the apps that were reserved on the node
 	for _, res := range reservations {
 		if res.app.ApplicationID == sa.ApplicationID {
-			num, err = res.app.unReserveInternal(res.node, res.ask)
+			num, err = sa.unReserveInternal(res.node, res.ask)
 		} else {
 			num, err = res.app.UnReserve(res.node, res.ask)
 		}

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -889,9 +889,11 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, nodeIterator fu
 			}
 			// Are there any non daemon set reservations on specific required node?
 			// Cancel those reservations to run daemon set pods
-			reservations := node.getReservations()
+			reservations := node.GetReservations()
 			if len(reservations) > 0 {
-				sa.removeReservations(reservations)
+				if !sa.cancelReservations(reservations) {
+					return nil
+				}
 			}
 			alloc := sa.tryNode(node, request)
 			if alloc != nil {
@@ -926,47 +928,45 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, nodeIterator fu
 	return nil
 }
 
-func (sa *Application) removeReservations(reservations map[string]*reservation) {
-	unreserve := true
+func (sa *Application) cancelReservations(reservations []*reservation) bool {
 	for _, res := range reservations {
 		// skip the node
 		if res.ask.GetRequiredNode() != "" {
 			log.Logger().Warn("reservation for ask with required node already exists on the node",
 				zap.String("required node", res.node.NodeID),
 				zap.String("existing ask reservation key", res.getKey()))
-			unreserve = false
-			break
+			return false
 		}
 	}
-	if unreserve {
-		var err error
-		var num int
-		// un reserve all the apps that were reserved on the node
-		for _, res := range reservations {
-			if res.app.ApplicationID == sa.ApplicationID {
-				num, err = res.app.unReserveInternal(res.node, res.ask)
-			} else {
-				num, err = res.app.UnReserve(res.node, res.ask)
-			}
-			if err != nil {
-				log.Logger().Warn("Unable to cancel reservations on node",
-					zap.String("victim application ID", res.app.ApplicationID),
-					zap.String("victim allocationKey", res.getKey()),
-					zap.String("required node", res.node.NodeID),
-					zap.Int("reservations count", num),
-					zap.String("application ID", sa.ApplicationID))
-			} else {
-				log.Logger().Info("Cancelled reservation on required node",
-					zap.String("affected application ID", res.app.ApplicationID),
-					zap.String("affected allocationKey", res.getKey()),
-					zap.String("required node", res.node.NodeID),
-					zap.Int("reservations count", num),
-					zap.String("application ID", sa.ApplicationID))
-			}
-			// remove the reservation of the queue
-			res.app.queue.UnReserve(res.app.ApplicationID, num)
+	var err error
+	var num int
+	// un reserve all the apps that were reserved on the node
+	for _, res := range reservations {
+		if res.app.ApplicationID == sa.ApplicationID {
+			num, err = res.app.unReserveInternal(res.node, res.ask)
+		} else {
+			num, err = res.app.UnReserve(res.node, res.ask)
 		}
+		if err != nil {
+			log.Logger().Warn("Unable to cancel reservations on node",
+				zap.String("victim application ID", res.app.ApplicationID),
+				zap.String("victim allocationKey", res.getKey()),
+				zap.String("required node", res.node.NodeID),
+				zap.Int("reservations count", num),
+				zap.String("application ID", sa.ApplicationID))
+			return false
+		} else {
+			log.Logger().Info("Cancelled reservation on required node",
+				zap.String("affected application ID", res.app.ApplicationID),
+				zap.String("affected allocationKey", res.getKey()),
+				zap.String("required node", res.node.NodeID),
+				zap.Int("reservations count", num),
+				zap.String("application ID", sa.ApplicationID))
+		}
+		// remove the reservation of the queue
+		res.app.queue.UnReserve(res.app.ApplicationID, num)
 	}
+	return true
 }
 
 // tryPlaceholderAllocate tries to replace a placeholder that is allocated with a real allocation

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -117,6 +117,16 @@ func (sn *Node) GetAttribute(key string) string {
 	return sn.attributes[key]
 }
 
+func (sn *Node) getReservations() map[string]*reservation {
+	sn.RLock()
+	defer sn.RUnlock()
+	reservations := make(map[string]*reservation)
+	for key, res := range sn.reservations {
+		reservations[key] = res
+	}
+	return reservations
+}
+
 // GetReservationKeys Return an array of all reservation keys for the node.
 // This will return an empty array if there are no reservations.
 // Visible for tests

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -117,16 +117,6 @@ func (sn *Node) GetAttribute(key string) string {
 	return sn.attributes[key]
 }
 
-func (sn *Node) getReservations() map[string]*reservation {
-	sn.RLock()
-	defer sn.RUnlock()
-	reservations := make(map[string]*reservation)
-	for key, res := range sn.reservations {
-		reservations[key] = res
-	}
-	return reservations
-}
-
 // GetReservationKeys Return an array of all reservation keys for the node.
 // This will return an empty array if there are no reservations.
 // Visible for tests

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -1150,7 +1150,7 @@ func (sq *Queue) GetQueueOutstandingRequests(total *[]*AllocationAsk) {
 func (sq *Queue) TryReservedAllocate(iterator func() NodeIterator) *Allocation {
 	if sq.IsLeafQueue() {
 		// skip if it has no reservations
-		reservedCopy := sq.getReservedApps()
+		reservedCopy := sq.GetReservedApps()
 		if len(reservedCopy) != 0 {
 			// get the headroom
 			headRoom := sq.getHeadRoom()
@@ -1199,9 +1199,9 @@ func (sq *Queue) TryReservedAllocate(iterator func() NodeIterator) *Allocation {
 	return nil
 }
 
-// getReservedApps returns a shallow copy of the reserved app list
+// GetReservedApps returns a shallow copy of the reserved app list
 // locked to prevent race conditions from event updates
-func (sq *Queue) getReservedApps() map[string]int {
+func (sq *Queue) GetReservedApps() map[string]int {
 	sq.RLock()
 	defer sq.RUnlock()
 

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1116,6 +1116,155 @@ func TestRequiredNodeReservation(t *testing.T) {
 	assertUserGroupResource(t, getTestUserGroup(), res)
 }
 
+// allocate ask request with required node having non daemon set reservations
+func TestRequiredNodeCancelNonDSReservations(t *testing.T) {
+	partition := createQueuesNodes(t)
+	if partition == nil {
+		t.Fatal("partition create failed")
+	}
+	if alloc := partition.tryAllocate(); alloc != nil {
+		t.Fatalf("empty cluster allocate returned allocation: %s", alloc)
+	}
+
+	// override the reservation delay, and cleanup when done
+	objects.SetReservationDelay(10 * time.Nanosecond)
+	defer objects.SetReservationDelay(2 * time.Second)
+
+	// turn off the second node
+	node2 := partition.GetNode(nodeID2)
+	node2.SetSchedulable(false)
+
+	res, err := resources.NewResourceFromConf(map[string]string{"vcore": "7"})
+	assert.NilError(t, err, "failed to create resource")
+
+	// only one resource for alloc fits on a node
+	app := newApplication(appID1, "default", "root.parent.sub-leaf")
+	err = partition.AddApplication(app)
+	assert.NilError(t, err, "failed to add app-1 to partition")
+
+	ask := newAllocationAskRepeat("alloc-1", appID1, res, 2)
+	err = app.AddAllocationAsk(ask)
+	assert.NilError(t, err, "failed to add ask to app")
+	// calculate the resource size using the repeat request (reuse is possible using proto conversions in ask)
+	res.MultiplyTo(2)
+	assert.Assert(t, resources.Equals(res, app.GetPendingResource()), "pending resource not set as expected")
+	assert.Assert(t, resources.Equals(res, partition.root.GetPendingResource()), "pending resource not set as expected on root queue")
+
+	// the first one should be allocated
+	alloc := partition.tryAllocate()
+	if alloc == nil {
+		t.Fatal("1st allocation did not return the correct allocation")
+	}
+	assert.Equal(t, objects.Allocated, alloc.GetResult(), "allocation result should have been allocated")
+
+	// the second one should be reserved as the 2nd node is not scheduling
+	alloc = partition.tryAllocate()
+	if alloc != nil {
+		t.Fatal("2nd allocation did not return the correct allocation")
+	}
+	// check if updated (must be after allocate call)
+	assert.Equal(t, 1, len(app.GetReservations()), "ask should have been reserved")
+	assert.Equal(t, 1, len(app.GetQueue().GetReservedApps()), "queue reserved apps should be 1")
+
+	res1, err := resources.NewResourceFromConf(map[string]string{"vcore": "1"})
+	assert.NilError(t, err, "failed to create resource")
+
+	// only one resource for alloc fits on a node
+	app1 := newApplication(appID2, "default", "root.parent.sub-leaf")
+	err = partition.AddApplication(app1)
+	assert.NilError(t, err, "failed to add app-2 to partition")
+
+	// required node set on ask
+	ask2 := newAllocationAsk("alloc-2", appID2, res1)
+	ask2.SetRequiredNode(nodeID1)
+	err = app1.AddAllocationAsk(ask2)
+	assert.NilError(t, err, "failed to add ask alloc-2 to app-1")
+
+	alloc = partition.tryAllocate()
+	if alloc == nil {
+		t.Fatal("1st allocation did not return the correct allocation")
+	}
+	assert.Equal(t, objects.Allocated, alloc.GetResult(), "allocation result should have been allocated")
+
+	// earlier app (app1) reservation count should be zero
+	assert.Equal(t, 0, len(app.GetReservations()), "ask should have been reserved")
+	assert.Equal(t, 0, len(app.GetQueue().GetReservedApps()), "queue reserved apps should be 0")
+}
+
+// allocate ask request with required node having daemon set reservations
+func TestRequiredNodeCancelDSReservations(t *testing.T) {
+	partition := createQueuesNodes(t)
+	if partition == nil {
+		t.Fatal("partition create failed")
+	}
+	if alloc := partition.tryAllocate(); alloc != nil {
+		t.Fatalf("empty cluster allocate returned allocation: %s", alloc)
+	}
+
+	// override the reservation delay, and cleanup when done
+	objects.SetReservationDelay(10 * time.Nanosecond)
+	defer objects.SetReservationDelay(2 * time.Second)
+
+	// turn off the second node
+	node2 := partition.GetNode(nodeID2)
+	node2.SetSchedulable(false)
+
+	res, err := resources.NewResourceFromConf(map[string]string{"vcore": "7"})
+	assert.NilError(t, err, "failed to create resource")
+
+	// only one resource for alloc fits on a node
+	app := newApplication(appID1, "default", "root.parent.sub-leaf")
+	err = partition.AddApplication(app)
+	assert.NilError(t, err, "failed to add app-1 to partition")
+
+	ask := newAllocationAskRepeat("alloc-1", appID1, res, 2)
+	ask.SetRequiredNode(nodeID1)
+	err = app.AddAllocationAsk(ask)
+	assert.NilError(t, err, "failed to add ask to app")
+	// calculate the resource size using the repeat request (reuse is possible using proto conversions in ask)
+	res.MultiplyTo(2)
+	assert.Assert(t, resources.Equals(res, app.GetPendingResource()), "pending resource not set as expected")
+	assert.Assert(t, resources.Equals(res, partition.root.GetPendingResource()), "pending resource not set as expected on root queue")
+
+	// the first one should be allocated
+	alloc := partition.tryAllocate()
+	if alloc == nil {
+		t.Fatal("1st allocation did not return the correct allocation")
+	}
+	assert.Equal(t, objects.Allocated, alloc.GetResult(), "allocation result should have been allocated")
+
+	// the second one should be reserved as the 2nd node is not scheduling
+	alloc = partition.tryAllocate()
+	if alloc != nil {
+		t.Fatal("2nd allocation did not return the correct allocation")
+	}
+	// check if updated (must be after allocate call)
+	assert.Equal(t, 1, len(app.GetReservations()), "ask should have been reserved")
+	assert.Equal(t, 1, len(app.GetQueue().GetReservedApps()), "queue reserved apps should be 1")
+
+	res1, err := resources.NewResourceFromConf(map[string]string{"vcore": "1"})
+	assert.NilError(t, err, "failed to create resource")
+
+	// only one resource for alloc fits on a node
+	app1 := newApplication(appID2, "default", "root.parent.sub-leaf")
+	err = partition.AddApplication(app1)
+	assert.NilError(t, err, "failed to add app-2 to partition")
+
+	// required node set on ask
+	ask2 := newAllocationAsk("alloc-2", appID2, res1)
+	ask2.SetRequiredNode(nodeID1)
+	err = app1.AddAllocationAsk(ask2)
+	assert.NilError(t, err, "failed to add ask alloc-2 to app-1")
+
+	alloc = partition.tryAllocate()
+	if alloc != nil {
+		t.Fatal("3rd allocation did not return the correct allocation")
+	}
+	// still reservation count is 1
+	assert.Equal(t, 1, len(app.GetReservations()), "ask should have been reserved")
+	assert.Equal(t, 1, len(app.GetQueue().GetReservedApps()), "queue reserved apps should be 1")
+}
+
 func TestRequiredNodeNotExist(t *testing.T) {
 	setupUGM()
 	partition := createQueuesNodes(t)

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1361,15 +1361,11 @@ func TestPreemptionForRequiredNodeNormalAlloc(t *testing.T) {
 	partition, app := setupPreemptionForRequiredNode(t)
 	// now try the allocation again: the normal path
 	alloc := partition.tryAllocate()
-	if alloc == nil {
+	if alloc != nil {
 		t.Fatal("allocation attempt should have returned an allocation")
 	}
 	// check if updated (must be after allocate call)
-	assert.Equal(t, 0, len(app.GetReservations()), "ask should have no longer be reserved")
-	assert.Equal(t, alloc.GetResult(), objects.AllocatedReserved, "result is not the expected AllocatedReserved")
-	assert.Equal(t, alloc.GetReleaseCount(), 0, "released allocations should have been 0")
-	assert.Equal(t, alloc.GetAllocationKey(), allocID2, "expected ask alloc-2 to be allocated")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 8000}))
+	assert.Equal(t, 1, len(app.GetReservations()), "ask should have no longer be reserved")
 }
 
 // Preemption followed by a reserved allocation

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1236,7 +1236,7 @@ func TestRequiredNodeCancelDSReservations(t *testing.T) {
 	// the second one should be reserved as the 2nd node is not scheduling
 	alloc = partition.tryAllocate()
 	if alloc != nil {
-		t.Fatal("2nd allocation did not return the correct allocation")
+		t.Fatal("2nd allocation should not return allocation")
 	}
 	// check if updated (must be after allocate call)
 	assert.Equal(t, 1, len(app.GetReservations()), "ask should have been reserved")
@@ -1258,7 +1258,7 @@ func TestRequiredNodeCancelDSReservations(t *testing.T) {
 
 	alloc = partition.tryAllocate()
 	if alloc != nil {
-		t.Fatal("3rd allocation did not return the correct allocation")
+		t.Fatal("3rd allocation should not return allocation")
 	}
 	// still reservation count is 1
 	assert.Equal(t, 1, len(app.GetReservations()), "ask should have been reserved")
@@ -1362,10 +1362,10 @@ func TestPreemptionForRequiredNodeNormalAlloc(t *testing.T) {
 	// now try the allocation again: the normal path
 	alloc := partition.tryAllocate()
 	if alloc != nil {
-		t.Fatal("allocation attempt should have returned an allocation")
+		t.Fatal("allocations should not have returned an allocation")
 	}
 	// check if updated (must be after allocate call)
-	assert.Equal(t, 1, len(app.GetReservations()), "ask should have no longer be reserved")
+	assert.Equal(t, 1, len(app.GetReservations()), "ask should have been reserved")
 }
 
 // Preemption followed by a reserved allocation


### PR DESCRIPTION
### What is this PR for?
Cancel non daemon set reservations (if any) on specific node to give preference to daemon sets allocation during upscaling

### What type of PR is it?
* [ ] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1398

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
