### PR TITLE
[YUNIKORN-1603] Configuration processing to support limit new wildcard interpretation syntax checking

### DIFF
--- a/pkg/common/configs/config_test.go
+++ b/pkg/common/configs/config_test.go
@@ -1175,6 +1175,130 @@ partitions:
 	if err == nil {
 		t.Errorf("limit parsing should have failed group @: %v", conf)
 	}
+
+	data = `
+partitions:
+  - name: default
+    limits:
+      - limit: dot user
+        users:
+        - user.lastname
+        maxapplications: 1
+      - limit: "@ user"
+        users:
+        - user@domain
+        maxapplications: 1
+      - limit: wildcard user
+        users:
+        - "*"
+        maxapplications: 1
+      - limit: wildcard group
+        groups:
+        - "*"
+        maxapplications: 1
+      - limit: error no wildcard user after wildcard user
+        users:
+        - "user1"
+        maxapplications: 1
+    queues:
+      - name: root
+`
+	// validate the config and check after the update
+	conf, err = CreateConfig(data)
+	assert.ErrorContains(t, err, "should not set no wildcard user user1 after wildcard user limit")
+
+	data = `
+partitions:
+  - name: default
+    limits:
+      - limit: dot user
+        users:
+        - user.lastname
+        maxapplications: 1
+      - limit: "@ user"
+        users:
+        - user@domain
+        maxapplications: 1
+      - limit: wildcard user
+        users:
+        - "*"
+        maxapplications: 1
+      - limit: wildcard group
+        groups:
+        - "*"
+        maxapplications: 1
+      - limit: error no wildcard group after wildcard user
+        groups:
+        - "group1"
+        maxapplications: 1
+    queues:
+      - name: root
+`
+	// validate the config and check after the update
+	conf, err = CreateConfig(data)
+	assert.ErrorContains(t, err, "should not set no wildcard group group1 after wildcard group limit")
+
+	data = `
+partitions:
+  - name: default
+    limits:
+      - limit: dot user
+        users:
+        - user.lastname
+        maxapplications: 1
+      - limit: "@ user"
+        users:
+        - user@domain
+        maxapplications: 1
+      - limit: wildcard user
+        users:
+        - "*"
+        maxapplications: 1
+      - limit: wildcard group
+        groups:
+        - "*"
+        maxapplications: 1
+      - limit: more than one wildcard user
+        users:
+        - "*"
+        maxapplications: 2
+    queues:
+      - name: root
+`
+	// validate the config and check after the update
+	conf, err = CreateConfig(data)
+	assert.ErrorContains(t, err, "should not set more than one wildcard user")
+
+	data = `
+partitions:
+  - name: default
+    limits:
+      - limit: dot user
+        users:
+        - user.lastname
+        maxapplications: 1
+      - limit: "@ user"
+        users:
+        - user@domain
+        maxapplications: 1
+      - limit: wildcard user
+        users:
+        - "*"
+        maxapplications: 1
+      - limit: wildcard group
+        groups:
+        - "*"
+        maxapplications: 1
+      - limit: more than one wildcard group
+        groups:
+        - "*"
+        maxapplications: 2
+    queues:
+      - name: root
+`
+	// validate the config and check after the update
+	conf, err = CreateConfig(data)
+	assert.ErrorContains(t, err, "should not set more than one wildcard group")
 }
 
 func TestLoadSchedulerConfigFromByteArray(t *testing.T) {

--- a/pkg/common/configs/config_test.go
+++ b/pkg/common/configs/config_test.go
@@ -1204,7 +1204,7 @@ partitions:
       - name: root
 `
 	// validate the config and check after the update
-	conf, err = CreateConfig(data)
+	_, err = CreateConfig(data)
 	assert.ErrorContains(t, err, "should not set no wildcard user user1 after wildcard user limit")
 
 	data = `
@@ -1235,7 +1235,7 @@ partitions:
       - name: root
 `
 	// validate the config and check after the update
-	conf, err = CreateConfig(data)
+	_, err = CreateConfig(data)
 	assert.ErrorContains(t, err, "should not set no wildcard group group1 after wildcard group limit")
 
 	data = `
@@ -1266,7 +1266,7 @@ partitions:
       - name: root
 `
 	// validate the config and check after the update
-	conf, err = CreateConfig(data)
+	_, err = CreateConfig(data)
 	assert.ErrorContains(t, err, "should not set more than one wildcard user")
 
 	data = `
@@ -1297,7 +1297,7 @@ partitions:
       - name: root
 `
 	// validate the config and check after the update
-	conf, err = CreateConfig(data)
+	_, err = CreateConfig(data)
 	assert.ErrorContains(t, err, "should not set more than one wildcard group")
 }
 

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -252,10 +252,8 @@ func checkLimit(limit Limit, currIdx int, userWildCardIdx, groupWildCardIdx *int
 				return fmt.Errorf("should not set more than one wildcard user")
 			}
 			*userWildCardIdx = currIdx
-		} else {
-			if *userWildCardIdx != -1 && currIdx > *userWildCardIdx {
-				return fmt.Errorf("should not set no wildcard user %s after wildcard user limit", name)
-			}
+		} else if *userWildCardIdx != -1 && currIdx > *userWildCardIdx {
+			return fmt.Errorf("should not set no wildcard user %s after wildcard user limit", name)
 		}
 	}
 	for _, name := range limit.Groups {
@@ -270,10 +268,8 @@ func checkLimit(limit Limit, currIdx int, userWildCardIdx, groupWildCardIdx *int
 				return fmt.Errorf("should not set more than one wildcard group")
 			}
 			*groupWildCardIdx = currIdx
-		} else {
-			if *groupWildCardIdx != -1 && currIdx > *groupWildCardIdx {
-				return fmt.Errorf("should not set no wildcard group %s after wildcard group limit", name)
-			}
+		} else if *groupWildCardIdx != -1 && currIdx > *groupWildCardIdx {
+			return fmt.Errorf("should not set no wildcard group %s after wildcard group limit", name)
 		}
 	}
 	var limitResource = resources.NewResource()

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -235,18 +235,45 @@ func checkPlacementFilter(filter Filter) error {
 }
 
 // Check a single limit entry
-func checkLimit(limit Limit) error {
+func checkLimit(limit Limit, currIdx int, userWildCardIdx, groupWildCardIdx *int) error {
 	if len(limit.Users) == 0 && len(limit.Groups) == 0 {
 		return fmt.Errorf("empty user and group lists defined in limit '%v'", limit)
 	}
+
 	for _, name := range limit.Users {
 		if name != "*" && !UserRegExp.MatchString(name) {
 			return fmt.Errorf("invalid limit user name '%s' in limit definition", name)
+		}
+		// The user without wildcard should not happen after the wildcard user
+		// It means the wildcard for user should be the last item for limits object list which including the username,
+		// and we should only set one wildcard user for all limits
+		if name == "*" {
+			if *userWildCardIdx != -1 && currIdx > *userWildCardIdx {
+				return fmt.Errorf("should not set more than one wildcard user")
+			}
+			*userWildCardIdx = currIdx
+		} else {
+			if *userWildCardIdx != -1 && currIdx > *userWildCardIdx {
+				return fmt.Errorf("should not set no wildcard user %s after wildcard user limit", name)
+			}
 		}
 	}
 	for _, name := range limit.Groups {
 		if name != "*" && !GroupRegExp.MatchString(name) {
 			return fmt.Errorf("invalid limit group name '%s' in limit definition", name)
+		}
+		// The group without wildcard should not happen after the wildcard group
+		// It means the wildcard for group should be the last item for limits object list which including the group name,
+		// and we should only set one wildcard group for all limits
+		if name == "*" {
+			if *groupWildCardIdx != -1 && currIdx > *groupWildCardIdx {
+				return fmt.Errorf("should not set more than one wildcard group")
+			}
+			*groupWildCardIdx = currIdx
+		} else {
+			if *groupWildCardIdx != -1 && currIdx > *groupWildCardIdx {
+				return fmt.Errorf("should not set no wildcard group %s after wildcard group limit", name)
+			}
 		}
 	}
 	var limitResource = resources.NewResource()
@@ -277,8 +304,11 @@ func checkLimits(limits []Limit, obj string) error {
 	log.Logger().Debug("checking limits configs",
 		zap.String("objName", obj),
 		zap.Int("limitsLength", len(limits)))
-	for _, limit := range limits {
-		if err := checkLimit(limit); err != nil {
+
+	var userWildCardIdx = -1
+	var groupWildCardIdx = -1
+	for index, limit := range limits {
+		if err := checkLimit(limit, index, &userWildCardIdx, &groupWildCardIdx); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
### What is this PR for?
Wildcard interpretation
Wildcard can only be used as the only entry in the limit object according to the documentation. There can be multiple limit objects in the overall limits for a queue. As part of this design the interpretation of the wildcard needs to be defined. Wildcards interpretation is related to the ordering of the limit objects in the overall limits object. The usage and interpretation will be different for users and groups. 

In general terms: allowing a wildcard in the user or group list only as part of the last entry of the limits list. After the wildcard has been added for either the user or group list we do not allow a user or group list with a non wildcard entry. This is especially important for the group resolution. It does allow specifying a user and group wildcard with different limits set. In all cases, there will only be a match using the wildcard if none of the earlier limit entries match.

As part of the already existing queue configuration processing the syntax for the configuration is checked. This check is triggered also for a reload of the file, via the config map. Rudimentary limit object checking is implemented as part of the config check.

 

The above described changes around the wildcards and what is allowed is not part of the configuration validation and must be added. 


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse//YUNIKORN-1603
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
