### PR TITLE
[YUNIKORN-1714] Fatal error: concurrent write/read when calling Queue.RemoveApplication()

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -694,7 +694,7 @@ func (sq *Queue) AddApplication(app *Application) {
 func (sq *Queue) RemoveApplication(app *Application) {
 	// clean up any outstanding pending resources
 	appID := app.ApplicationID
-	if _, ok := sq.applications[appID]; !ok {
+	if !sq.appExists(appID) {
 		log.Logger().Debug("Application not found while removing from queue",
 			zap.String("queueName", sq.QueuePath),
 			zap.String("applicationID", appID))
@@ -742,6 +742,14 @@ func (sq *Queue) RemoveApplication(app *Application) {
 	log.Logger().Info("Application completed and removed from queue",
 		zap.String("queueName", sq.QueuePath),
 		zap.String("applicationID", appID))
+}
+
+func (sq *Queue) appExists(appID string) bool {
+	sq.RLock()
+	defer sq.RUnlock()
+
+	_, ok := sq.applications[appID]
+	return ok
 }
 
 // GetCopyOfApps gets a shallow copy of all non-completed apps holding the lock


### PR DESCRIPTION
### What is this PR for?
Race condition in `Queue.RemoveApplication()`: we need to lock when accessing `sq.applications[]`. Currently, we check if the application exists without locking, but the map can be modified concurrently.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1714

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
