### PR TITLE
[YUNIKORN-1700] Fix the wrong objects comparing in the Yunikorn-core sorts.go

### DIFF
--- a/pkg/scheduler/objects/sorters.go
+++ b/pkg/scheduler/objects/sorters.go
@@ -155,7 +155,7 @@ func sortApplicationsBySubmissionTimeAndPriority(sortedApps []*Application) {
 		r := sortedApps[j]
 		if l.SubmissionTime.Before(r.SubmissionTime) {
 			return true
-		} else if r.SubmissionTime.Before(r.SubmissionTime) {
+		} else if r.SubmissionTime.Before(l.SubmissionTime) {
 			return false
 		}
 		return l.GetAskMaxPriority() > r.GetAskMaxPriority()

--- a/pkg/scheduler/objects/sorters_test.go
+++ b/pkg/scheduler/objects/sorters_test.go
@@ -456,3 +456,26 @@ func assertAppListLength(t *testing.T, list []*Application, apps []string, name 
 		assert.Equal(t, apps[i], app.ApplicationID, "test name: %s", name)
 	}
 }
+
+func TestSortBySubmissionTime(t *testing.T) {
+	var list []*Application
+
+	// stable sort is used so equal values stay where they were
+	// let all resource have same resource but submissionTime is different
+	res := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": resources.Quantity(100)})
+	baseline := time.Now()
+	// setup to sort descending: all apps have pending resource
+	input := make(map[string]*Application, 4)
+	for i := 0; i < 4; i++ {
+		num := strconv.Itoa(i)
+		appID := "app-" + num
+		app := newApplication(appID, "partition", "queue")
+		app.pending = res
+		input[appID] = app
+		app.SubmissionTime = baseline.Add(-time.Minute * time.Duration(i))
+		input[appID] = app
+	}
+
+	list = sortApplications(input, policies.FifoSortPolicy, true, nil)
+	assertAppList(t, list, []int{3, 2, 1, 0}, "sort by submission time")
+}


### PR DESCRIPTION
### What is this PR for?
In the FIFO policy,  sorting applications is wrong.
Because `r.SubmissionTime.Before(r.SubmissionTime) is useless comparison in the FIFO `

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1700

### How should this be tested?
make test

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
