### PR TITLE
[YUNIKORN-1567] Do not attempt to schedule tasks if partition update is in progress

### DIFF
--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -61,6 +61,7 @@ type PartitionContext struct {
 	userGroupCache         *security.UserGroupCache        // user cache per partition
 	totalPartitionResource *resources.Resource             // Total node resources
 	allocations            int                             // Number of allocations on the partition
+	updateLock             sync.Mutex
 
 	// The partition write lock must not be held while manipulating an application.
 	// Scheduling is running continuously as a lock free background task. Scheduling an application


### PR DESCRIPTION
### What is this PR for?
We should block config updates while we're scheduling allocation asks. If the queue hierarchy changes, this can result in an incorrect, undeterministic behavior.
`ClusterContext.Lock()` is too coarse, `PartitionContext.Lock()` is also problematic for this purpose.
For each partition, a mutex is created which is locked during scheduling and config update.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1567

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
