### PR TITLE
[YUNIKORN-1476] Fix typo in negative resource health check logging

### DIFF
--- a/pkg/scheduler/health_checker.go
+++ b/pkg/scheduler/health_checker.go
@@ -215,7 +215,7 @@ func checkSchedulingContext(schedulerContext *ClusterContext) []dao.HealthCheckI
 		fmt.Sprintf("Partitions with negative resources: %q", partitionsWithNegResources))
 	info[1] = CreateCheckInfo(len(nodesWithNegResources) == 0, "Negative resources",
 		"Check for negative resources in the nodes",
-		fmt.Sprintf("Nodes with negative resources: %q", partitionsWithNegResources))
+		fmt.Sprintf("Nodes with negative resources: %q", nodesWithNegResources))
 	info[2] = CreateCheckInfo(len(allocationMismatch) == 0, "Consistency of data",
 		"Check if a node's allocated resource <= total resource of the node",
 		fmt.Sprintf("Nodes with inconsistent data: %q", allocationMismatch))


### PR DESCRIPTION
### What is this PR for?

In the health check logs I was seeing `{"Name":"Negative resources","Succeeded":false,"Description":"Check for negative resources in the nodes","DiagnosisMessage":"Nodes with negative resources: []"}`
I noticed that there appears to be a typo where it is checking `nodesWithNegResources` but then logging the values of `partitionsWithNegResources`. 

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-1476

### How should this be tested?

I am not 100% sure the best way to test this.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
