### PR TITLE
[YUNIKORN-1578][core] Use zap.Stringer instead of calling String on object

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -870,7 +870,7 @@ func CalculateAbsUsedCapacity(capacity, used *Resource) *Resource {
 		log.Logger().Debug("Cannot calculate absolute capacity because of missing capacity or usage")
 		return absResource
 	}
-	var missingResources strings.Builder
+	missingResources := &strings.Builder{}
 	for resourceName, availableResource := range capacity.Resources {
 		var absResValue int64
 		if usedResource, ok := used.Resources[resourceName]; ok {
@@ -909,7 +909,7 @@ func CalculateAbsUsedCapacity(capacity, used *Resource) *Resource {
 	}
 	if missingResources.Len() != 0 {
 		log.Logger().Debug("Absolute usage result is missing resource information",
-			zap.Stringer("missing resource(s)", &missingResources))
+			zap.Stringer("missing resource(s)", missingResources))
 	}
 	return absResource
 }

--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -909,7 +909,7 @@ func CalculateAbsUsedCapacity(capacity, used *Resource) *Resource {
 	}
 	if missingResources.Len() != 0 {
 		log.Logger().Debug("Absolute usage result is missing resource information",
-			zap.String("missing resource(s)", missingResources.String()))
+			zap.Stringer("missing resource(s)", &missingResources))
 	}
 	return absResource
 }

--- a/pkg/common/security/usergroup.go
+++ b/pkg/common/security/usergroup.go
@@ -81,7 +81,7 @@ func GetUserGroupCache(resolver string) *UserGroupCache {
 		}
 		instance.ugs = make(map[string]*UserGroup)
 		log.Logger().Info("starting UserGroupCache cleaner",
-			zap.String("cleanerInterval", instance.interval.String()))
+			zap.Stringer("cleanerInterval", instance.interval))
 		go instance.run()
 	})
 	return instance
@@ -94,7 +94,7 @@ func (c *UserGroupCache) run() {
 		runStart := time.Now()
 		c.cleanUpCache()
 		log.Logger().Debug("time consumed cleaning the UserGroupCache",
-			zap.String("duration", time.Since(runStart).String()))
+			zap.Stringer("duration", time.Since(runStart)))
 	}
 }
 

--- a/pkg/common/server.go
+++ b/pkg/common/server.go
@@ -134,7 +134,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ss si.SchedulerServer) {
 	}
 
 	log.Logger().Info("listening for connections",
-		zap.String("address", listener.Addr().String()))
+		zap.Stringer("address", listener.Addr()))
 
 	if err = server.Serve(listener); err != nil {
 		log.Logger().Fatal("failed to serve", zap.Error(err))

--- a/pkg/rmproxy/rmproxy.go
+++ b/pkg/rmproxy/rmproxy.go
@@ -57,12 +57,12 @@ func enqueueAndCheckFull(queue chan interface{}, ev interface{}) {
 	select {
 	case queue <- ev:
 		log.Logger().Debug("enqueue event",
-			zap.String("eventType", reflect.TypeOf(ev).String()),
+			zap.Stringer("eventType", reflect.TypeOf(ev)),
 			zap.Any("event", ev),
 			zap.Int("currentQueueSize", len(queue)))
 	default:
 		log.Logger().DPanic("failed to enqueue event",
-			zap.String("event", reflect.TypeOf(ev).String()))
+			zap.Stringer("event", reflect.TypeOf(ev)))
 	}
 }
 

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -644,7 +644,7 @@ func (cc *ClusterContext) updateNode(nodeInfo *si.NodeInfo) {
 	} else {
 		log.Logger().Error("node partition not specified",
 			zap.String("nodeID", nodeInfo.NodeID),
-			zap.String("nodeAction", nodeInfo.Action.String()))
+			zap.Stringer("nodeAction", nodeInfo.Action))
 		return
 	}
 
@@ -652,7 +652,7 @@ func (cc *ClusterContext) updateNode(nodeInfo *si.NodeInfo) {
 		log.Logger().Error("Failed to update node on non existing partition",
 			zap.String("nodeID", nodeInfo.NodeID),
 			zap.String("partitionName", nodeInfo.Attributes[siCommon.NodePartition]),
-			zap.String("nodeAction", nodeInfo.Action.String()))
+			zap.Stringer("nodeAction", nodeInfo.Action))
 		return
 	}
 
@@ -661,7 +661,7 @@ func (cc *ClusterContext) updateNode(nodeInfo *si.NodeInfo) {
 		log.Logger().Error("Failed to update non existing node",
 			zap.String("nodeID", nodeInfo.NodeID),
 			zap.String("partitionName", nodeInfo.Attributes[siCommon.NodePartition]),
-			zap.String("nodeAction", nodeInfo.Action.String()))
+			zap.Stringer("nodeAction", nodeInfo.Action))
 		return
 	}
 
@@ -725,7 +725,7 @@ func (cc *ClusterContext) updateNode(nodeInfo *si.NodeInfo) {
 		log.Logger().Debug("unknown action for node update",
 			zap.String("nodeID", nodeInfo.NodeID),
 			zap.String("partitionName", nodeInfo.Attributes[siCommon.NodePartition]),
-			zap.String("nodeAction", nodeInfo.Action.String()))
+			zap.Stringer("nodeAction", nodeInfo.Action))
 	}
 }
 

--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -116,7 +116,7 @@ func NewAllocationFromSI(alloc *si.Allocation) *Allocation {
 	// order is important as task group can be set without placeholder but not the other way around
 	if alloc.Placeholder && alloc.TaskGroupName == "" {
 		log.Logger().Debug("Allocation cannot be a placeholder without a TaskGroupName",
-			zap.Stringer("SI alloc", alloc),
+			zap.Stringer("SI alloc", alloc))
 		return nil
 	}
 

--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -116,7 +116,7 @@ func NewAllocationFromSI(alloc *si.Allocation) *Allocation {
 	// order is important as task group can be set without placeholder but not the other way around
 	if alloc.Placeholder && alloc.TaskGroupName == "" {
 		log.Logger().Debug("Allocation cannot be a placeholder without a TaskGroupName",
-			zap.String("SI alloc", alloc.String()))
+			zap.Stringer("SI alloc", alloc)
 		return nil
 	}
 

--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -116,7 +116,7 @@ func NewAllocationFromSI(alloc *si.Allocation) *Allocation {
 	// order is important as task group can be set without placeholder but not the other way around
 	if alloc.Placeholder && alloc.TaskGroupName == "" {
 		log.Logger().Debug("Allocation cannot be a placeholder without a TaskGroupName",
-			zap.Stringer("SI alloc", alloc)
+			zap.Stringer("SI alloc", alloc),
 		return nil
 	}
 

--- a/pkg/scheduler/objects/allocation_ask.go
+++ b/pkg/scheduler/objects/allocation_ask.go
@@ -94,7 +94,7 @@ func NewAllocationAskFromSI(ask *si.AllocationAsk) *AllocationAsk {
 	// order is important as task group can be set without placeholder but not the other way around
 	if saa.placeholder && saa.taskGroupName == "" {
 		log.Logger().Debug("ask cannot be a placeholder without a TaskGroupName",
-			zap.String("SI ask", ask.String()))
+			zap.Stringer("SI ask", ask))
 		return nil
 	}
 	return saa

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -561,7 +561,7 @@ func (sa *Application) removeAsksInternal(allocKey string) int {
 	log.Logger().Info("ask removed successfully from application",
 		zap.String("appID", sa.ApplicationID),
 		zap.String("ask", allocKey),
-		zap.String("pendingDelta", deltaPendingResource.String()))
+		zap.Stringer("pendingDelta", deltaPendingResource))
 
 	return toRelease
 }
@@ -618,7 +618,7 @@ func (sa *Application) AddAllocationAsk(ask *AllocationAsk) error {
 		zap.String("appID", sa.ApplicationID),
 		zap.String("ask", ask.GetAllocationKey()),
 		zap.Bool("placeholder", ask.IsPlaceholder()),
-		zap.String("pendingDelta", delta.String()))
+		zap.Stringer("pendingDelta", delta))
 
 	return nil
 }
@@ -775,8 +775,8 @@ func (sa *Application) unReserveInternal(node *Node, ask *AllocationAsk) (int, e
 	if resKey == "" {
 		log.Logger().Debug("unreserve reservation key create failed unexpectedly",
 			zap.String("appID", sa.ApplicationID),
-			zap.String("node", node.String()),
-			zap.String("ask", ask.String()))
+			zap.Stringer("node", node),
+			zap.Stringer("ask", ask))
 		return 0, fmt.Errorf("reservation key failed node or ask are nil for appID %s", sa.ApplicationID)
 	}
 	// unReserve the node before removing from the app
@@ -952,7 +952,7 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, nodeIterator fu
 				log.Logger().Debug("allocation on required node is completed",
 					zap.String("nodeID", node.NodeID),
 					zap.String("allocationKey", request.GetAllocationKey()),
-					zap.String("AllocationResult", alloc.GetResult().String()))
+					zap.Stringer("AllocationResult", alloc.GetResult()))
 				return alloc
 			}
 			return newReservedAllocation(Reserved, node.NodeID, request)
@@ -1054,9 +1054,9 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 			// All placeholders in the same task group are always the same size.
 			if delta.HasNegativeValue() {
 				log.Logger().Warn("releasing placeholder: real allocation is larger than placeholder",
-					zap.String("requested resource", request.GetAllocatedResource().String()),
+					zap.Stringer("requested resource", request.GetAllocatedResource()),
 					zap.String("placeholderID", ph.GetUUID()),
-					zap.String("placeholder resource", ph.GetAllocatedResource().String()))
+					zap.Stringer("placeholder resource", ph.GetAllocatedResource()))
 				// release the placeholder and tell the RM
 				ph.SetReleased(true)
 				sa.notifyRMAllocationReleased(sa.rmID, []*Allocation{ph}, si.TerminationType_TIMEOUT, "cancel placeholder: resource incompatible")
@@ -1143,8 +1143,8 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 			if !node.AddAllocation(alloc) {
 				log.Logger().Debug("Node update failed unexpectedly",
 					zap.String("applicationID", sa.ApplicationID),
-					zap.String("ask", reqFit.String()),
-					zap.String("placeholder", phFit.String()))
+					zap.Stringer("ask", reqFit),
+					zap.Stringer("placeholder", phFit))
 				return nil
 			}
 			_, err := sa.updateAskRepeatInternal(reqFit, -1)
@@ -1593,7 +1593,7 @@ func (sa *Application) ReplaceAllocation(uuid string) *Allocation {
 	if ph == nil || ph.GetReleaseCount() == 0 {
 		log.Logger().Debug("Unexpected placeholder released",
 			zap.String("applicationID", sa.ApplicationID),
-			zap.String("placeholder", ph.String()))
+			zap.Stringer("placeholder", ph))
 		return nil
 	}
 	// weird issue we should never have more than 1 log it for debugging this error
@@ -1684,7 +1684,7 @@ func (sa *Application) removeAllocationInternal(uuid string, releaseType si.Term
 		if err := sa.HandleApplicationEvent(event); err != nil {
 			log.Logger().Warn(eventWarning,
 				zap.String("currentState", sa.CurrentState()),
-				zap.String("event", event.String()),
+				zap.Stringer("event", event),
 				zap.Error(err))
 		}
 	}

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -177,10 +177,10 @@ func (sn *Node) refreshAvailableResource() {
 	// check if any quantity is negative: a nil resource is all 0's
 	if !resources.StrictlyGreaterThanOrEquals(sn.availableResource, nil) {
 		log.Logger().Warn("Node update triggered over allocated node",
-			zap.String("available", sn.availableResource.String()),
-			zap.String("total", sn.totalResource.String()),
-			zap.String("occupied", sn.occupiedResource.String()),
-			zap.String("allocated", sn.allocatedResource.String()))
+			zap.Stringer("available", sn.availableResource),
+			zap.Stringer("total", sn.totalResource),
+			zap.Stringer("occupied", sn.occupiedResource),
+			zap.Stringer("allocated", sn.allocatedResource))
 	}
 }
 
@@ -316,7 +316,7 @@ func (sn *Node) ReplaceAllocation(uuid string, replace *Allocation, delta *resou
 		log.Logger().Warn("unexpected increase in node usage after placeholder replacement",
 			zap.String("placeholder uuid", uuid),
 			zap.String("allocation uuid", replace.GetUUID()),
-			zap.String("delta", delta.String()))
+			zap.Stringer("delta", delta))
 	}
 }
 
@@ -452,7 +452,7 @@ func (sn *Node) Reserve(app *Application, ask *AllocationAsk) error {
 			zap.String("nodeID", sn.NodeID),
 			zap.String("appID", app.ApplicationID),
 			zap.String("ask", ask.GetAllocationKey()),
-			zap.String("allocationAsk", ask.GetAllocatedResource().String()))
+			zap.Stringer("allocationAsk", ask.GetAllocatedResource()))
 		return fmt.Errorf("reservation does not fit on node %s, appID %s, ask %s", sn.NodeID, app.ApplicationID, ask.GetAllocatedResource().String())
 	}
 	sn.reservations[appReservation.getKey()] = appReservation

--- a/pkg/scheduler/objects/nodesorting.go
+++ b/pkg/scheduler/objects/nodesorting.go
@@ -138,6 +138,6 @@ func NewNodeSortingPolicy(policyType string, resourceWeights map[string]float64)
 	}
 
 	log.Logger().Debug("new node sorting policy added",
-		zap.String("type", pType.String()), zap.Any("resourceWeights", weights))
+		zap.Stringer("type", pType), zap.Any("resourceWeights", weights))
 	return sp
 }

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -653,7 +653,7 @@ func (sq *Queue) AddApplication(app *Application) {
 	}
 	if !resources.StrictlyGreaterThanZero(res) {
 		log.Logger().Warn("application resource quota has at least one 0 value: cannot set queue limit",
-			zap.String("maxResource", res.String()))
+			zap.Stringer("maxResource", res))
 		return
 	}
 	// set the quota
@@ -916,9 +916,9 @@ func (sq *Queue) IncAllocatedResource(alloc *resources.Resource, nodeReported bo
 			if sq.isLeaf {
 				log.Logger().Warn("parent queue exceeds maximum resource",
 					zap.String("leafQueue", sq.QueuePath),
-					zap.String("allocationRequest", alloc.String()),
-					zap.String("queueUsage", sq.allocatedResource.String()),
-					zap.String("maxResource", sq.maxResource.String()),
+					zap.Stringer("allocationRequest", alloc),
+					zap.Stringer("queueUsage", sq.allocatedResource),
+					zap.Stringer("maxResource", sq.maxResource),
 					zap.Error(err))
 			}
 			return err
@@ -952,9 +952,9 @@ func (sq *Queue) DecAllocatedResource(alloc *resources.Resource) error {
 			if sq.isLeaf {
 				log.Logger().Warn("released allocation is larger than parent queue allocated resource",
 					zap.String("leafQueue", sq.QueuePath),
-					zap.String("allocationRequest", alloc.String()),
-					zap.String("queueUsage", sq.allocatedResource.String()),
-					zap.String("maxResource", sq.maxResource.String()),
+					zap.Stringer("allocationRequest", alloc),
+					zap.Stringer("queueUsage", sq.allocatedResource),
+					zap.Stringer("maxResource", sq.maxResource),
 					zap.Error(err))
 			}
 			return err
@@ -1147,8 +1147,8 @@ func (sq *Queue) SetMaxResource(max *resources.Resource) {
 		return
 	}
 	log.Logger().Info("updating root queue max resources",
-		zap.String("current max", sq.maxResource.String()),
-		zap.String("new max", max.String()))
+		zap.Stringer("current max", sq.maxResource),
+		zap.Stringer("new max", max))
 	sq.maxResource = max.Clone()
 	sq.updateMaxResourceMetrics()
 }
@@ -1195,7 +1195,7 @@ func (sq *Queue) TryAllocate(iterator func() NodeIterator, getnode func(string) 
 				log.Logger().Debug("allocation found on queue",
 					zap.String("queueName", sq.QueuePath),
 					zap.String("appID", app.ApplicationID),
-					zap.String("allocation", alloc.String()))
+					zap.Stringer("allocation", alloc))
 				// if the app is still in Accepted state we're allocating placeholders.
 				// we want to count these apps as running
 				if app.IsAccepted() {
@@ -1231,7 +1231,7 @@ func (sq *Queue) TryPlaceholderAllocate(iterator func() NodeIterator, getnode fu
 				log.Logger().Debug("allocation found on queue",
 					zap.String("queueName", sq.QueuePath),
 					zap.String("appID", app.ApplicationID),
-					zap.String("allocation", alloc.String()))
+					zap.Stringer("allocation", alloc))
 				return alloc
 			}
 		}
@@ -1300,7 +1300,7 @@ func (sq *Queue) TryReservedAllocate(iterator func() NodeIterator) *Allocation {
 					log.Logger().Debug("reservation found for allocation found on queue",
 						zap.String("queueName", sq.QueuePath),
 						zap.String("appID", appID),
-						zap.String("allocation", alloc.String()),
+						zap.Stringer("allocation", alloc),
 						zap.String("appStatus", app.CurrentState()))
 					// if the app is still in Accepted state we're allocating placeholders.
 					// we want to count these apps as running

--- a/pkg/scheduler/objects/reservation.go
+++ b/pkg/scheduler/objects/reservation.go
@@ -41,9 +41,9 @@ type reservation struct {
 func newReservation(node *Node, app *Application, ask *AllocationAsk, appBased bool) *reservation {
 	if ask == nil || app == nil || node == nil {
 		log.Logger().Warn("Illegal reservation requested: one input is nil",
-			zap.String("node", node.String()),
-			zap.String("app", app.String()),
-			zap.String("ask", ask.String()))
+			zap.Stringer("node", node),
+			zap.Stringer("app", app),
+			zap.Stringer("ask", ask))
 		return nil
 	}
 	res := &reservation{

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -144,7 +144,7 @@ func (pc *PartitionContext) updateNodeSortingPolicy(conf configs.PartitionConfig
 		log.Logger().Info(fmt.Sprintf("NodeSorting policy not set using '%s' as default", configuredPolicy))
 	} else {
 		log.Logger().Info("NodeSorting policy set from config",
-			zap.String("policyName", configuredPolicy.String()))
+			zap.Stringer("policyName", configuredPolicy))
 	}
 	pc.nodes.SetNodeSortingPolicy(objects.NewNodeSortingPolicy(conf.NodeSortPolicy.Type, conf.NodeSortPolicy.ResourceWeights))
 }
@@ -557,7 +557,7 @@ func (pc *PartitionContext) AddNode(node *objects.Node, existingAllocations []*o
 					zap.Int("existingAllocations", len(existingAllocations)),
 					zap.Int("releasedAllocations", len(released)),
 					zap.Int("processingAlloc", current),
-					zap.String("allocation", alloc.String()),
+					zap.Stringer("allocation", alloc),
 					zap.Error(err))
 				// update failed metric, active metrics are tracked in add/remove from list
 				metrics.GetSchedulerMetrics().IncFailedNodes()
@@ -604,7 +604,7 @@ func (pc *PartitionContext) addNodeToList(node *objects.Node) error {
 	log.Logger().Info("Updated available resources from added node",
 		zap.String("partitionName", pc.Name),
 		zap.String("nodeID", node.NodeID),
-		zap.String("partitionResource", pc.totalPartitionResource.String()))
+		zap.Stringer("partitionResource", pc.totalPartitionResource))
 	return nil
 }
 
@@ -631,7 +631,7 @@ func (pc *PartitionContext) removeNodeFromList(nodeID string) *objects.Node {
 	log.Logger().Info("Updated available resources from removed node",
 		zap.String("partitionName", pc.Name),
 		zap.String("nodeID", node.NodeID),
-		zap.String("partitionResource", pc.totalPartitionResource.String()))
+		zap.Stringer("partitionResource", pc.totalPartitionResource))
 	return node
 }
 
@@ -712,9 +712,9 @@ func (pc *PartitionContext) removeNodeAllocations(node *objects.Node) ([]*object
 						}
 						log.Logger().Warn("replacing placeholder: placeholder is larger than real allocation",
 							zap.String("allocationID", release.GetUUID()),
-							zap.String("requested resource", release.GetAllocatedResource().String()),
+							zap.Stringer("requested resource", release.GetAllocatedResource()),
 							zap.String("placeholderID", alloc.GetUUID()),
-							zap.String("placeholder resource", alloc.GetAllocatedResource().String()))
+							zap.Stringer("placeholder resource", alloc.GetAllocatedResource()))
 					}
 					// track what we confirm on the other node to confirm it in the shim and get is bound
 					confirmed = append(confirmed, release)
@@ -888,7 +888,7 @@ func (pc *PartitionContext) allocate(alloc *objects.Allocation) *objects.Allocat
 		zap.String("appID", alloc.GetApplicationID()),
 		zap.String("allocationKey", alloc.GetAllocationKey()),
 		zap.String("uuid", alloc.GetUUID()),
-		zap.String("allocatedResource", alloc.GetAllocatedResource().String()),
+		zap.Stringer("allocatedResource", alloc.GetAllocatedResource()),
 		zap.Bool("placeholder", alloc.IsPlaceholder()),
 		zap.String("targetNode", alloc.GetNodeID()))
 	// pass the allocation back to the RM via the cluster context
@@ -1212,7 +1212,7 @@ func (pc *PartitionContext) removeAllocation(release *si.AllocationRelease) ([]*
 		log.Logger().Info("Application not found while releasing allocation",
 			zap.String("appID", appID),
 			zap.String("allocationId", uuid),
-			zap.String("terminationType", release.TerminationType.String()))
+			zap.Stringer("terminationType", release.TerminationType))
 		return nil, nil
 	}
 	// temp store for allocations manipulated
@@ -1236,7 +1236,7 @@ func (pc *PartitionContext) removeAllocation(release *si.AllocationRelease) ([]*
 			log.Logger().Info("removing allocation from application",
 				zap.String("appID", appID),
 				zap.String("allocationId", uuid),
-				zap.String("terminationType", release.TerminationType.String()))
+				zap.Stringer("terminationType", release.TerminationType))
 			if alloc := app.RemoveAllocation(uuid, release.TerminationType); alloc != nil {
 				released = append(released, alloc)
 			}
@@ -1267,9 +1267,9 @@ func (pc *PartitionContext) removeAllocation(release *si.AllocationRelease) ([]*
 				total.SubFrom(delta)
 				log.Logger().Warn("replacing placeholder: placeholder is larger than real allocation",
 					zap.String("allocationID", confirmed.GetUUID()),
-					zap.String("requested resource", confirmed.GetAllocatedResource().String()),
+					zap.Stringer("requested resource", confirmed.GetAllocatedResource()),
 					zap.String("placeholderID", alloc.GetUUID()),
-					zap.String("placeholder resource", alloc.GetAllocatedResource().String()))
+					zap.Stringer("placeholder resource", alloc.GetAllocatedResource()))
 			}
 			// replacements could be on a different node and different size handle all cases
 			if confirmed.GetNodeID() == alloc.GetNodeID() {
@@ -1339,7 +1339,7 @@ func (pc *PartitionContext) removeAllocationAsk(release *si.AllocationAskRelease
 		log.Logger().Info("Invalid ask release requested by shim",
 			zap.String("appID", appID),
 			zap.String("ask", allocKey),
-			zap.String("terminationType", release.TerminationType.String()))
+			zap.Stringer("terminationType", release.TerminationType))
 		return
 	}
 	// remove the allocation asks from the app

--- a/pkg/scheduler/partition_manager.go
+++ b/pkg/scheduler/partition_manager.go
@@ -62,7 +62,7 @@ func newPartitionManager(pc *PartitionContext, cc *ClusterContext) *partitionMan
 func (manager *partitionManager) Run() {
 	log.Logger().Info("starting partition manager",
 		zap.String("partition", manager.pc.Name),
-		zap.String("cleanRootInterval", manager.cleanRootInterval.String()))
+		zap.Stringer("cleanRootInterval", manager.cleanRootInterval))
 	go manager.cleanExpiredApps()
 	go manager.cleanRoot()
 }
@@ -81,7 +81,7 @@ func (manager *partitionManager) cleanRoot() {
 			runStart := time.Now()
 			manager.cleanQueues(manager.pc.root)
 			log.Logger().Debug("time consumed for queue cleaner",
-				zap.String("duration", time.Since(runStart).String()))
+				zap.Stringer("duration", time.Since(runStart)))
 		}
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -94,12 +94,12 @@ func enqueueAndCheckFull(queue chan interface{}, ev interface{}) {
 	select {
 	case queue <- ev:
 		log.Logger().Debug("enqueued event",
-			zap.String("eventType", reflect.TypeOf(ev).String()),
+			zap.Stringer("eventType", reflect.TypeOf(ev)),
 			zap.Any("event", ev),
 			zap.Int("currentQueueSize", len(queue)))
 	default:
 		log.Logger().DPanic("failed to enqueue event",
-			zap.String("event", reflect.TypeOf(ev).String()))
+			zap.Stringer("event", reflect.TypeOf(ev)))
 	}
 }
 
@@ -121,7 +121,7 @@ func (s *Scheduler) handleRMEvent() {
 			s.clusterContext.processRMConfigUpdateEvent(v)
 		default:
 			log.Logger().Error("Received type is not an acceptable type for RM event.",
-				zap.String("received type", reflect.TypeOf(v).String()))
+				zap.Stringer("received type", reflect.TypeOf(v)))
 		}
 		s.registerActivity()
 	}

--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -63,13 +63,13 @@ func (m *Manager) IncreaseTrackedResource(queuePath string, applicationID string
 	log.Logger().Debug("Increasing resource usage", zap.String("user", user.User),
 		zap.String("queue path", queuePath),
 		zap.String("application", applicationID),
-		zap.String("resource", usage.String()))
+		zap.Stringer("resource", usage))
 	if queuePath == "" || applicationID == "" || usage == nil || user.User == "" {
 		log.Logger().Error("Mandatory parameters are missing to increase the resource usage",
 			zap.String("user", user.User),
 			zap.String("queue path", queuePath),
 			zap.String("application", applicationID),
-			zap.String("resource", usage.String()))
+			zap.Stringer("resource", usage))
 		return fmt.Errorf("mandatory parameters are missing. queuepath: %s, application id: %s, resource usage: %s, user: %s",
 			queuePath, applicationID, usage.String(), user.User)
 	}
@@ -88,7 +88,7 @@ func (m *Manager) IncreaseTrackedResource(queuePath string, applicationID string
 			zap.String("user", user.User),
 			zap.String("queue path", queuePath),
 			zap.String("application", applicationID),
-			zap.String("resource", usage.String()),
+			zap.Stringer("resource", usage),
 			zap.String("err message", err.Error()))
 		return err
 	}
@@ -108,7 +108,7 @@ func (m *Manager) IncreaseTrackedResource(queuePath string, applicationID string
 				zap.String("group", group),
 				zap.String("queue path", queuePath),
 				zap.String("application", applicationID),
-				zap.String("resource", usage.String()),
+				zap.Stringer("resource", usage),
 				zap.String("err message", err.Error()))
 			return err
 		}
@@ -124,14 +124,14 @@ func (m *Manager) DecreaseTrackedResource(queuePath string, applicationID string
 	log.Logger().Debug("Decreasing resource usage", zap.String("user", user.User),
 		zap.String("queue path", queuePath),
 		zap.String("application", applicationID),
-		zap.String("resource", usage.String()),
+		zap.Stringer("resource", usage),
 		zap.Bool("removeApp", removeApp))
 	if queuePath == "" || applicationID == "" || usage == nil || user.User == "" {
 		log.Logger().Error("Mandatory parameters are missing to decrease the resource usage",
 			zap.String("user", user.User),
 			zap.String("queue path", queuePath),
 			zap.String("application", applicationID),
-			zap.String("resource", usage.String()),
+			zap.Stringer("resource", usage),
 			zap.Bool("removeApp", removeApp))
 		return fmt.Errorf("mandatory parameters are missing. queuepath: %s, application id: %s, resource usage: %s, user: %s",
 			queuePath, applicationID, usage.String(), user.User)
@@ -146,7 +146,7 @@ func (m *Manager) DecreaseTrackedResource(queuePath string, applicationID string
 				zap.String("user", user.User),
 				zap.String("queue path", queuePath),
 				zap.String("application", applicationID),
-				zap.String("resource", usage.String()),
+				zap.Stringer("resource", usage),
 				zap.Bool("removeApp", removeApp),
 				zap.String("err message", err.Error()))
 			return err
@@ -175,7 +175,7 @@ func (m *Manager) DecreaseTrackedResource(queuePath string, applicationID string
 				zap.String("group", group),
 				zap.String("queue path", queuePath),
 				zap.String("application", applicationID),
-				zap.String("resource", usage.String()),
+				zap.Stringer("resource", usage),
 				zap.Bool("removeApp", removeApp),
 				zap.String("err message", err.Error()))
 			return err

--- a/pkg/scheduler/ugm/queue_tracker.go
+++ b/pkg/scheduler/ugm/queue_tracker.go
@@ -57,7 +57,7 @@ func (qt *QueueTracker) increaseTrackedResource(queuePath string, applicationID 
 	log.Logger().Debug("Increasing resource usage",
 		zap.String("queue path", queuePath),
 		zap.String("application", applicationID),
-		zap.String("resource", usage.String()))
+		zap.Stringer("resource", usage))
 	if queuePath == "" || applicationID == "" || usage == nil {
 		return fmt.Errorf("mandatory parameters are missing. queuepath: %s, application id: %s, resource usage: %s",
 			queuePath, applicationID, usage.String())
@@ -91,7 +91,7 @@ func (qt *QueueTracker) decreaseTrackedResource(queuePath string, applicationID 
 	log.Logger().Debug("Decreasing resource usage",
 		zap.String("queue path", queuePath),
 		zap.String("application", applicationID),
-		zap.String("resource", usage.String()),
+		zap.Stringer("resource", usage),
 		zap.Bool("removeApp", removeApp))
 	if queuePath == "" || usage == nil {
 		return fmt.Errorf("mandatory parameters are missing. queuepath: %s, application id: %s, resource usage: %s",


### PR DESCRIPTION
### What is this PR for?
Throughout the code we have lots of places where we use the following call structure:

zap.String("text here", object.String()) 
This causes the object.String() call to happen before we even consider if it needs to be logged. Zap has a lazy way of doing this that removes the call to create the string  until it is needed, after the level checks etc. The above call becomes:

zap.Stringer("text here", object) 
Affect core and k8shim

### What type of PR is it?
* [x] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1578

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
