### PR TITLE
[YUNIKORN-1468] Remove completedApplications from Queue

### DIFF
--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -328,13 +328,9 @@ func TestRemoveApplication(t *testing.T) {
 	leaf.RemoveApplication(nonExist)
 	assert.Equal(t, len(leaf.applications), 1, "Non existing application was removed from the queue")
 	assert.Equal(t, len(leaf.GetCopyOfApps()), 1, "Non existing application was removed from the queue")
-	assert.Equal(t, len(leaf.completedApplications), 0)
-	assert.Equal(t, len(leaf.GetCopyOfCompletedApps()), 0)
 	leaf.RemoveApplication(app)
 	assert.Equal(t, len(leaf.applications), 0, "Application was not removed from the queue as expected")
 	assert.Equal(t, len(leaf.GetCopyOfApps()), 0, "Application was not removed from the queue as expected")
-	assert.Equal(t, len(leaf.completedApplications), 1)
-	assert.Equal(t, len(leaf.GetCopyOfCompletedApps()), 1)
 
 	// try the same again now with pending resources set
 	res := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -535,7 +535,14 @@ func getQueueApplications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	apps := queue.GetCopyOfApps()
-	completedApps := queue.GetCopyOfCompletedApps()
+
+	completedApps := make(map[string]*objects.Application)
+	for _, app := range partitionContext.GetCompletedApplications() {
+		if app.GetQueuePath() == queueName {
+			completedApps[app.ApplicationID] = app
+		}
+	}
+
 	appsDao := make([]*dao.ApplicationDAOInfo, 0, len(apps)+len(completedApps))
 	for _, app := range apps {
 		appsDao = append(appsDao, getApplicationJSON(app))

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -534,22 +534,18 @@ func getQueueApplications(w http.ResponseWriter, r *http.Request) {
 		buildJSONErrorResponse(w, QueueDoesNotExists, http.StatusBadRequest)
 		return
 	}
-	apps := queue.GetCopyOfApps()
 
-	completedApps := make(map[string]*objects.Application)
+	appsDao := make([]*dao.ApplicationDAOInfo, 0)
+	for _, app := range queue.GetCopyOfApps() {
+		appsDao = append(appsDao, getApplicationJSON(app))
+	}
+
 	for _, app := range partitionContext.GetCompletedApplications() {
 		if app.GetQueuePath() == queueName {
-			completedApps[app.ApplicationID] = app
+			appsDao = append(appsDao, getApplicationJSON(app))
 		}
 	}
 
-	appsDao := make([]*dao.ApplicationDAOInfo, 0, len(apps)+len(completedApps))
-	for _, app := range apps {
-		appsDao = append(appsDao, getApplicationJSON(app))
-	}
-	for _, app := range completedApps {
-		appsDao = append(appsDao, getApplicationJSON(app))
-	}
 	if err := json.NewEncoder(w).Encode(appsDao); err != nil {
 		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -540,12 +540,6 @@ func getQueueApplications(w http.ResponseWriter, r *http.Request) {
 		appsDao = append(appsDao, getApplicationJSON(app))
 	}
 
-	for _, app := range partitionContext.GetCompletedApplications() {
-		if app.GetQueuePath() == queueName {
-			appsDao = append(appsDao, getApplicationJSON(app))
-		}
-	}
-
 	if err := json.NewEncoder(w).Encode(appsDao); err != nil {
 		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -881,9 +881,8 @@ func addAppWithUserGroup(t *testing.T, id string, part *scheduler.PartitionConte
 func TestGetQueueApplicationsHandler(t *testing.T) {
 	part := setup(t, configDefault, 1)
 
-	// add two applications
+	// add an application
 	app := addApp(t, "app-1", part, "root.default", false)
-	addApp(t, "app-2", part, "root.default", true)
 
 	// add placeholder to test PlaceholderDAOInfo
 	tg := "tg-1"
@@ -916,7 +915,7 @@ func TestGetQueueApplicationsHandler(t *testing.T) {
 	getQueueApplications(resp, req)
 	err = json.Unmarshal(resp.outputBytes, &appsDao)
 	assert.NilError(t, err, "failed to unmarshal applications dao response from response body: %s", string(resp.outputBytes))
-	assert.Equal(t, len(appsDao), 2)
+	assert.Equal(t, len(appsDao), 1)
 
 	if !appsDao[0].HasReserved {
 		assert.Equal(t, len(appsDao[0].Reservations), 0)

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -871,8 +871,9 @@ func addAppWithUserGroup(t *testing.T, id string, part *scheduler.PartitionConte
 	assert.Equal(t, app.CurrentState(), objects.New.String())
 	assert.Equal(t, 1+initSize, len(part.GetApplications()))
 	if isCompleted {
-		// we don't test partition, so it is fine to skip to update partition
-		app.UnSetQueue()
+		app.SetState(objects.Completing.String())
+		err = app.HandleApplicationEvent(objects.CompleteApplication)
+		assert.NilError(t, err, "The app should have completed")
 	}
 	return app
 }


### PR DESCRIPTION
### What is this PR for?
As described in the Jira, this is a more comprehensive fix for the issues identified via YUNIKORN-1440 and discussed in #471. Proposed changes ensure that app history and cleanup mechanisms are solely managed at the Partition level and unlinked from the Queue. Queue history is also removed from the `/ws/v1/partition/{partition}/queue/{queue}/applications` REST endpoint.


### What type of PR is it?
* [x] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1468

### How should this be tested?
Tests modified but largely unchanged.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
