### PR TITLE
[YUNIKORN-1668] Check there must be one more limit setting for group with specific name defined in the config when use wildcard group limit

### DIFF
--- a/pkg/common/configs/config_test.go
+++ b/pkg/common/configs/config_test.go
@@ -1193,6 +1193,10 @@ partitions:
         users:
         - "*"
         maxapplications: 1
+      - limit: no wildcard group
+        groups:
+        - "test"
+        maxapplications: 1
       - limit: wildcard group
         groups:
         - "*"
@@ -1223,6 +1227,10 @@ partitions:
       - limit: wildcard user
         users:
         - "*"
+        maxapplications: 1
+      - limit: no wildcard group
+        groups:
+        - "test"
         maxapplications: 1
       - limit: wildcard group
         groups:
@@ -1255,6 +1263,10 @@ partitions:
         users:
         - "*"
         maxapplications: 1
+      - limit: no wildcard group
+        groups:
+        - "test"
+        maxapplications: 1
       - limit: wildcard group
         groups:
         - "*"
@@ -1286,6 +1298,10 @@ partitions:
         users:
         - "*"
         maxapplications: 1
+      - limit: no wildcard group
+        groups:
+        - "test"
+        maxapplications: 1
       - limit: wildcard group
         groups:
         - "*"
@@ -1300,6 +1316,33 @@ partitions:
 	// validate the config and check after the update
 	_, err = CreateConfig(data)
 	assert.ErrorContains(t, err, "should not set more than one wildcard group")
+
+	data = `
+partitions:
+  - name: default
+    limits:
+      - limit: dot user
+        users:
+        - user.lastname
+        maxapplications: 1
+      - limit: "@ user"
+        users:
+        - user@domain
+        maxapplications: 1
+      - limit: wildcard user
+        users:
+        - "*"
+        maxapplications: 1
+      - limit: wildcard group
+        groups:
+        - "*"
+        maxapplications: 1
+    queues:
+      - name: root
+`
+	// validate the config and check after the update
+	_, err = CreateConfig(data)
+	assert.ErrorContains(t, err, "should not specify only one group limit that is using the wildcard")
 }
 
 func TestLoadSchedulerConfigFromByteArray(t *testing.T) {

--- a/pkg/common/configs/config_test.go
+++ b/pkg/common/configs/config_test.go
@@ -1012,6 +1012,10 @@ partitions:
         users:
         - "*"
         maxapplications: 1
+      - limit: no wildcard group
+        groups:
+        - "test"
+        maxapplications: 1
       - limit: wildcard group
         groups:
         - "*"
@@ -1026,7 +1030,7 @@ partitions:
 	if len(conf.Partitions[0].Queues) != 1 && len(conf.Partitions[0].Queues[0].Limits) != 0 {
 		t.Errorf("failed to load queues from config: %v", conf)
 	}
-	if len(conf.Partitions[0].Limits) != 4 {
+	if len(conf.Partitions[0].Limits) != 5 {
 		t.Errorf("failed to load partition limits from config: %v", conf)
 	}
 

--- a/pkg/common/configs/config_test.go
+++ b/pkg/common/configs/config_test.go
@@ -1347,6 +1347,76 @@ partitions:
 	// validate the config and check after the update
 	_, err = CreateConfig(data)
 	assert.ErrorContains(t, err, "should not specify only one group limit that is using the wildcard")
+
+	data = `
+partitions:
+  - name: default
+    limits:
+      - limit: dot user
+        users:
+        - user.lastname
+        maxapplications: 1
+      - limit: duplicated user
+        users:
+        - user.lastname
+        maxapplications: 1
+      - limit: "@ user"
+        users:
+        - user@domain
+        maxapplications: 1
+      - limit: wildcard user
+        users:
+        - "*"
+        maxapplications: 1
+      - limit: no wildcard group
+        groups:
+        - "test"
+        maxapplications: 1
+      - limit: wildcard group
+        groups:
+        - "*"
+        maxapplications: 1
+    queues:
+      - name: root
+`
+	// validate the config and check after the update
+	_, err = CreateConfig(data)
+	assert.ErrorContains(t, err, "duplicated user name user.lastname")
+
+	data = `
+partitions:
+  - name: default
+    limits:
+      - limit: dot user
+        users:
+        - user.lastname
+        maxapplications: 1
+      - limit: "@ user"
+        users:
+        - user@domain
+        maxapplications: 1
+      - limit: wildcard user
+        users:
+        - "*"
+        maxapplications: 1
+      - limit: no wildcard group
+        groups:
+        - "test"
+        maxapplications: 1
+      - limit: duplicated group
+        groups:
+        - "test"
+        maxapplications: 1
+      - limit: wildcard group
+        groups:
+        - "*"
+        maxapplications: 1
+    queues:
+      - name: root
+`
+	// validate the config and check after the update
+	_, err = CreateConfig(data)
+	assert.ErrorContains(t, err, "duplicated group name test")
 }
 
 func TestLoadSchedulerConfigFromByteArray(t *testing.T) {

--- a/pkg/common/configs/config_test.go
+++ b/pkg/common/configs/config_test.go
@@ -1605,6 +1605,46 @@ partitions:
 	// validate the config and check after the update
 	_, err = CreateConfig(data)
 	assert.ErrorContains(t, err, "duplicated group name test")
+
+	// Make sure different queues can support same username or groupname
+	data = `
+partitions:
+  - name: default
+    queues:
+      - name: root
+        maxapplications: 500
+        limits:
+          - limit:
+            users: 
+            - user1
+            maxresources: {memory: 10000, vcore: 10}
+            maxapplications: 5
+          - limit:
+            users:
+            - user2
+            groups:
+            - prod
+            maxapplications: 3
+        queues:
+          - name: level1
+            maxapplications: 100
+            resources:
+              guaranteed:
+                {memory: 1000, vcore: 10}
+              max:
+                {memory: 10000, vcore: 10}
+            limits:
+              - limit:
+                users: 
+                - user1
+                groups:
+                - prod
+                maxapplications: 5
+                maxresources: {memory: 10000, vcore: 10}
+`
+	// validate the config and check after the update
+	_, err = CreateConfig(data)
+	assert.NilError(t, err, "different queues should support same username or groupname")
 }
 
 func TestLoadSchedulerConfigFromByteArray(t *testing.T) {

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -89,8 +89,6 @@ type placementPathCheckResult int
 type LimitValidator struct {
 	existedUserName  map[string]bool
 	existedGroupName map[string]bool
-	userWildCardIdx  int
-	groupWildCardIdx int
 }
 
 const (

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -420,11 +420,11 @@ func checkLimits(limits []Limit, obj string, queue *QueueConfig) error {
 	}
 
 	defer func() {
-		for k, _ := range limitValidator.existedUserName {
+		for k := range limitValidator.existedUserName {
 			delete(limitValidator.existedUserName, k)
 		}
 
-		for k, _ := range limitValidator.existedGroupName {
+		for k := range limitValidator.existedGroupName {
 			delete(limitValidator.existedGroupName, k)
 		}
 	}()

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -86,11 +86,6 @@ type placementStaticPath struct {
 
 type placementPathCheckResult int
 
-type LimitValidator struct {
-	existedUserName  map[string]bool
-	existedGroupName map[string]bool
-}
-
 const (
 	checkOK placementPathCheckResult = iota
 	nonExistingQueue

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -418,6 +418,17 @@ func checkLimits(limits []Limit, obj string, queue *QueueConfig) error {
 		existedUserName:  make(map[string]bool),
 		existedGroupName: make(map[string]bool),
 	}
+
+	defer func() {
+		for k, _ := range limitValidator.existedUserName {
+			delete(limitValidator.existedUserName, k)
+		}
+
+		for k, _ := range limitValidator.existedGroupName {
+			delete(limitValidator.existedGroupName, k)
+		}
+	}()
+
 	for _, limit := range limits {
 		if err := checkLimit(limit, &limitValidator, queue); err != nil {
 			return err


### PR DESCRIPTION
### What is this PR for?
Specifying a wildcard for the group limit sets a cumulative limit for all users in that queue. If there is no specific group mentioned the wildcard group limit would thus be the same as the queue limit. For that reason we do not allow specifying only one group limit that is using the wildcard. There must be at least one limit with a group name defined.  


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1668
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
