### PR TITLE
[YUNIKORN-1720] Improve the performance of the node.preAllocateCheck() function

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -1145,7 +1145,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 					zap.String("node", node.NodeID))
 				continue
 			}
-			if err := node.preAllocateCheck(reqFit.GetAllocatedResource(), reservationKey(nil, sa, reqFit)); err != nil {
+			if node.preAllocateCheck(reqFit.GetAllocatedResource(), reservationKey(nil, sa, reqFit)) {
 				continue
 			}
 			// skip the node if conditions can not be satisfied
@@ -1426,7 +1426,7 @@ func (sa *Application) tryNodes(ask *AllocationAsk, iterator NodeIterator) *Allo
 func (sa *Application) tryNode(node *Node, ask *AllocationAsk) *Allocation {
 	toAllocate := ask.GetAllocatedResource()
 	// create the key for the reservation
-	if err := node.preAllocateCheck(toAllocate, reservationKey(nil, sa, ask)); err != nil {
+	if node.preAllocateCheck(toAllocate, reservationKey(nil, sa, ask)) {
 		// skip schedule onto node
 		return nil
 	}

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -1145,7 +1145,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 					zap.String("node", node.NodeID))
 				continue
 			}
-			if node.preAllocateCheck(reqFit.GetAllocatedResource(), reservationKey(nil, sa, reqFit)) {
+			if !node.preAllocateCheck(reqFit.GetAllocatedResource(), reservationKey(nil, sa, reqFit)) {
 				continue
 			}
 			// skip the node if conditions can not be satisfied
@@ -1426,7 +1426,7 @@ func (sa *Application) tryNodes(ask *AllocationAsk, iterator NodeIterator) *Allo
 func (sa *Application) tryNode(node *Node, ask *AllocationAsk) *Allocation {
 	toAllocate := ask.GetAllocatedResource()
 	// create the key for the reservation
-	if node.preAllocateCheck(toAllocate, reservationKey(nil, sa, ask)) {
+	if !node.preAllocateCheck(toAllocate, reservationKey(nil, sa, ask)) {
 		// skip schedule onto node
 		return nil
 	}

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -376,12 +376,12 @@ func (sn *Node) preConditions(ask *AllocationAsk, allocate bool) bool {
 
 // Check if the node should be considered as a possible node to allocate on.
 // This is a lock free call. No updates are made this only performs a pre allocate checks
-func (sn *Node) preAllocateCheck(res *resources.Resource, resKey string) error {
+func (sn *Node) preAllocateCheck(res *resources.Resource, resKey string) bool {
 	// cannot allocate zero or negative resource
 	if !resources.StrictlyGreaterThanZero(res) {
 		log.Logger().Debug("pre alloc check: requested resource is zero",
 			zap.String("nodeID", sn.NodeID))
-		return fmt.Errorf("pre alloc check: requested resource is zero: %s", sn.NodeID)
+		return false
 	}
 	// check if the node is reserved for this app/alloc
 	if sn.IsReserved() {
@@ -389,19 +389,14 @@ func (sn *Node) preAllocateCheck(res *resources.Resource, resKey string) error {
 			log.Logger().Debug("pre alloc check: node reserved for different app or ask",
 				zap.String("nodeID", sn.NodeID),
 				zap.String("resKey", resKey))
-			return fmt.Errorf("pre alloc check: node %s reserved for different app or ask: %s", sn.NodeID, resKey)
+			return false
 		}
 	}
 
 	// check if resources are available
 	available := sn.GetAvailableResource()
-	// check the request fits in what we have calculated
-	if !available.FitInMaxUndef(res) {
-		// requested resource is larger than currently available node resources
-		return fmt.Errorf("pre alloc check: requested resource %s is larger than currently available %s resource on %s", res.String(), available.String(), sn.NodeID)
-	}
-	// can allocate, based on resource size
-	return nil
+	// returns true/false based on if the request fits in what we have calculated
+	return available.FitInMaxUndef(res)
 }
 
 // Return if the node has been reserved by any application


### PR DESCRIPTION
### What is this PR for?

The node.preAllocateCheck() function gets run a lot during the scheduling cycle. The function is effectively a boolean function, either the node can be allocated on or it cannot. Instead of returning a bool it returns nil for true and a full error message for false. The thing is, that error message is never read anywhere. From what I can tell, the only thing the code does is check if there is an error message but not the contents.

I ran a profiler on the code and noticed that about 25% of the scheduling cycle was spend on generating these error messages that are not used. By switching to a bool for the return value it should improve the performance of this one function and therefore the entire scheduling cycle overall.




### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
N/A

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-1720


### How should this be tested?

I have it running on my end and it seems to work. The unit tests also pass after I updated them to look at the new boolean value over the old error message.

### Screenshots (if appropriate)

Before this change (note the large `(*Resource).String (resources.go:L#110)` section under the highlighted function):
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/18558130/235989846-ae798dc3-5e3f-4d52-84e7-64d171b5e940.png">

After this change:
<img width="1128" alt="image" src="https://user-images.githubusercontent.com/18558130/235989957-a8159b5e-ed50-4008-8112-8644544da5b8.png">

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
