### PR TITLE
[YUNIKORN-1551] remove unused parameter from ClusterContext.addNode()

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -264,7 +264,7 @@ func (cc *ClusterContext) processNodes(request *si.NodeRequest) {
 			}
 			switch nodeInfo.Action {
 			case si.NodeInfo_CREATE:
-				err := cc.addNode(nodeInfo, nodeCount)
+				err := cc.addNode(nodeInfo)
 				if err == nil {
 					acceptedNodes = append(acceptedNodes, &si.AcceptedNode{
 						NodeID: nodeInfo.NodeID,
@@ -602,7 +602,7 @@ func (cc *ClusterContext) removePartition(partitionName string) {
 
 // addNode adds a new node to the cluster enforcing just one unlimited node in the cluster.
 // nil nodeInfo objects must be filtered out before calling this function
-func (cc *ClusterContext) addNode(nodeInfo *si.NodeInfo, nodeCount int) error {
+func (cc *ClusterContext) addNode(nodeInfo *si.NodeInfo) error {
 	sn := objects.NewNode(nodeInfo)
 	if !sn.IsReady() {
 		metrics.GetSchedulerMetrics().IncUnhealthyNodes()

--- a/pkg/scheduler/context_test.go
+++ b/pkg/scheduler/context_test.go
@@ -111,7 +111,7 @@ func TestContext_UpdateNode(t *testing.T) {
 	context.updateNode(n)
 	assert.Equal(t, 0, len(partition.GetNodes()), "unexpected node found on partition (correct partition set)")
 	// add the node to the context
-	err := context.addNode(n, 1)
+	err := context.addNode(n)
 	assert.NilError(t, err, "unexpected error returned from addNode")
 	assert.Equal(t, 1, len(partition.GetNodes()), "expected node not found on partition")
 	assert.Assert(t, resources.Equals(full, partition.GetTotalPartitionResource()), "partition resource should be updated")
@@ -154,12 +154,12 @@ func TestContext_AddNode(t *testing.T) {
 		Attributes:          map[string]string{"si/node-partition": "unknown"},
 		SchedulableResource: &si.Resource{Resources: map[string]*si.Quantity{"first": {Value: 10}}},
 	}
-	err := context.addNode(n, 1)
+	err := context.addNode(n)
 	if err == nil {
 		t.Fatalf("unknown node partition should have failed the node add")
 	}
 	n.Attributes = map[string]string{"si/node-partition": pName}
-	err = context.addNode(n, 1)
+	err = context.addNode(n)
 	assert.NilError(t, err, "unexpected error returned adding node")
 	partition := context.GetPartition(pName)
 	if partition == nil {
@@ -167,7 +167,7 @@ func TestContext_AddNode(t *testing.T) {
 	}
 	assert.Equal(t, 1, len(partition.GetNodes()), "expected node not found on partition")
 	// add same node again should show an error
-	err = context.addNode(n, 1)
+	err = context.addNode(n)
 	if err == nil {
 		t.Fatalf("existing node addition should have failed")
 	}
@@ -241,7 +241,7 @@ func TestContextUpdateNodeMetrics(t *testing.T) {
 
 	n := getNodeInfoForAddingNode(true)
 
-	err := context.addNode(n, 1)
+	err := context.addNode(n)
 	assert.NilError(t, err, "unexpected error returned from addNode")
 	verifyMetrics(t, 1, "active")
 
@@ -262,7 +262,7 @@ func TestContextAddUnhealthyNodeMetrics(t *testing.T) {
 
 	n := getNodeInfoForAddingNode(false)
 
-	err := context.addNode(n, 1)
+	err := context.addNode(n)
 	assert.NilError(t, err, "unexpected error returned from addNode")
 	verifyMetrics(t, 1, "active")
 	verifyMetrics(t, 1, "unhealthy")
@@ -273,7 +273,7 @@ func TestContextDrainingNodeMetrics(t *testing.T) {
 	context := createTestContext(t, pName)
 
 	n := getNodeInfoForAddingNode(true)
-	err := context.addNode(n, 1)
+	err := context.addNode(n)
 	assert.NilError(t, err, "unexpected error returned from addNode")
 
 	n = getNodeInfoForUpdatingNode(si.NodeInfo_DRAIN_NODE, true)
@@ -286,7 +286,7 @@ func TestContextDrainingNodeBackToSchedulableMetrics(t *testing.T) {
 	context := createTestContext(t, pName)
 
 	n := getNodeInfoForAddingNode(true)
-	err := context.addNode(n, 1)
+	err := context.addNode(n)
 	assert.NilError(t, err, "unexpected error returned from addNode")
 
 	n = getNodeInfoForUpdatingNode(si.NodeInfo_DRAIN_NODE, true)


### PR DESCRIPTION
### What is this PR for?
I remove the unused parameter called node Count.
Where the function is used is also modified.

### What type of PR is it?
* [x] - Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN1551/
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
