### PR TITLE
[YUNIKORN-1453] Remove asks from completed applications

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -1913,6 +1913,11 @@ func (sa *Application) GetAskMaxPriority() int32 {
 	return sa.askMaxPriority
 }
 
+func (sa *Application) cleanupAsks() {
+	sa.requests = make(map[string]*AllocationAsk)
+	sa.sortedRequests = nil
+}
+
 // test only
 func SetCompletingTimeout(duration time.Duration) {
 	completingTimeout = duration

--- a/pkg/scheduler/objects/application_state.go
+++ b/pkg/scheduler/objects/application_state.go
@@ -207,6 +207,7 @@ func NewAppState() *fsm.FSM {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				app.setStateTimer(terminatedTimeout, app.stateMachine.Current(), ExpireApplication)
 				app.executeTerminatedCallback()
+				app.cleanupAsks()
 			},
 		},
 	)

--- a/pkg/scheduler/objects/application_state.go
+++ b/pkg/scheduler/objects/application_state.go
@@ -196,6 +196,7 @@ func NewAppState() *fsm.FSM {
 				app.setStateTimer(terminatedTimeout, app.stateMachine.Current(), ExpireApplication)
 				app.executeTerminatedCallback()
 				app.clearPlaceholderTimer()
+				app.cleanupAsks()
 			},
 			fmt.Sprintf("enter_%s", Failing.String()): func(event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -1035,6 +1035,10 @@ func TestCompleted(t *testing.T) {
 		terminatedTimeout = 3 * 24 * time.Hour
 	}()
 	app := newApplication(appID1, "default", "root.a")
+	app.requests = map[string]*AllocationAsk{
+		"test": {},
+	}
+	app.sortedRequests = append(app.sortedRequests, &AllocationAsk{})
 	err := app.HandleApplicationEvent(RunApplication)
 	assert.NilError(t, err, "no error expected new to accepted (completed test)")
 	err = app.HandleApplicationEvent(CompleteApplication)
@@ -1047,6 +1051,8 @@ func TestCompleted(t *testing.T) {
 	err = common.WaitFor(1*time.Millisecond, time.Millisecond*200, app.IsExpired)
 	assert.NilError(t, err, "Application did not progress into Expired state")
 
+	assert.Assert(t, app.sortedRequests == nil)
+	assert.Equal(t, 0, len(app.requests))
 	log := app.GetStateLog()
 	assert.Equal(t, len(log), 4, "wrong number of app events")
 	assert.Equal(t, log[0].ApplicationState, Accepted.String())


### PR DESCRIPTION
### What is this PR for?
If the application is completed, we should clean up containers which hold `AllocationAsk` objects .

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1453

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
