### PR TITLE
[YUNIKORN-1712]  Fix allocatedResource and availableResource should be updated at the sametime for ReplaceAllocation

### DIFF
--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -317,7 +317,9 @@ func (sn *Node) ReplaceAllocation(uuid string, replace *Allocation, delta *resou
 	replace.SetPlaceholderUsed(true)
 	sn.allocations[replace.GetUUID()] = replace
 	before := sn.allocatedResource.Clone()
+	// The allocatedResource and availableResource should be updated in the same way
 	sn.allocatedResource.AddTo(delta)
+	sn.availableResource.SubFrom(delta)
 	if !resources.FitIn(before, sn.allocatedResource) {
 		log.Logger().Warn("unexpected increase in node usage after placeholder replacement",
 			zap.String("placeholder uuid", uuid),

--- a/pkg/scheduler/objects/node_test.go
+++ b/pkg/scheduler/objects/node_test.go
@@ -422,6 +422,7 @@ func TestNodeReplaceAllocation(t *testing.T) {
 	node.AddAllocation(ph)
 	assert.Assert(t, node.GetAllocation(phID) != nil, "failed to add placeholder allocation")
 	assert.Assert(t, resources.Equals(node.GetAllocatedResource(), half), "allocated resource not set correctly %v got %v", half, node.GetAllocatedResource())
+	assert.Assert(t, resources.Equals(node.GetAvailableResource(), half), "available resource not set correctly %v got %v", half, node.GetAvailableResource())
 
 	allocID := "real-1"
 	piece := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 25, "second": 50})
@@ -433,10 +434,12 @@ func TestNodeReplaceAllocation(t *testing.T) {
 	node.ReplaceAllocation(phID, alloc, delta)
 	assert.Assert(t, node.GetAllocation(allocID) != nil, "failed to replace allocation: allocation not returned")
 	assert.Assert(t, resources.Equals(node.GetAllocatedResource(), piece), "allocated resource not set correctly %v got %v", piece, node.GetAllocatedResource())
+	assert.Assert(t, resources.Equals(node.GetAvailableResource(), resources.Sub(node.GetCapacity(), piece)), "available resource not set correctly %v got %v", resources.Sub(node.GetCapacity(), piece), node.GetAvailableResource())
 
 	// clean up all should be zero
 	assert.Assert(t, node.RemoveAllocation(allocID) != nil, "allocation should have been removed but was not")
 	assert.Assert(t, resources.IsZero(node.GetAllocatedResource()), "allocated resource not updated correctly")
+	assert.Assert(t, resources.Equals(node.GetAvailableResource(), node.GetCapacity()), "available resource not set correctly %v got %v", node.GetCapacity(), node.GetAvailableResource())
 }
 
 func TestGetAllocation(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
See my latest comments in https://issues.apache.org/jira/browse/YUNIKORN-1712.

From the dump log:
```
        {
          "nodeID": "ip-10-0-104-175.eu-central-1.compute.internal",
          "hostName": "",
          "rackName": "",
          "capacity": {
            "attachable-volumes-aws-ebs": 39,
            "ephemeral-storage": 18233774458,
            "hugepages-1Gi": 0,
            "hugepages-2Mi": 0,
            "hugepages-32Mi": 0,
            "hugepages-64Ki": 0,
            "memory": 7106445312,
            "pods": 58,
            "vcore": 3920
          },
          "allocated": {
            "memory": 0,
            "vcore": 0
          },
          "occupied": {
            "memory": 1000000,
            "vcore": 125
          },
          "available": {
            "attachable-volumes-aws-ebs": 39,
            "ephemeral-storage": 18233774458,
            "hugepages-1Gi": 0,
            "hugepages-2Mi": 0,
            "hugepages-32Mi": 0,
            "hugepages-64Ki": 0,
            "memory": 6670286272,
            "pods": 58,
            "vcore": 3595
          },
          "utilized": {
            "memory": 0,
            "vcore": 0
          },
          "allocations": [],
          "schedulable": true,
          "isReserved": false,
          "reservations": []
        }
      ]
    } 
```

Use the core for example:

 

capacity  = 3920
occupied = 125
available  = 3595 

3920- 125 - 3595 = 200  the gap is 200


From the debug log:
```
2023-05-03T07:11:20.875Z	WARN	scheduler/partition.go:1272	replacing placeholder: placeholder is larger than real allocation	{"allocationID": "3fa7fdcd-bc46-446d-ab44-f33ec55b2b4c", "requested resource": "map[memory:1712324608 vcore:1000]", "placeholderID": "8261fb9c-24eb-465c-8549-89b58659901c", "placeholder resource": "map[memory:2147483648 vcore:1200]" 
```


The placeholder resource vcore 1200, the real allocatin vcore 1000.
1200 - 1000 = 200 
The gap is also 200.

Next i confirm the gap, here the allocationID is not equal to the placeholderID, will call the replaceAllocation:

```
// replacements could be on a different node and different size handle all cases
if confirmed.GetNodeID() == alloc.GetNodeID() {
   // this is the real swap on the node, adjust usage if needed
   node.ReplaceAllocation(alloc.GetUUID(), confirmed, delta)
} 
// ReplaceAllocation replaces the placeholder with the real allocation on the node.
// The delta passed in is the difference in resource usage between placeholder and real allocation.
// It should always be a negative value or zero: it is a decrease in usage or no change
func (sn *Node) ReplaceAllocation(uuid string, replace *Allocation, delta *resources.Resource) {
   defer sn.notifyListeners()
   sn.Lock()
   defer sn.Unlock()

   replace.SetPlaceholderCreateTime(sn.allocations[uuid].GetCreateTime())
   delete(sn.allocations, uuid)
   replace.SetPlaceholderUsed(true)
   sn.allocations[replace.GetUUID()] = replace
   before := sn.allocatedResource.Clone()
   sn.allocatedResource.AddTo(delta)
   if !resources.FitIn(before, sn.allocatedResource) {
      log.Logger().Warn("unexpected increase in node usage after placeholder replacement",
         zap.String("placeholder uuid", uuid),
         zap.String("allocation uuid", replace.GetUUID()),
         zap.Stringer("delta", delta))
   }
} 
```
The above code is the root cause, we  add the delta to allocatedResource, sn.allocatedResource.AddTo(delta),  but we forget to update the  availableResource.

This should be a pair to update, the same as:
```
func (sn *Node) RemoveAllocation(uuid string) *Allocation {
   defer sn.notifyListeners()
   sn.Lock()
   defer sn.Unlock()

   alloc := sn.allocations[uuid]
   if alloc != nil {
      delete(sn.allocations, uuid)
      sn.allocatedResource.SubFrom(alloc.GetAllocatedResource())
      sn.availableResource.AddTo(alloc.GetAllocatedResource())
      return alloc
   }

   return nil
}

func (sn *Node) AddAllocation(alloc *Allocation) bool {
   if alloc == nil {
      return false
   }
   defer sn.notifyListeners()
   sn.Lock()
   defer sn.Unlock()
   // check if this still fits: it might have changed since pre check
   res := alloc.GetAllocatedResource()
   if sn.availableResource.FitInMaxUndef(res) {
      sn.allocations[alloc.GetUUID()] = alloc
      sn.allocatedResource.AddTo(res)
      sn.availableResource.SubFrom(res)
      return true
   }
   return false
} 
 ```

The delta gap is 200, this is the root cause!


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1712
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
