### PR TITLE
[YUNIKORN-1722] Remove excessive resource clone calls

### DIFF
--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1183,9 +1183,11 @@ func (pc *PartitionContext) calculateNodesResourceUsage() map[string][]int {
 	nodesCopy := pc.GetNodes()
 	mapResult := make(map[string][]int)
 	for _, node := range nodesCopy {
-		for name, total := range node.GetCapacity().Resources {
-			if float64(total) > 0 {
-				resourceAllocated := float64(node.GetAllocatedResource().Resources[name])
+		capacity := node.GetCapacity()
+		allocated := node.GetAllocatedResource()
+		for name, total := range capacity.Resources {
+			if total > 0 {
+				resourceAllocated := float64(allocated.Resources[name])
 				// Consider over-allocated node as 100% utilized.
 				v := math.Min(resourceAllocated/float64(total), 1)
 				idx := int(math.Dim(math.Ceil(v*10), 1))


### PR DESCRIPTION
### What is this PR for?
The node calculateNodesResourceUsage clones the  resource object inside a loop. The clone is correct as the allocated resource could be changed while the calculation is happening in the scheduling cycle. However, it should not happen inside the loop.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1722

### How should this be tested?
unit test cover the code
performance test should improve