### PR TITLE
[YUNIKORN-1709] Add event streaming logic

### DIFF
--- a/pkg/events/event_ringbuffer.go
+++ b/pkg/events/event_ringbuffer.go
@@ -70,12 +70,36 @@ func (e *eventRingBuffer) Add(event *si.EventRecord) {
 	e.id++
 }
 
-// GetEventsFromID returns "count" number of event records from "id" if possible. The id can be determined from
+func (e *eventRingBuffer) GetRecentEvents(count uint64) []*si.EventRecord {
+	e.RLock()
+	defer e.RUnlock()
+
+	lastID := e.getLastEventID()
+	var startID uint64
+	if lastID < count {
+		startID = 0
+	} else {
+		startID = lastID - count + 1
+	}
+
+	history, _, _ := e.getEventsFromID(startID, count)
+	return history
+}
+
+// GetEventsFromID returns "count" number of event records from id if possible. The id can be determined from
 // the first call of the method - if it returns nothing because the id is not in the buffer, the lowest valid
 // identifier is returned which can be used to get the first batch.
 // If the caller does not want to pose limit on the number of events returned, "count" must be set to a high
 // value, e.g. math.MaxUint64.
 func (e *eventRingBuffer) GetEventsFromID(id uint64, count uint64) ([]*si.EventRecord, uint64, uint64) {
+	e.RLock()
+	defer e.RUnlock()
+
+	return e.getEventsFromID(id, count)
+}
+
+// getEventsFromID unlocked version of GetEventsFromID
+func (e *eventRingBuffer) getEventsFromID(id uint64, count uint64) ([]*si.EventRecord, uint64, uint64) {
 	e.RLock()
 	defer e.RUnlock()
 	lowest := e.getLowestID()

--- a/pkg/events/event_ringbuffer_test.go
+++ b/pkg/events/event_ringbuffer_test.go
@@ -277,6 +277,39 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, uint64(7), ringBuffer.resizeOffset)
 }
 
+func TestGetRecentEvents(t *testing.T) {
+	// empty
+	buffer := newEventRingBuffer(10)
+	records := buffer.GetRecentEvents(5)
+	assert.Equal(t, 0, len(records))
+
+	populate(buffer, 5)
+
+	// count < elements
+	records = buffer.GetRecentEvents(2)
+	assert.Equal(t, 2, len(records))
+	assert.Equal(t, int64(3), records[0].TimestampNano)
+	assert.Equal(t, int64(4), records[1].TimestampNano)
+
+	// count = elements
+	records = buffer.GetRecentEvents(5)
+	assert.Equal(t, 5, len(records))
+	assert.Equal(t, int64(0), records[0].TimestampNano)
+	assert.Equal(t, int64(1), records[1].TimestampNano)
+	assert.Equal(t, int64(2), records[2].TimestampNano)
+	assert.Equal(t, int64(3), records[3].TimestampNano)
+	assert.Equal(t, int64(4), records[4].TimestampNano)
+
+	// count > elements
+	records = buffer.GetRecentEvents(15)
+	assert.Equal(t, 5, len(records))
+	assert.Equal(t, int64(0), records[0].TimestampNano)
+	assert.Equal(t, int64(1), records[1].TimestampNano)
+	assert.Equal(t, int64(2), records[2].TimestampNano)
+	assert.Equal(t, int64(3), records[3].TimestampNano)
+	assert.Equal(t, int64(4), records[4].TimestampNano)
+}
+
 func populate(buffer *eventRingBuffer, count int) {
 	for i := 0; i < count; i++ {
 		buffer.Add(&si.EventRecord{

--- a/pkg/events/event_streaming.go
+++ b/pkg/events/event_streaming.go
@@ -172,12 +172,9 @@ func (e *EventStreaming) Close() {
 
 // NewEventStreaming creates a new event streaming infrastructure.
 func NewEventStreaming(eventBuffer *eventRingBuffer) *EventStreaming {
-	stopCh := make(chan struct{})
-	e := &EventStreaming{
+	return &EventStreaming{
 		buffer:       eventBuffer,
-		stopCh:       stopCh,
+		stopCh:       make(chan struct{}),
 		eventStreams: make(map[*EventStream]eventConsumerDetails),
 	}
-
-	return e
 }

--- a/pkg/events/event_streaming.go
+++ b/pkg/events/event_streaming.go
@@ -1,0 +1,166 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package events
+
+import (
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/apache/yunikorn-core/pkg/log"
+	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
+)
+
+const defaultChannelBufSize = 100
+
+type EventStreaming struct {
+	buffer       *eventRingBuffer
+	stopCh       chan struct{}
+	eventStreams map[*EventStream]eventConsumerDetails
+	sync.Mutex
+}
+
+type eventConsumerDetails struct {
+	local     chan *si.EventRecord
+	consumer  chan<- *si.EventRecord
+	stopCh    chan struct{}
+	name      string
+	createdAt time.Time
+}
+
+// EventStream handle type returned to the client who wants to capture the stream of events.
+type EventStream struct {
+	Events <-chan *si.EventRecord
+}
+
+// PublishEvent publishes an event to all event stream consumers.
+func (e *EventStreaming) PublishEvent(event *si.EventRecord) {
+	e.Lock()
+	defer e.Unlock()
+
+	for consumer, details := range e.eventStreams {
+		if len(details.local) == defaultChannelBufSize {
+			log.Log(log.Events).Warn("Listener buffer full due to potentially slow consumer, removing it")
+			e.removeEventStream(consumer)
+			continue
+		}
+
+		details.local <- event
+	}
+}
+
+// CreateEventStream sets up event streaming for a consumer. The returned EventStream object
+// contains a channel that can be used for reading.
+// When a consumer is finished, it is supposed to call RemoveEventStream to free up resources.
+// Consumers have an arbitrary name for logging purposes. The "count" parameter defines the number
+// of maximum historical events from the ring buffer.
+func (e *EventStreaming) CreateEventStream(name string, count uint64) *EventStream {
+	consumer := make(chan *si.EventRecord, defaultChannelBufSize)
+	stream := &EventStream{
+		Events: consumer,
+	}
+	local := make(chan *si.EventRecord, defaultChannelBufSize)
+	stop := make(chan struct{})
+	history := e.createEventStreamInternal(stream, local, consumer, stop, name, count)
+
+	go func(consumer chan<- *si.EventRecord, local <-chan *si.EventRecord, stop <-chan struct{}) {
+		// store the refs of historical events; it's possible that some events are added to the
+		// ring buffer and also to "local" channel
+		seen := make(map[*si.EventRecord]bool)
+		for _, event := range history {
+			consumer <- event
+			seen[event] = true
+		}
+		for {
+			select {
+			case <-e.stopCh:
+				close(consumer)
+				return
+			case <-stop:
+				close(consumer)
+				return
+			case event := <-local:
+				if seen[event] {
+					continue
+				}
+				// since events are processed in a single goroutine, doubling is no longer
+				// possible at this point
+				seen = make(map[*si.EventRecord]bool)
+				consumer <- event
+			}
+		}
+	}(consumer, local, stop)
+
+	log.Log(log.Events).Info("Created event stream", zap.String("consumer name", name))
+	return stream
+}
+
+func (e *EventStreaming) createEventStreamInternal(stream *EventStream,
+	local chan *si.EventRecord,
+	consumer chan *si.EventRecord,
+	stop chan struct{},
+	name string,
+	count uint64) []*si.EventRecord {
+	// stuff that needs locking
+	e.Lock()
+	defer e.Unlock()
+
+	e.eventStreams[stream] = eventConsumerDetails{
+		local:     local,
+		consumer:  consumer,
+		stopCh:    stop,
+		name:      name,
+		createdAt: time.Now(),
+	}
+
+	return e.buffer.GetRecentEvents(count)
+}
+
+func (e *EventStreaming) RemoveEventStream(consumer *EventStream) {
+	e.Lock()
+	defer e.Unlock()
+
+	e.removeEventStream(consumer)
+}
+
+func (e *EventStreaming) removeEventStream(consumer *EventStream) {
+	if details, ok := e.eventStreams[consumer]; ok {
+		log.Log(log.Events).Info("Removing event stream consumer", zap.String("name", details.name),
+			zap.Time("creation time", details.createdAt))
+		close(details.stopCh)
+		close(details.local)
+		delete(e.eventStreams, consumer)
+	}
+}
+
+func (e *EventStreaming) Close() {
+	close(e.stopCh)
+}
+
+func NewEventStreaming(eventBuffer *eventRingBuffer) *EventStreaming {
+	stopCh := make(chan struct{})
+	e := &EventStreaming{
+		buffer:       eventBuffer,
+		stopCh:       stopCh,
+		eventStreams: make(map[*EventStream]eventConsumerDetails),
+	}
+
+	return e
+}

--- a/pkg/events/event_streaming.go
+++ b/pkg/events/event_streaming.go
@@ -28,7 +28,7 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
-const defaultChannelBufSize = 100
+const defaultChannelBufSize = 1000
 
 // EventStreaming implements the event streaming logic.
 // New events are immediately forwarded to all active consumers.

--- a/pkg/events/event_streaming_test.go
+++ b/pkg/events/event_streaming_test.go
@@ -127,7 +127,7 @@ func TestEventStreaming_SlowConsumer(t *testing.T) {
 	defer streaming.Close()
 	streaming.CreateEventStream("test", 10000)
 
-	for i := 0; i < 300; i++ {
+	for i := 0; i < 2500; i++ {
 		streaming.PublishEvent(&si.EventRecord{TimestampNano: int64(i)})
 	}
 

--- a/pkg/events/event_streaming_test.go
+++ b/pkg/events/event_streaming_test.go
@@ -1,0 +1,145 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package events
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
+)
+
+var defaultCount = uint64(10000)
+
+func TestEventStreaming_WithoutHistory(t *testing.T) {
+	buffer := newEventRingBuffer(10)
+	streaming := NewEventStreaming(buffer)
+	es := streaming.CreateEventStream("test", defaultCount)
+	defer streaming.Close()
+
+	sent := &si.EventRecord{
+		Message: "testMessage",
+	}
+	streaming.PublishEvent(sent)
+	received := receive(t, es.Events)
+	streaming.RemoveEventStream(es)
+	assert.Equal(t, 0, len(streaming.eventStreams[es].local))
+	assert.Equal(t, 0, len(streaming.eventStreams[es].consumer))
+	assert.Equal(t, received.Message, sent.Message)
+	assert.Equal(t, 0, len(streaming.eventStreams))
+}
+
+func TestEventStreaming_WithHistory(t *testing.T) {
+	buffer := newEventRingBuffer(10)
+	streaming := NewEventStreaming(buffer)
+	defer streaming.Close()
+
+	buffer.Add(&si.EventRecord{TimestampNano: 1})
+	buffer.Add(&si.EventRecord{TimestampNano: 5})
+	buffer.Add(&si.EventRecord{TimestampNano: 6})
+	buffer.Add(&si.EventRecord{TimestampNano: 9})
+	es := streaming.CreateEventStream("test", defaultCount)
+
+	streaming.PublishEvent(&si.EventRecord{TimestampNano: 10})
+
+	received1 := receive(t, es.Events)
+	received2 := receive(t, es.Events)
+	received3 := receive(t, es.Events)
+	received4 := receive(t, es.Events)
+	received5 := receive(t, es.Events)
+	assert.Equal(t, 0, len(streaming.eventStreams[es].local))
+	assert.Equal(t, 0, len(streaming.eventStreams[es].consumer))
+	assert.Equal(t, int64(1), received1.TimestampNano)
+	assert.Equal(t, int64(5), received2.TimestampNano)
+	assert.Equal(t, int64(6), received3.TimestampNano)
+	assert.Equal(t, int64(9), received4.TimestampNano)
+	assert.Equal(t, int64(10), received5.TimestampNano)
+	streaming.RemoveEventStream(es)
+	assert.Equal(t, 0, len(streaming.eventStreams))
+}
+
+func TestEventStreaming_WithHistoryCount(t *testing.T) {
+	buffer := newEventRingBuffer(10)
+	streaming := NewEventStreaming(buffer)
+	defer streaming.Close()
+
+	buffer.Add(&si.EventRecord{TimestampNano: 1})
+	buffer.Add(&si.EventRecord{TimestampNano: 5})
+	buffer.Add(&si.EventRecord{TimestampNano: 6})
+	buffer.Add(&si.EventRecord{TimestampNano: 9})
+	es := streaming.CreateEventStream("test", 2)
+
+	streaming.PublishEvent(&si.EventRecord{TimestampNano: 10})
+
+	received1 := receive(t, es.Events)
+	received2 := receive(t, es.Events)
+	received3 := receive(t, es.Events)
+	assert.Equal(t, 0, len(streaming.eventStreams[es].local))
+	assert.Equal(t, 0, len(streaming.eventStreams[es].consumer))
+	assert.Equal(t, int64(6), received1.TimestampNano)
+	assert.Equal(t, int64(9), received2.TimestampNano)
+	assert.Equal(t, int64(10), received3.TimestampNano)
+}
+
+func TestEventStreaming_TwoConsumers(t *testing.T) {
+	buffer := newEventRingBuffer(10)
+	streaming := NewEventStreaming(buffer)
+	defer streaming.Close()
+
+	es1 := streaming.CreateEventStream("stream1", defaultCount)
+	es2 := streaming.CreateEventStream("stream2", defaultCount)
+	for i := 0; i < 5; i++ {
+		streaming.PublishEvent(&si.EventRecord{TimestampNano: int64(i)})
+	}
+
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, int64(i), receive(t, es1.Events).TimestampNano)
+		assert.Equal(t, int64(i), receive(t, es2.Events).TimestampNano)
+	}
+	assert.Equal(t, 0, len(streaming.eventStreams[es1].local))
+	assert.Equal(t, 0, len(streaming.eventStreams[es1].consumer))
+	assert.Equal(t, 0, len(streaming.eventStreams[es2].local))
+	assert.Equal(t, 0, len(streaming.eventStreams[es2].consumer))
+}
+
+func TestEventStreaming_SlowConsumer(t *testing.T) {
+	// simulating a slow event consumer by ignoring events
+	buffer := newEventRingBuffer(10)
+	streaming := NewEventStreaming(buffer)
+	defer streaming.Close()
+	streaming.CreateEventStream("test", 10000)
+
+	for i := 0; i < 300; i++ {
+		streaming.PublishEvent(&si.EventRecord{TimestampNano: int64(i)})
+	}
+
+	assert.Equal(t, 0, len(streaming.eventStreams))
+}
+
+func receive(t *testing.T, input <-chan *si.EventRecord) *si.EventRecord {
+	select {
+	case event := <-input:
+		return event
+	case <-time.After(time.Second):
+		t.Fatal("receive failed")
+		return nil
+	}
+}

--- a/pkg/scheduler/objects/common_test.go
+++ b/pkg/scheduler/objects/common_test.go
@@ -20,12 +20,20 @@ import (
 	"github.com/google/btree"
 
 	"github.com/apache/yunikorn-core/pkg/common/resources"
+	"github.com/apache/yunikorn-core/pkg/events"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
 type EventSystemMock struct {
 	events  []*si.EventRecord
 	enabled bool
+}
+
+func (m *EventSystemMock) CreateEventStream(_ string, _ uint64) *events.EventStream {
+	return nil
+}
+
+func (m *EventSystemMock) RemoveStream(_ *events.EventStream) {
 }
 
 func (m *EventSystemMock) AddEvent(event *si.EventRecord) {

--- a/pkg/webservice/handler_mock_test.go
+++ b/pkg/webservice/handler_mock_test.go
@@ -19,6 +19,7 @@ package webservice
 
 import (
 	"net/http"
+	"time"
 )
 
 // InternalMetricHistory needs resetting between tests
@@ -48,4 +49,8 @@ func (trw *MockResponseWriter) Write(bytes []byte) (int, error) {
 
 func (trw *MockResponseWriter) WriteHeader(statusCode int) {
 	trw.statusCode = statusCode
+}
+
+func (trw *MockResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	return nil
 }

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -176,6 +176,12 @@ var webRoutes = routes{
 		"/ws/v1/events/batch",
 		getEvents,
 	},
+	route{
+		"Scheduler",
+		"GET",
+		"/ws/v1/events/stream",
+		getStream,
+	},
 	// endpoint to retrieve CPU, Memory profiling data,
 	// this works with pprof tool. By default, pprof endpoints
 	// are only registered to http.DefaultServeMux. Here, we

--- a/pkg/webservice/webservice.go
+++ b/pkg/webservice/webservice.go
@@ -65,7 +65,6 @@ func loggingHandler(inner http.Handler, name string) http.HandlerFunc {
 // TODO we need the port to be configurable
 func (m *WebService) StartWebApp() {
 	router := newRouter()
-	// Important: do not use ReadTimeout, WriteTimeout or IdleTimeout because those can break the event streaming
 	m.httpServer = &http.Server{Addr: ":9080", Handler: router}
 
 	log.Log(log.REST).Info("web-app started", zap.Int("port", 9080))

--- a/pkg/webservice/webservice.go
+++ b/pkg/webservice/webservice.go
@@ -65,6 +65,7 @@ func loggingHandler(inner http.Handler, name string) http.HandlerFunc {
 // TODO we need the port to be configurable
 func (m *WebService) StartWebApp() {
 	router := newRouter()
+	// Important: do not use ReadTimeout, WriteTimeout or IdleTimeout because those can break the event streaming
 	m.httpServer = &http.Server{Addr: ":9080", Handler: router}
 
 	log.Log(log.REST).Info("web-app started", zap.Int("port", 9080))


### PR DESCRIPTION
### What is this PR for?
Core implementation of event streaming. Clients are updated real time on the REST interface. A persistent HTTP connection is maintained for them.

Consumers can request a new stream and receive core scheduler events immediately on a read-only channel. Slow consumers are detected by checking the number of elements in the channel buffer. If the channel buffer on the local side is full, we remove the consumer.

Explicit closure of the event stream is possible and consumers are expected to do it.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1709

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
