### PR TITLE
[YUNIKORN-1641] Queue tracker object is not cleaned up when a queue is deleted

### DIFF
--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -50,7 +50,7 @@ func (gt *GroupTracker) increaseTrackedResource(queuePath, applicationID string,
 	return gt.queueTracker.increaseTrackedResource(queuePath, applicationID, usage)
 }
 
-func (gt *GroupTracker) decreaseTrackedResource(queuePath, applicationID string, usage *resources.Resource, removeApp bool) error {
+func (gt *GroupTracker) decreaseTrackedResource(queuePath, applicationID string, usage *resources.Resource, removeApp bool) (bool, error) {
 	gt.Lock()
 	defer gt.Unlock()
 	if removeApp {

--- a/pkg/scheduler/ugm/group_tracker_test.go
+++ b/pkg/scheduler/ugm/group_tracker_test.go
@@ -132,13 +132,23 @@ func TestGTDecreaseTrackedResource(t *testing.T) {
 	assert.Equal(t, "map[mem:60000000 vcore:60000]", actualResources1["root.parent.child1"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:10000000 vcore:10000]", actualResources1["root.parent.child2"].String(), "wrong resource")
 
-	err = groupTracker.decreaseTrackedResource(queuePath1, TestApp1, usage1, true)
+	usage4, err := resources.NewResourceFromConf(map[string]string{"mem": "60M", "vcore": "60"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
+	}
+
+	err = groupTracker.decreaseTrackedResource(queuePath1, TestApp1, usage4, true)
 	if err != nil {
 		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, usage1, err)
 	}
 	assert.Equal(t, 1, len(groupTracker.getTrackedApplications()))
 
-	err = groupTracker.decreaseTrackedResource(queuePath2, TestApp2, usage2, true)
+	usage5, err := resources.NewResourceFromConf(map[string]string{"mem": "10M", "vcore": "10"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
+	}
+
+	err = groupTracker.decreaseTrackedResource(queuePath2, TestApp2, usage5, true)
 	if err != nil {
 		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage2, err)
 	}

--- a/pkg/scheduler/ugm/group_tracker_test.go
+++ b/pkg/scheduler/ugm/group_tracker_test.go
@@ -117,14 +117,18 @@ func TestGTDecreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
-	err = groupTracker.decreaseTrackedResource(queuePath1, TestApp1, usage3, false)
+	removeQT, err := groupTracker.decreaseTrackedResource(queuePath1, TestApp1, usage3, false)
 	if err != nil {
 		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, usage3, err)
 	}
-	err = groupTracker.decreaseTrackedResource(queuePath2, TestApp2, usage3, false)
+	assert.Equal(t, removeQT, false, "wrong remove queue tracker value")
+
+	removeQT, err = groupTracker.decreaseTrackedResource(queuePath2, TestApp2, usage3, false)
 	if err != nil {
 		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage3, err)
 	}
+	assert.Equal(t, removeQT, false, "wrong remove queue tracker value")
+
 	actualResources1 := getGroupResource(groupTracker)
 
 	assert.Equal(t, "map[mem:70000000 vcore:70000]", actualResources1["root"].String(), "wrong resource")
@@ -137,22 +141,24 @@ func TestGTDecreaseTrackedResource(t *testing.T) {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
 
-	err = groupTracker.decreaseTrackedResource(queuePath1, TestApp1, usage4, true)
+	removeQT, err = groupTracker.decreaseTrackedResource(queuePath1, TestApp1, usage4, true)
 	if err != nil {
 		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, usage1, err)
 	}
 	assert.Equal(t, 1, len(groupTracker.getTrackedApplications()))
+	assert.Equal(t, removeQT, false, "wrong remove queue tracker value")
 
 	usage5, err := resources.NewResourceFromConf(map[string]string{"mem": "10M", "vcore": "10"})
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
 
-	err = groupTracker.decreaseTrackedResource(queuePath2, TestApp2, usage5, true)
+	removeQT, err = groupTracker.decreaseTrackedResource(queuePath2, TestApp2, usage5, true)
 	if err != nil {
 		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage2, err)
 	}
 	assert.Equal(t, 0, len(groupTracker.getTrackedApplications()))
+	assert.Equal(t, removeQT, true, "wrong remove queue tracker value")
 }
 
 func getGroupResource(gt *GroupTracker) map[string]*resources.Resource {

--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -140,7 +140,7 @@ func (m *Manager) DecreaseTrackedResource(queuePath string, applicationID string
 	defer m.lock.Unlock()
 	userTracker := m.userTrackers[user.User]
 	if userTracker != nil {
-		err := userTracker.decreaseTrackedResource(queuePath, applicationID, usage, removeApp)
+		removeQT, err := userTracker.decreaseTrackedResource(queuePath, applicationID, usage, removeApp)
 		if err != nil {
 			log.Logger().Error("Problem in decreasing the user resource usage",
 				zap.String("user", user.User),
@@ -151,10 +151,8 @@ func (m *Manager) DecreaseTrackedResource(queuePath string, applicationID string
 				zap.String("err message", err.Error()))
 			return err
 		}
-		if removeApp {
-			if m.isUserRemovable(userTracker) {
-				delete(m.userTrackers, user.User)
-			}
+		if removeApp && removeQT {
+			delete(m.userTrackers, user.User)
 		}
 	} else {
 		log.Logger().Error("user tracker must be available in userTrackers map",
@@ -168,7 +166,7 @@ func (m *Manager) DecreaseTrackedResource(queuePath string, applicationID string
 	}
 	groupTracker := m.groupTrackers[group]
 	if groupTracker != nil {
-		err := groupTracker.decreaseTrackedResource(queuePath, applicationID, usage, removeApp)
+		removeQT, err := groupTracker.decreaseTrackedResource(queuePath, applicationID, usage, removeApp)
 		if err != nil {
 			log.Logger().Error("Problem in decreasing the group resource usage",
 				zap.String("user", user.User),
@@ -180,10 +178,8 @@ func (m *Manager) DecreaseTrackedResource(queuePath string, applicationID string
 				zap.String("err message", err.Error()))
 			return err
 		}
-		if removeApp {
-			if m.isGroupRemovable(groupTracker) {
-				delete(m.groupTrackers, group)
-			}
+		if removeApp && removeQT {
+			delete(m.groupTrackers, group)
 		}
 	} else {
 		log.Logger().Error("appGroupTrackers tracker must be available in groupTrackers map",

--- a/pkg/scheduler/ugm/queue_tracker_test.go
+++ b/pkg/scheduler/ugm/queue_tracker_test.go
@@ -136,18 +136,31 @@ func TestQTDecreaseTrackedResource(t *testing.T) {
 	assert.Equal(t, "map[mem:70000000 vcore:70000]", actualResources1["root.parent"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:60000000 vcore:60000]", actualResources1["root.parent.child1"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:10000000 vcore:10000]", actualResources1["root.parent.child2"].String(), "wrong resource")
+	assert.Equal(t, len(queueTracker.childQueueTrackers["parent"].childQueueTrackers), 2)
 
-	err = queueTracker.decreaseTrackedResource(queuePath1, TestApp1, usage1, true)
+	usage4, err := resources.NewResourceFromConf(map[string]string{"mem": "60M", "vcore": "60"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
+	}
+	err = queueTracker.decreaseTrackedResource(queuePath1, TestApp1, usage4, true)
 	if err != nil {
 		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, usage1, err)
 	}
 	assert.Equal(t, 1, len(queueTracker.runningApplications))
+	// Make sure childQueueTracker cleaned
+	assert.Equal(t, len(queueTracker.childQueueTrackers["parent"].childQueueTrackers), 1)
 
-	err = queueTracker.decreaseTrackedResource(queuePath2, TestApp2, usage2, true)
+	usage5, err := resources.NewResourceFromConf(map[string]string{"mem": "10M", "vcore": "10"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage5)
+	}
+	err = queueTracker.decreaseTrackedResource(queuePath2, TestApp2, usage5, true)
 	if err != nil {
 		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage2, err)
 	}
 	assert.Equal(t, 0, len(queueTracker.runningApplications))
+	// Make sure all childQueueTracker cleaned
+	assert.Equal(t, len(queueTracker.childQueueTrackers), 0)
 }
 
 func TestGetChildQueuePath(t *testing.T) {

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -55,7 +55,7 @@ func (ut *UserTracker) increaseTrackedResource(queuePath, applicationID string, 
 	return ut.queueTracker.increaseTrackedResource(queuePath, applicationID, usage)
 }
 
-func (ut *UserTracker) decreaseTrackedResource(queuePath, applicationID string, usage *resources.Resource, removeApp bool) error {
+func (ut *UserTracker) decreaseTrackedResource(queuePath, applicationID string, usage *resources.Resource, removeApp bool) (bool, error) {
 	ut.Lock()
 	defer ut.Unlock()
 	if removeApp {

--- a/pkg/scheduler/ugm/user_tracker_test.go
+++ b/pkg/scheduler/ugm/user_tracker_test.go
@@ -140,16 +140,19 @@ func TestDecreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
-	err = userTracker.decreaseTrackedResource(queuePath1, TestApp1, usage3, false)
+	removeQT, err := userTracker.decreaseTrackedResource(queuePath1, TestApp1, usage3, false)
 	if err != nil {
 		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, usage3, err)
 	}
-	err = userTracker.decreaseTrackedResource(queuePath2, TestApp2, usage3, false)
+	assert.Equal(t, removeQT, false, "wrong remove queue tracker value")
+
+	removeQT, err = userTracker.decreaseTrackedResource(queuePath2, TestApp2, usage3, false)
 	if err != nil {
 		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage3, err)
 	}
 	actualResources1 := getUserResource(userTracker)
 
+	assert.Equal(t, removeQT, false, "wrong remove queue tracker value")
 	assert.Equal(t, "map[mem:70000000 vcore:70000]", actualResources1["root"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:70000000 vcore:70000]", actualResources1["root.parent"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:60000000 vcore:60000]", actualResources1["root.parent.child1"].String(), "wrong resource")
@@ -160,21 +163,23 @@ func TestDecreaseTrackedResource(t *testing.T) {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
 
-	err = userTracker.decreaseTrackedResource(queuePath1, TestApp1, usage4, true)
+	removeQT, err = userTracker.decreaseTrackedResource(queuePath1, TestApp1, usage4, true)
 	if err != nil {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, usage1, err)
 	}
 	assert.Equal(t, 1, len(userTracker.getTrackedApplications()))
+	assert.Equal(t, removeQT, false, "wrong remove queue tracker value")
 
 	usage5, err := resources.NewResourceFromConf(map[string]string{"mem": "10M", "vcore": "10"})
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage5)
 	}
-	err = userTracker.decreaseTrackedResource(queuePath2, TestApp2, usage5, true)
+	removeQT, err = userTracker.decreaseTrackedResource(queuePath2, TestApp2, usage5, true)
 	if err != nil {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage2, err)
 	}
 	assert.Equal(t, 0, len(userTracker.getTrackedApplications()))
+	assert.Equal(t, removeQT, true, "wrong remove queue tracker value")
 }
 
 func getUserResource(ut *UserTracker) map[string]*resources.Resource {

--- a/pkg/scheduler/ugm/user_tracker_test.go
+++ b/pkg/scheduler/ugm/user_tracker_test.go
@@ -155,13 +155,22 @@ func TestDecreaseTrackedResource(t *testing.T) {
 	assert.Equal(t, "map[mem:60000000 vcore:60000]", actualResources1["root.parent.child1"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:10000000 vcore:10000]", actualResources1["root.parent.child2"].String(), "wrong resource")
 
-	err = userTracker.decreaseTrackedResource(queuePath1, TestApp1, usage1, true)
+	usage4, err := resources.NewResourceFromConf(map[string]string{"mem": "60M", "vcore": "60"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
+	}
+
+	err = userTracker.decreaseTrackedResource(queuePath1, TestApp1, usage4, true)
 	if err != nil {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, usage1, err)
 	}
 	assert.Equal(t, 1, len(userTracker.getTrackedApplications()))
 
-	err = userTracker.decreaseTrackedResource(queuePath2, TestApp2, usage2, true)
+	usage5, err := resources.NewResourceFromConf(map[string]string{"mem": "10M", "vcore": "10"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage5)
+	}
+	err = userTracker.decreaseTrackedResource(queuePath2, TestApp2, usage5, true)
 	if err != nil {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage2, err)
 	}


### PR DESCRIPTION
### What is this PR for?
Currently, every queue has its own QueueTracker object which is managed by ugm.Manager.

But when the queue is deleted either by a config change or automatically by the partition manager, the tracker object stays in memory, causing a memory leak.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1641
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
