### PR TITLE
[YUNIKORN-1608] Configuration updates and storage for limit

### DIFF
--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -34,11 +34,11 @@ import (
 )
 
 const (
-	appID0  = "app-0"
-	appID1  = "app-1"
-	appID2  = "app-2"
-	aKey    = "alloc-1"
-	nodeID1 = "node-1"
+	appID0    = "app-0"
+	appID1    = "app-1"
+	appID2    = "app-2"
+	aKey      = "alloc-1"
+	nodeID1   = "node-1"
 	instType1 = "itype-1"
 )
 

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -94,6 +94,22 @@ func TestNewPartition(t *testing.T) {
 				Parent:    true,
 				SubmitACL: "*",
 				Queues:    nil,
+				Limits: []configs.Limit{
+					{
+						Limit: "root queue limit",
+						Users: []string{
+							"user1",
+						},
+						Groups: []string{
+							"group1",
+						},
+						MaxResources: map[string]string{
+							"memory": "10",
+							"vcores": "10",
+						},
+						MaxApplications: 1,
+					},
+				},
 			},
 		},
 	}
@@ -254,7 +270,7 @@ func TestAddNodeWithAllocations(t *testing.T) {
 		t.Errorf("add node to partition should have failed (uuid missing)")
 	}
 	assert.Equal(t, partition.nodes.GetNodeCount(), 0, "error returned but node still added to the partition (uuid)")
-	assertUserGroupResource(t, getTestUserGroup(), nil)
+	assertLimits(t, getTestUserGroup(), nil)
 
 	// fix the alloc add the node will work now
 	alloc = objects.NewAllocation("alloc-1-uuid", nodeID1, instType1, ask)
@@ -269,7 +285,7 @@ func TestAddNodeWithAllocations(t *testing.T) {
 
 	// check the queue usage
 	assert.Assert(t, resources.Equals(q.GetAllocatedResource(), appRes), "add node to partition did not update queue as expected")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 }
 
 func TestRemoveNode(t *testing.T) {
@@ -313,7 +329,7 @@ func TestRemoveNodeWithAllocations(t *testing.T) {
 	// get what was allocated
 	allocated := node.GetAllAllocations()
 	assert.Equal(t, 1, len(allocated), "allocation not added correctly")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	// add broken allocations
 	ask = newAllocationAsk("alloc-na", "not-an-app", appRes)
@@ -322,7 +338,7 @@ func TestRemoveNodeWithAllocations(t *testing.T) {
 	ask = newAllocationAsk("alloc-2", appID1, appRes)
 	alloc = objects.NewAllocation("alloc-2-uuid", nodeID1, instType1, ask)
 	node.AddAllocation(alloc)
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	// remove the node this cannot fail
 	released, confirmed := partition.removeNode(nodeID1)
@@ -330,7 +346,7 @@ func TestRemoveNodeWithAllocations(t *testing.T) {
 	assert.Equal(t, 1, len(released), "node did not release correct allocation")
 	assert.Equal(t, 0, len(confirmed), "node did not confirm correct allocation")
 	assert.Equal(t, released[0].GetUUID(), allocUUID, "uuid returned by release not the same as on allocation")
-	assertUserGroupResource(t, getTestUserGroup(), nil)
+	assertLimits(t, getTestUserGroup(), nil)
 }
 
 // test with a replacement of a placeholder: placeholder and real on the same node that gets removed
@@ -357,7 +373,7 @@ func TestRemoveNodeWithPlaceholders(t *testing.T) {
 	allocated := node1.GetAllAllocations()
 	assert.Equal(t, 1, len(allocated), "allocation not added correctly to node1 expected 1 got: %v", allocated)
 	assert.Assert(t, resources.Equals(node1.GetAllocatedResource(), appRes), "allocation not added correctly to node1")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	// fake an ask that is used
 	ask = newAllocationAskAll(allocID, appID1, taskGroup, appRes, 1, 1, false)
@@ -366,7 +382,7 @@ func TestRemoveNodeWithPlaceholders(t *testing.T) {
 	_, err = app.UpdateAskRepeat(allocID, -1)
 	assert.NilError(t, err, "ask should have been updated without error")
 	assert.Assert(t, resources.IsZero(app.GetPendingResource()), "app should not have pending resources")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	// add real allocation that is replacing the placeholder
 	alloc := objects.NewAllocation(allocID, nodeID1, instType1, ask)
@@ -377,7 +393,7 @@ func TestRemoveNodeWithPlaceholders(t *testing.T) {
 
 	allocs = app.GetAllAllocations()
 	assert.Equal(t, len(allocs), 1, "expected one allocation for the app (placeholder)")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	// remove the node that has both placeholder and real allocation
 	released, confirmed := partition.removeNode(nodeID1)
@@ -390,7 +406,7 @@ func TestRemoveNodeWithPlaceholders(t *testing.T) {
 	assert.Assert(t, resources.Equals(app.GetPendingResource(), appRes), "app should have updated pending resources")
 	// check the interim state of the placeholder involved
 	assert.Equal(t, 0, ph.GetReleaseCount(), "placeholder should have no releases linked anymore")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}))
 }
 
 func TestCalculateNodesResourceUsage(t *testing.T) {
@@ -758,7 +774,7 @@ func TestRemoveNodeWithReplacement(t *testing.T) {
 	// get what was allocated
 	allocated := node1.GetAllAllocations()
 	assert.Equal(t, 1, len(allocated), "allocation not added correctly to node1")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 	assert.Assert(t, resources.Equals(node1.GetAllocatedResource(), appRes), "allocation not added correctly to node1")
 
 	node2 := setupNode(t, nodeID2, partition, nodeRes)
@@ -780,14 +796,14 @@ func TestRemoveNodeWithReplacement(t *testing.T) {
 	allocated = node2.GetAllAllocations()
 	assert.Equal(t, 1, len(allocated), "allocation not added correctly to node2")
 	assert.Assert(t, resources.Equals(node2.GetAllocatedResource(), appRes), "allocation not added correctly to node2 (resource count)")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	// double link as if the replacement is ongoing
 	ph.SetRelease(alloc)
 
 	allocs = app.GetAllAllocations()
 	assert.Equal(t, len(allocs), 1, "expected one allocation for the app (placeholder)")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	// remove the node with the placeholder
 	released, confirmed := partition.removeNode(nodeID1)
@@ -803,7 +819,7 @@ func TestRemoveNodeWithReplacement(t *testing.T) {
 	assert.Equal(t, allocID, allocs[0].GetUUID(), "uuid for the app is not the same as the real allocation")
 	assert.Equal(t, objects.Allocated, allocs[0].GetResult(), "allocation state should be allocated")
 	assert.Equal(t, 0, allocs[0].GetReleaseCount(), "real allocation should have no releases linked anymore")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 }
 
 // test with a replacement of a placeholder: real on the removed node placeholder on the 2nd node
@@ -830,7 +846,7 @@ func TestRemoveNodeWithReal(t *testing.T) {
 	allocated := node1.GetAllAllocations()
 	assert.Equal(t, 1, len(allocated), "allocation not added correctly to node1")
 	assert.Assert(t, resources.Equals(node1.GetAllocatedResource(), appRes), "allocation not added correctly to node1")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	node2 := setupNode(t, nodeID2, partition, nodeRes)
 	assert.Equal(t, 2, partition.GetTotalNodeCount(), "node list was not updated as expected")
@@ -851,7 +867,7 @@ func TestRemoveNodeWithReal(t *testing.T) {
 	allocated = node2.GetAllAllocations()
 	assert.Equal(t, 1, len(allocated), "allocation not added correctly to node2")
 	assert.Assert(t, resources.Equals(node2.GetAllocatedResource(), appRes), "allocation not added correctly to node2 (resource count)")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	// double link as if the replacement is ongoing
 	ph.SetRelease(alloc)
@@ -869,7 +885,7 @@ func TestRemoveNodeWithReal(t *testing.T) {
 	assert.Equal(t, 1, len(allocs), "expected one allocation for the app (placeholder")
 	assert.Equal(t, phID, allocs[0].GetUUID(), "uuid for the app is not the same as the real allocation")
 	assert.Equal(t, 0, ph.GetReleaseCount(), "no inflight replacements linked")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 }
 
 func TestAddApp(t *testing.T) {
@@ -983,7 +999,7 @@ func TestRemoveApp(t *testing.T) {
 	alloc := objects.NewAllocation(uuid, nodeID1, instType1, ask)
 	err = partition.addAllocation(alloc)
 	assert.NilError(t, err, "add allocation to partition should not have failed")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	allocs := partition.removeApplication("does_not_exist")
 	if allocs != nil {
@@ -994,13 +1010,13 @@ func TestRemoveApp(t *testing.T) {
 	app = newApplication(appID1, "default", defQueue)
 	err = partition.AddApplication(app)
 	assert.NilError(t, err, "add application to partition should not have failed")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	// remove the newly added app (no allocations)
 	allocs = partition.removeApplication(appID1)
 	assert.Equal(t, 0, len(allocs), "existing application without allocations returned allocations %v", allocs)
 	assert.Equal(t, 1, len(partition.applications), "existing application was not removed")
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	// add the application again and then an allocation
 	err = partition.AddApplication(app)
@@ -1010,7 +1026,7 @@ func TestRemoveApp(t *testing.T) {
 	alloc = objects.NewAllocation("alloc-1-uuid", nodeID1, instType1, ask)
 	err = partition.addAllocation(alloc)
 	assert.NilError(t, err, "add allocation to partition should not have failed")
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(appRes, 2))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(appRes, 2))
 
 	// remove the newly added app
 	allocs = partition.removeApplication(appID1)
@@ -1019,11 +1035,11 @@ func TestRemoveApp(t *testing.T) {
 	if partition.GetTotalAllocationCount() != 1 {
 		t.Errorf("allocation that should have been left was removed")
 	}
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	allocs = partition.removeApplication("will_not_remove")
 	assert.Equal(t, 1, len(allocs), "existing application with allocations returned unexpected allocations %v", allocs)
-	assertUserGroupResource(t, getTestUserGroup(), nil)
+	assertLimits(t, getTestUserGroup(), nil)
 }
 
 func TestRemoveAppAllocs(t *testing.T) {
@@ -1043,14 +1059,14 @@ func TestRemoveAppAllocs(t *testing.T) {
 	ask := newAllocationAsk("alloc-nr", appNotRemoved, appRes)
 	alloc := objects.NewAllocation("alloc-nr-uuid", nodeID1, instType1, ask)
 	err = partition.addAllocation(alloc)
-	assertUserGroupResource(t, getTestUserGroup(), appRes)
+	assertLimits(t, getTestUserGroup(), appRes)
 
 	ask = newAllocationAsk("alloc-1", appNotRemoved, appRes)
 	uuid := "alloc-1-uuid"
 	alloc = objects.NewAllocation(uuid, nodeID1, instType1, ask)
 	err = partition.addAllocation(alloc)
 	assert.NilError(t, err, "add allocation to partition should not have failed")
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(appRes, 2))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(appRes, 2))
 	release := &si.AllocationRelease{
 		PartitionName:   "default",
 		ApplicationID:   "",
@@ -1060,31 +1076,31 @@ func TestRemoveAppAllocs(t *testing.T) {
 
 	allocs, _ := partition.removeAllocation(release)
 	assert.Equal(t, 0, len(allocs), "empty removal request returned allocations: %v", allocs)
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(appRes, 2))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(appRes, 2))
 	// create a new release without app: should just return
 	release.ApplicationID = "does_not_exist"
 	allocs, _ = partition.removeAllocation(release)
 	assert.Equal(t, 0, len(allocs), "removal request for non existing application returned allocations: %v", allocs)
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(appRes, 2))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(appRes, 2))
 	// create a new release with app, non existing allocation: should just return
 	release.ApplicationID = appNotRemoved
 	release.UUID = "does_not_exist"
 	allocs, _ = partition.removeAllocation(release)
 	assert.Equal(t, 0, len(allocs), "removal request for non existing allocation returned allocations: %v", allocs)
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(appRes, 2))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(appRes, 2))
 	// create a new release with app, existing allocation: should return 1 alloc
 	assert.Equal(t, 2, partition.GetTotalAllocationCount(), "pre-remove allocation list incorrect: %v", partition.allocations)
 	release.UUID = uuid
 	allocs, _ = partition.removeAllocation(release)
 	assert.Equal(t, 1, len(allocs), "removal request for existing allocation returned wrong allocations: %v", allocs)
 	assert.Equal(t, 1, partition.GetTotalAllocationCount(), "allocation removal requests removed more than expected: %v", partition.allocations)
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(appRes, 1))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(appRes, 1))
 	// create a new release with app, no uuid: should return last left alloc
 	release.UUID = ""
 	allocs, _ = partition.removeAllocation(release)
 	assert.Equal(t, 1, len(allocs), "removal request for existing allocation returned wrong allocations: %v", allocs)
 	assert.Equal(t, 0, partition.GetTotalAllocationCount(), "removal requests did not remove all allocations: %v", partition.allocations)
-	assertUserGroupResource(t, getTestUserGroup(), nil)
+	assertLimits(t, getTestUserGroup(), nil)
 }
 
 // Dynamic queue creation based on the name from the rules
@@ -1308,7 +1324,15 @@ func TestTryAllocate(t *testing.T) {
 	assert.NilError(t, err, "failed to add app-2 to partition")
 	err = app.AddAllocationAsk(newAllocationAskPriority(allocID, appID2, res, 1, 2))
 	assert.NilError(t, err, "failed to add ask alloc-1 to app-2")
-	assertUserGroupResource(t, getTestUserGroup(), nil)
+
+	expectedQueuesMaxLimits := make(map[string]map[string]interface{})
+	expectedQueuesMaxLimits["root"] = make(map[string]interface{})
+	expectedQueuesMaxLimits["root.leaf"] = make(map[string]interface{})
+	expectedQueuesMaxLimits["root"][maxresources] = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 10, "vcores": 10})
+	expectedQueuesMaxLimits["root.leaf"][maxresources] = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 5, "vcores": 5})
+	expectedQueuesMaxLimits["root"][maxapplications] = uint64(2)
+	expectedQueuesMaxLimits["root.leaf"][maxapplications] = uint64(1)
+	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), nil, expectedQueuesMaxLimits)
 
 	// first allocation should be app-1 and alloc-2
 	alloc := partition.tryAllocate()
@@ -1319,7 +1343,7 @@ func TestTryAllocate(t *testing.T) {
 	assert.Equal(t, alloc.GetReleaseCount(), 0, "released allocations should have been 0")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocID2, "expected ask alloc-2 to be allocated")
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(res, 1))
+	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.Multiply(res, 1), expectedQueuesMaxLimits)
 
 	// second allocation should be app-2 and alloc-1: higher up in the queue hierarchy
 	alloc = partition.tryAllocate()
@@ -1330,7 +1354,7 @@ func TestTryAllocate(t *testing.T) {
 	assert.Equal(t, alloc.GetReleaseCount(), 0, "released allocations should have been 0")
 	assert.Equal(t, alloc.GetApplicationID(), appID2, "expected application app-2 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocID, "expected ask alloc-1 to be allocated")
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(res, 2))
+	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.Multiply(res, 2), expectedQueuesMaxLimits)
 
 	// third allocation should be app-1 and alloc-1
 	alloc = partition.tryAllocate()
@@ -1342,7 +1366,7 @@ func TestTryAllocate(t *testing.T) {
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocID, "expected ask alloc-1 to be allocated")
 	assert.Assert(t, resources.IsZero(partition.root.GetPendingResource()), "pending resources should be set to zero")
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(res, 3))
+	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.Multiply(res, 3), expectedQueuesMaxLimits)
 }
 
 // allocate ask request with required node
@@ -1367,7 +1391,7 @@ func TestRequiredNodeReservation(t *testing.T) {
 	ask.SetRequiredNode(nodeID1)
 	err = app.AddAllocationAsk(ask)
 	assert.NilError(t, err, "failed to add ask alloc-1 to app-1")
-	assertUserGroupResource(t, getTestUserGroup(), nil)
+	assertLimits(t, getTestUserGroup(), nil)
 
 	// first allocation should be app-1 and alloc-1
 	alloc := partition.tryAllocate()
@@ -1378,7 +1402,7 @@ func TestRequiredNodeReservation(t *testing.T) {
 	assert.Equal(t, alloc.GetReleaseCount(), 0, "released allocations should have been 0")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocID, "expected ask alloc-1 to be allocated")
-	assertUserGroupResource(t, getTestUserGroup(), res)
+	assertLimits(t, getTestUserGroup(), res)
 
 	ask2 := newAllocationAsk(allocID2, appID1, res)
 	ask2.SetRequiredNode(nodeID1)
@@ -1391,7 +1415,7 @@ func TestRequiredNodeReservation(t *testing.T) {
 	// check if updated (must be after allocate call)
 	assert.Equal(t, 1, len(app.GetReservations()), "app should have one reserved ask")
 	assert.Equal(t, 1, len(app.GetAskReservations(allocID2)), "ask should have been reserved")
-	assertUserGroupResource(t, getTestUserGroup(), res)
+	assertLimits(t, getTestUserGroup(), res)
 
 	// allocation that fits on the node should not be allocated
 	var res2 *resources.Resource
@@ -1409,7 +1433,7 @@ func TestRequiredNodeReservation(t *testing.T) {
 
 	// reservation count remains same as last try allocate should have failed to find a reservation
 	assert.Equal(t, 1, len(app.GetReservations()), "ask should not have been reserved, count changed")
-	assertUserGroupResource(t, getTestUserGroup(), res)
+	assertLimits(t, getTestUserGroup(), res)
 }
 
 // allocate ask request with required node having non daemon set reservations
@@ -1595,7 +1619,7 @@ func TestRequiredNodeNotExist(t *testing.T) {
 	if alloc != nil {
 		t.Fatal("allocation should not have worked on unknown node")
 	}
-	assertUserGroupResource(t, getTestUserGroup(), nil)
+	assertLimits(t, getTestUserGroup(), nil)
 }
 
 // basic ds scheduling on specific node in first allocate run itself (without any need for reservation)
@@ -1630,7 +1654,7 @@ func TestRequiredNodeAllocation(t *testing.T) {
 	assert.Equal(t, alloc.GetReleaseCount(), 0, "released allocations should have been 0")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocID, "expected ask alloc-1 to be allocated")
-	assertUserGroupResource(t, getTestUserGroup(), res)
+	assertLimits(t, getTestUserGroup(), res)
 
 	// required node set on ask
 	ask2 := newAllocationAsk(allocID2, appID1, res)
@@ -1647,7 +1671,7 @@ func TestRequiredNodeAllocation(t *testing.T) {
 	assert.Equal(t, 0, len(app.GetReservations()), "ask should not have been reserved")
 	assert.Equal(t, alloc.GetAllocationKey(), allocID2, "expected ask alloc-2 to be allocated")
 	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(res, 2))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(res, 2))
 }
 
 func TestPreemption(t *testing.T) {
@@ -1707,7 +1731,7 @@ func TestPreemption(t *testing.T) {
 	assert.Equal(t, 0, len(app2.GetReservations()), "ask should not be reserved")
 	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result should be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocID3, "expected ask alloc-3 to be allocated")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 10000}))
+	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 10000}), getExpectedQueuesLimitsForPreemption())
 }
 
 // Preemption followed by a normal allocation
@@ -1739,7 +1763,7 @@ func TestPreemptionForRequiredNodeReservedAlloc(t *testing.T) {
 	assert.Equal(t, alloc.GetResult(), objects.AllocatedReserved, "result is not the expected AllocatedReserved")
 	assert.Equal(t, alloc.GetReleaseCount(), 0, "released allocations should have been 0")
 	assert.Equal(t, alloc.GetAllocationKey(), allocID2, "expected ask alloc-2 to be allocated")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 8000}))
+	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 8000}), getExpectedQueuesLimitsForPreemption())
 }
 
 func TestPreemptionForRequiredNodeMultipleAttemptsAvoided(t *testing.T) {
@@ -1790,6 +1814,38 @@ func TestPreemptionForRequiredNodeMultipleAttemptsAvoided(t *testing.T) {
 	assert.Equal(t, true, alloc.IsPreempted())
 }
 
+func getExpectedQueuesLimitsForPreemption() map[string]map[string]interface{} {
+	expectedQueuesMaxLimits := make(map[string]map[string]interface{})
+	expectedQueuesMaxLimits["root"] = make(map[string]interface{})
+	expectedQueuesMaxLimits["root.parent"] = make(map[string]interface{})
+	expectedQueuesMaxLimits["root.parent.leaf1"] = make(map[string]interface{})
+	expectedQueuesMaxLimits["root"][maxresources] = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 10, "vcores": 10})
+	expectedQueuesMaxLimits["root.parent"][maxresources] = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 5, "vcores": 5})
+	expectedQueuesMaxLimits["root.parent.leaf1"][maxresources] = expectedQueuesMaxLimits["root.parent"][maxresources]
+	expectedQueuesMaxLimits["root"][maxapplications] = uint64(2)
+	expectedQueuesMaxLimits["root.parent"][maxapplications] = uint64(2)
+	expectedQueuesMaxLimits["root.parent.leaf1"][maxapplications] = uint64(1)
+	expectedQueuesMaxLimits["root.parent.leaf1"][maxapplications] = uint64(1)
+	return expectedQueuesMaxLimits
+}
+
+func getExpectedQueuesLimitsForPreemptionWithRequiredNode() map[string]map[string]interface{} {
+	expectedQueuesMaxLimits := make(map[string]map[string]interface{})
+	expectedQueuesMaxLimits["root"] = make(map[string]interface{})
+	expectedQueuesMaxLimits["root.leaf"] = make(map[string]interface{})
+	expectedQueuesMaxLimits["root.parent"] = make(map[string]interface{})
+	expectedQueuesMaxLimits["root.parent.sub-leaf"] = make(map[string]interface{})
+	expectedQueuesMaxLimits["root"][maxresources] = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 10, "vcores": 10})
+	expectedQueuesMaxLimits["root.leaf"][maxresources] = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 5, "vcores": 5})
+	expectedQueuesMaxLimits["root.parent"][maxresources] = expectedQueuesMaxLimits["root.leaf"][maxresources]
+	expectedQueuesMaxLimits["root.parent.sub-leaf"][maxresources] = resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 3, "vcores": 3})
+	expectedQueuesMaxLimits["root"][maxapplications] = uint64(2)
+	expectedQueuesMaxLimits["root.leaf"][maxapplications] = uint64(1)
+	expectedQueuesMaxLimits["root.parent"][maxapplications] = uint64(2)
+	expectedQueuesMaxLimits["root.parent.sub-leaf"][maxapplications] = uint64(2)
+	return expectedQueuesMaxLimits
+}
+
 // setup the partition with existing allocations so we can test preemption
 func setupPreemption(t *testing.T) (*PartitionContext, *objects.Application, *objects.Application, *objects.Allocation, *objects.Allocation) {
 	partition := createPreemptionQueuesNodes(t)
@@ -1823,7 +1879,8 @@ func setupPreemption(t *testing.T) (*PartitionContext, *objects.Application, *ob
 	assert.Equal(t, alloc1.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc1.GetAllocationKey(), allocID, "expected ask alloc-1 to be allocated")
 	assert.Equal(t, alloc1.GetNodeID(), nodeID1, "expected alloc-1 on node-1")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 5000}))
+
+	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 5000}), getExpectedQueuesLimitsForPreemption())
 
 	// ask 2
 	ask2 := newAllocationAskPreempt(allocID2, appID1, 1, res)
@@ -1840,7 +1897,7 @@ func setupPreemption(t *testing.T) (*PartitionContext, *objects.Application, *ob
 	assert.Equal(t, alloc2.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc2.GetAllocationKey(), allocID2, "expected ask alloc-2 to be allocated")
 	assert.Equal(t, alloc2.GetNodeID(), nodeID2, "expected alloc-2 on node-2")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 10000}))
+	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 10000}), getExpectedQueuesLimitsForPreemption())
 
 	app2, _ := newApplicationWithHandler(appID2, "default", "root.parent.leaf2")
 
@@ -1883,7 +1940,7 @@ func setupPreemptionForRequiredNode(t *testing.T) (*PartitionContext, *objects.A
 	assert.Equal(t, alloc.GetReleaseCount(), 0, "released allocations should have been 0")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocID, "expected ask alloc-1 to be allocated")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 8000}))
+	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 8000}), getExpectedQueuesLimitsForPreemptionWithRequiredNode())
 	uuid := alloc.GetUUID()
 
 	// required node set on ask
@@ -1900,7 +1957,7 @@ func setupPreemptionForRequiredNode(t *testing.T) (*PartitionContext, *objects.A
 	// check if updated (must be after allocate call)
 	assert.Equal(t, 1, len(app.GetReservations()), "ask should have been reserved")
 	assert.Equal(t, 1, len(app.GetAskReservations(allocID2)), "ask should have been reserved")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 8000}))
+	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 8000}), getExpectedQueuesLimitsForPreemptionWithRequiredNode())
 
 	// try through reserved scheduling cycle this should trigger preemption
 	alloc = partition.tryReservedAllocate()
@@ -1926,7 +1983,7 @@ func setupPreemptionForRequiredNode(t *testing.T) (*PartitionContext, *objects.A
 	}
 	releases, _ := partition.removeAllocation(release)
 	assert.Equal(t, 1, len(releases), "unexpected number of allocations released")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 0}))
+	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 0}), getExpectedQueuesLimitsForPreemptionWithRequiredNode())
 	return partition, app
 }
 
@@ -1960,7 +2017,7 @@ func TestTryAllocateLarge(t *testing.T) {
 		t.Fatalf("allocation did return allocation which does not fit: %s", alloc)
 	}
 	assert.Equal(t, 0, len(app.GetReservations()), "ask should not have been reserved")
-	assertUserGroupResource(t, getTestUserGroup(), nil)
+	assertLimits(t, getTestUserGroup(), nil)
 }
 
 func TestAllocReserveNewNode(t *testing.T) {
@@ -2003,7 +2060,7 @@ func TestAllocReserveNewNode(t *testing.T) {
 		t.Fatal("1st allocation did not return the correct allocation")
 	}
 	assert.Equal(t, objects.Allocated, alloc.GetResult(), "allocation result should have been allocated")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 8000}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 8000}))
 
 	// the second one should be reserved as the 2nd node is not scheduling
 	alloc = partition.tryAllocate()
@@ -2012,7 +2069,7 @@ func TestAllocReserveNewNode(t *testing.T) {
 	}
 	// check if updated (must be after allocate call)
 	assert.Equal(t, 1, len(app.GetReservations()), "ask should have been reserved")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 8000}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 8000}))
 
 	// turn on 2nd node
 	node2.SetSchedulable(true)
@@ -2024,7 +2081,7 @@ func TestAllocReserveNewNode(t *testing.T) {
 	node1 := partition.GetNode(nodeID1)
 	assert.Equal(t, 0, len(node1.GetReservationKeys()), "old node should have no more reservations")
 	assert.Equal(t, 0, len(app.GetReservations()), "ask should have been reserved")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 16000}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 16000}))
 }
 
 func TestTryAllocateReserve(t *testing.T) {
@@ -2073,7 +2130,7 @@ func TestTryAllocateReserve(t *testing.T) {
 	assert.Equal(t, alloc.GetReleaseCount(), 0, "released allocations should have been 0")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), "alloc-2", "expected ask alloc-2 to be allocated")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1000}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1000}))
 
 	// reservations should have been removed: it is in progress
 	if app.IsReservedOnNode(node2.NodeID) || len(app.GetAskReservations("alloc-2")) != 0 {
@@ -2094,7 +2151,7 @@ func TestTryAllocateReserve(t *testing.T) {
 	assert.Equal(t, alloc.GetReleaseCount(), 0, "released allocations should have been 0")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), "alloc-1", "expected ask alloc-1 to be allocated")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 2000}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 2000}))
 
 	if !resources.IsZero(partition.root.GetPendingResource()) {
 		t.Fatalf("pending allocations should be set to zero")
@@ -2139,7 +2196,7 @@ func TestTryAllocateWithReserved(t *testing.T) {
 	assert.Equal(t, "", alloc.GetReservedNodeID(), "reserved node should be reset after processing")
 	assert.Equal(t, 0, len(node2.GetReservationKeys()), "reservation should have been removed from node")
 	assert.Equal(t, false, app.IsReservedOnNode(node2.NodeID), "reservation cleanup for ask on app failed")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 5000}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 5000}))
 
 	// node2 is unreserved now so the next one should allocate on the 2nd node (fair sharing)
 	alloc = partition.tryAllocate()
@@ -2148,7 +2205,7 @@ func TestTryAllocateWithReserved(t *testing.T) {
 	}
 	assert.Equal(t, objects.Allocated, alloc.GetResult(), "expected allocated allocation to be returned")
 	assert.Equal(t, node2.NodeID, alloc.GetNodeID(), "expected allocation on node2 to be returned")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 10000}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 10000}))
 }
 
 // remove the reserved ask while allocating in flight for the ask
@@ -2186,7 +2243,7 @@ func TestScheduleRemoveReservedAsk(t *testing.T) {
 			t.Fatalf("expected allocated allocation to be returned (step %d) %s", i, alloc)
 		}
 	}
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 16000}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 16000}))
 
 	// add a asks which should reserve
 	ask = newAllocationAskRepeat("alloc-2", appID1, res, 1)
@@ -2206,7 +2263,7 @@ func TestScheduleRemoveReservedAsk(t *testing.T) {
 		assert.Equal(t, len(app.GetReservations()), i, "application reservations incorrect")
 	}
 	assert.Equal(t, len(app.GetReservations()), 2, "application reservations should be 2")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 16000}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 16000}))
 
 	// add a node
 	node := newNodeMaxResource("node-3", res)
@@ -2218,7 +2275,7 @@ func TestScheduleRemoveReservedAsk(t *testing.T) {
 	if alloc == nil || alloc.GetResult() != objects.AllocatedReserved {
 		t.Fatalf("expected allocatedReserved allocation to be returned %v", alloc)
 	}
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 20000}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 20000}))
 
 	// before confirming remove the ask: do what the scheduler does when it gets a request from a
 	// shim in processAllocationReleaseByAllocationKey()
@@ -2230,13 +2287,13 @@ func TestScheduleRemoveReservedAsk(t *testing.T) {
 	released := app.RemoveAllocationAsk(removeAskID)
 	assert.Equal(t, released, 1, "expected one reservations to be released")
 	assert.Equal(t, len(app.GetReservations()), 1, "application reservations should be 1")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 20000}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 20000}))
 
 	// now confirm the allocation: this should not remove the reservation
 	rmAlloc := partition.allocate(alloc)
 	assert.Equal(t, "", rmAlloc.GetReservedNodeID(), "reserved node should be reset after processing")
 	assert.Equal(t, len(app.GetReservations()), 1, "application reservations should be kept at 1")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 20000}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 20000}))
 }
 
 // update the config with nodes registered and make sure that the root max and guaranteed are not changed
@@ -2258,6 +2315,22 @@ func TestUpdateRootQueue(t *testing.T) {
 				Parent:    true,
 				SubmitACL: "*",
 				Queues:    nil,
+				Limits: []configs.Limit{
+					{
+						Limit: "root queue limit",
+						Users: []string{
+							"testuser",
+						},
+						Groups: []string{
+							"testgroup",
+						},
+						MaxResources: map[string]string{
+							"memory": "10",
+							"vcores": "10",
+						},
+						MaxApplications: 2,
+					},
+				},
 			},
 		},
 		PlacementRules: nil,
@@ -2538,7 +2611,7 @@ func TestPlaceholderSmallerThanReal(t *testing.T) {
 	assert.Assert(t, resources.Equals(phRes, app.GetQueue().GetAllocatedResource()), "placeholder size should be allocated on queue")
 	assert.Assert(t, resources.Equals(phRes, node.GetAllocatedResource()), "placeholder size should be allocated on node")
 	assert.Equal(t, 1, partition.GetTotalAllocationCount(), "placeholder allocation should be registered on the partition")
-	assertUserGroupResource(t, getTestUserGroup(), phRes)
+	assertLimits(t, getTestUserGroup(), phRes)
 
 	// add an ask which is larger than the placeholder
 	ask = newAllocationAskTG(allocID, appID1, taskGroup, tgRes, false)
@@ -2549,7 +2622,7 @@ func TestPlaceholderSmallerThanReal(t *testing.T) {
 		t.Fatal("allocation should not have matched placeholder")
 	}
 	assert.Assert(t, ph.IsReleased(), "placeholder should be released")
-	assertUserGroupResource(t, getTestUserGroup(), phRes)
+	assertLimits(t, getTestUserGroup(), phRes)
 
 	// wait for events to be processed
 	err = common.WaitFor(10*time.Millisecond, time.Second, func() bool {
@@ -2567,7 +2640,7 @@ func TestPlaceholderSmallerThanReal(t *testing.T) {
 	assert.Equal(t, phID, record.ObjectID, "incorrect allocation ID, expected placeholder alloc ID")
 	assert.Equal(t, appID1, record.ReferenceID, "event should reference application ID")
 	assert.Assert(t, strings.Contains(record.Message, "Task group 'tg-1' in application 'app-1'"), "unexpected message in record")
-	assertUserGroupResource(t, getTestUserGroup(), phRes)
+	assertLimits(t, getTestUserGroup(), phRes)
 
 	// release placeholder: do what the context would do after the shim processing
 	release := &si.AllocationRelease{
@@ -2581,7 +2654,7 @@ func TestPlaceholderSmallerThanReal(t *testing.T) {
 	assert.Assert(t, resources.IsZero(node.GetAllocatedResource()), "nothing should be allocated on node")
 	assert.Assert(t, resources.IsZero(app.GetQueue().GetAllocatedResource()), "nothing should be allocated on queue")
 	assert.Equal(t, 0, partition.GetTotalAllocationCount(), "no allocation should be registered on the partition")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0, "second": 0}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0, "second": 0}))
 }
 
 // one real allocation should trigger cleanup of all placeholders
@@ -2623,7 +2696,7 @@ func TestPlaceholderSmallerMulti(t *testing.T) {
 	assert.Assert(t, resources.Equals(tgRes, app.GetQueue().GetAllocatedResource()), "all placeholders should be allocated on queue")
 	assert.Assert(t, resources.Equals(tgRes, node.GetAllocatedResource()), "all placeholders should be allocated on node")
 	assert.Equal(t, phCount, partition.GetTotalAllocationCount(), "placeholder allocation should be registered on the partition")
-	assertUserGroupResource(t, getTestUserGroup(), tgRes)
+	assertLimits(t, getTestUserGroup(), tgRes)
 
 	// add an ask which is larger than the placeholder
 	ask := newAllocationAskTG(allocID, appID1, taskGroup, tgRes, false)
@@ -2649,7 +2722,7 @@ func TestPlaceholderSmallerMulti(t *testing.T) {
 		t.Fatal("collecting eventChannel should return something")
 	}
 	assert.Equal(t, phCount, len(records), "expecting %d events for placeholder mismatch", phCount)
-	assertUserGroupResource(t, getTestUserGroup(), tgRes)
+	assertLimits(t, getTestUserGroup(), tgRes)
 
 	// release placeholders: do what the context would do after the shim processing
 	for id, ph := range phs {
@@ -2666,7 +2739,7 @@ func TestPlaceholderSmallerMulti(t *testing.T) {
 	assert.Assert(t, resources.IsZero(node.GetAllocatedResource()), "nothing should be allocated on node")
 	assert.Assert(t, resources.IsZero(app.GetQueue().GetAllocatedResource()), "nothing should be allocated on queue")
 	assert.Equal(t, 0, partition.GetTotalAllocationCount(), "no allocation should be registered on the partition")
-	assertUserGroupResource(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0, "second": 0}))
+	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0, "second": 0}))
 }
 
 func TestPlaceholderBiggerThanReal(t *testing.T) {
@@ -2701,7 +2774,7 @@ func TestPlaceholderBiggerThanReal(t *testing.T) {
 	assert.Assert(t, resources.Equals(phRes, app.GetQueue().GetAllocatedResource()), "placeholder size should be allocated on queue")
 	assert.Assert(t, resources.Equals(phRes, node.GetAllocatedResource()), "placeholder size should be allocated on node")
 	assert.Equal(t, 1, partition.GetTotalAllocationCount(), "placeholder allocation should be registered on the partition")
-	assertUserGroupResource(t, getTestUserGroup(), phRes)
+	assertLimits(t, getTestUserGroup(), phRes)
 
 	// add a new ask with smaller request and allocate
 	ask = newAllocationAskTG(allocID, appID1, taskGroup, smallRes, false)
@@ -2716,7 +2789,7 @@ func TestPlaceholderBiggerThanReal(t *testing.T) {
 	// no updates yet on queue and node
 	assert.Assert(t, resources.Equals(phRes, app.GetQueue().GetAllocatedResource()), "placeholder size should still be allocated on queue")
 	assert.Assert(t, resources.Equals(phRes, node.GetAllocatedResource()), "placeholder size should still be allocated on node")
-	assertUserGroupResource(t, getTestUserGroup(), phRes)
+	assertLimits(t, getTestUserGroup(), phRes)
 
 	// replace the placeholder: do what the context would do after the shim processing
 	release := &si.AllocationRelease{
@@ -2733,7 +2806,7 @@ func TestPlaceholderBiggerThanReal(t *testing.T) {
 	assert.Equal(t, 1, partition.GetTotalAllocationCount(), "real allocation should be registered on the partition")
 	assert.Assert(t, resources.Equals(smallRes, app.GetQueue().GetAllocatedResource()), "real size should be allocated on queue")
 	assert.Assert(t, resources.Equals(smallRes, node.GetAllocatedResource()), "real size should be allocated on node")
-	assertUserGroupResource(t, getTestUserGroup(), smallRes)
+	assertLimits(t, getTestUserGroup(), smallRes)
 }
 
 func TestPlaceholderMatch(t *testing.T) {
@@ -2762,7 +2835,7 @@ func TestPlaceholderMatch(t *testing.T) {
 	phUUID := ph.GetUUID()
 	assert.Equal(t, phID, ph.GetAllocationKey(), "expected allocation of ph-1 to be returned")
 	assert.Equal(t, 1, len(app.GetAllPlaceholderData()), "placeholder data should be created on allocate")
-	assertUserGroupResource(t, getTestUserGroup(), phRes)
+	assertLimits(t, getTestUserGroup(), phRes)
 
 	// add a new ask with an unknown task group (should allocate directly)
 	ask = newAllocationAskTG(allocID, appID1, "unknown", phRes, false)
@@ -2776,7 +2849,7 @@ func TestPlaceholderMatch(t *testing.T) {
 	assert.Equal(t, 1, len(app.GetAllPlaceholderData()), "placeholder data should not be updated")
 	assert.Equal(t, int64(1), app.GetAllPlaceholderData()[0].Count, "placeholder data should show 1 available placeholder")
 	assert.Equal(t, int64(0), app.GetAllPlaceholderData()[0].Replaced, "placeholder data should show no replacements")
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(phRes, 2))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(phRes, 2))
 
 	// add a new ask the same task group as the placeholder
 	ask = newAllocationAskTG(allocID2, appID1, taskGroup, phRes, false)
@@ -2789,7 +2862,7 @@ func TestPlaceholderMatch(t *testing.T) {
 	assert.Equal(t, 1, len(app.GetAllPlaceholderData()), "placeholder data should not be updated")
 	assert.Equal(t, int64(1), app.GetAllPlaceholderData()[0].Count, "placeholder data should show 1 available placeholder")
 	assert.Equal(t, int64(0), app.GetAllPlaceholderData()[0].Replaced, "placeholder data should show no replacements")
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(phRes, 2))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(phRes, 2))
 
 	// replace the placeholder should work
 	alloc = partition.tryPlaceholderAllocate()
@@ -2812,7 +2885,7 @@ func TestPlaceholderMatch(t *testing.T) {
 		t.Fatal("confirmed allocation should not be nil")
 	}
 	assert.Equal(t, int64(1), app.GetAllPlaceholderData()[0].Replaced, "placeholder data should show the replacement")
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(phRes, 2))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(phRes, 2))
 
 	// add a new ask the same task group as the placeholder
 	// all placeholders are used so direct allocation is expected
@@ -2823,7 +2896,7 @@ func TestPlaceholderMatch(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("expected ask to be allocated no placeholders left")
 	}
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(phRes, 3))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(phRes, 3))
 }
 
 // simple direct replace with one node
@@ -2857,7 +2930,7 @@ func TestTryPlaceholderAllocate(t *testing.T) {
 	if alloc != nil {
 		t.Fatalf("placeholder ask should not be allocated: %s", alloc)
 	}
-	assertUserGroupResource(t, getTestUserGroup(), nil)
+	assertLimits(t, getTestUserGroup(), nil)
 	// try to allocate a placeholder via normal allocate
 	alloc = partition.tryAllocate()
 	if alloc == nil {
@@ -2870,7 +2943,7 @@ func TestTryPlaceholderAllocate(t *testing.T) {
 		t.Fatalf("placeholder allocation not updated as expected: got %s, expected %s", app.GetPlaceholderResource(), res)
 	}
 	assert.Equal(t, partition.GetTotalAllocationCount(), 1, "placeholder allocation should be counted as alloc")
-	assertUserGroupResource(t, getTestUserGroup(), res)
+	assertLimits(t, getTestUserGroup(), res)
 	// add a second ph ask and run it again it should not match the already allocated placeholder
 	ask = newAllocationAskTG("ph-2", appID1, taskGroup, res, true)
 	err = app.AddAllocationAsk(ask)
@@ -2880,7 +2953,7 @@ func TestTryPlaceholderAllocate(t *testing.T) {
 	if alloc != nil {
 		t.Fatalf("placeholder ask should not be allocated: %s", alloc)
 	}
-	assertUserGroupResource(t, getTestUserGroup(), res)
+	assertLimits(t, getTestUserGroup(), res)
 	alloc = partition.tryAllocate()
 	if alloc == nil {
 		t.Fatal("expected 2nd placeholder to be allocated")
@@ -2890,7 +2963,7 @@ func TestTryPlaceholderAllocate(t *testing.T) {
 		t.Fatalf("placeholder allocation not updated as expected: got %s, expected %s", app.GetPlaceholderResource(), resources.Multiply(res, 2))
 	}
 	assert.Equal(t, partition.GetTotalAllocationCount(), 2, "placeholder allocation should be counted as alloc")
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(res, 2))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(res, 2))
 
 	// not mapping to the same taskgroup should not do anything
 	ask = newAllocationAskTG(allocID, appID1, "tg-unk", res, false)
@@ -2900,7 +2973,7 @@ func TestTryPlaceholderAllocate(t *testing.T) {
 	if alloc != nil {
 		t.Fatalf("allocation should not have matched placeholder: %s", alloc)
 	}
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(res, 2))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(res, 2))
 
 	// add an ask with the TG
 	ask = newAllocationAskTG(allocID2, appID1, taskGroup, res, false)
@@ -2913,7 +2986,7 @@ func TestTryPlaceholderAllocate(t *testing.T) {
 	assert.Equal(t, partition.GetTotalAllocationCount(), 2, "placeholder replacement should not be counted as alloc")
 	assert.Equal(t, alloc.GetResult(), objects.Replaced, "result is not the expected allocated replaced")
 	assert.Equal(t, alloc.GetReleaseCount(), 1, "released allocations should have been 1")
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(res, 2))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(res, 2))
 	phUUID := alloc.GetFirstRelease().GetUUID()
 	// placeholder is not released until confirmed by the shim
 	if !resources.Equals(app.GetPlaceholderResource(), resources.Multiply(res, 2)) {
@@ -2940,7 +3013,7 @@ func TestTryPlaceholderAllocate(t *testing.T) {
 	if !resources.Equals(app.GetAllocatedResource(), res) {
 		t.Fatalf("allocations not updated as expected: got %s, expected %s", app.GetAllocatedResource(), res)
 	}
-	assertUserGroupResource(t, getTestUserGroup(), resources.Multiply(res, 2))
+	assertLimits(t, getTestUserGroup(), resources.Multiply(res, 2))
 }
 
 // The failure is triggered by the predicate plugin and is hidden in the alloc handling
@@ -2985,11 +3058,11 @@ func TestFailReplacePlaceholder(t *testing.T) {
 	if !resources.Equals(app.GetPlaceholderResource(), res) {
 		t.Fatalf("placeholder allocation not updated as expected: got %s, expected %s", app.GetPlaceholderResource(), res)
 	}
-	assertUserGroupResource(t, getTestUserGroup(), res)
+	assertLimits(t, getTestUserGroup(), res)
 
 	// add 2nd node to allow allocation
 	node2 := setupNode(t, nodeID2, partition, tgRes)
-	assertUserGroupResource(t, getTestUserGroup(), res)
+	assertLimits(t, getTestUserGroup(), res)
 	// add an ask with the TG
 	ask = newAllocationAskTG(allocID, appID1, taskGroup, res, false)
 	err = app.AddAllocationAsk(ask)
@@ -3016,7 +3089,7 @@ func TestFailReplacePlaceholder(t *testing.T) {
 	if !resources.Equals(app.GetPlaceholderResource(), res) {
 		t.Fatalf("placeholder allocation not updated as expected: got %s, expected %s", app.GetPlaceholderResource(), resources.Multiply(res, 2))
 	}
-	assertUserGroupResource(t, getTestUserGroup(), res)
+	assertLimits(t, getTestUserGroup(), res)
 
 	// release placeholder: do what the context would do after the shim processing
 	release := &si.AllocationRelease{
@@ -3040,7 +3113,7 @@ func TestFailReplacePlaceholder(t *testing.T) {
 	if !resources.Equals(node2.GetAllocatedResource(), res) {
 		t.Fatalf("node-2 allocations not set as expected: got %s, expected %s", node2.GetAllocatedResource(), res)
 	}
-	assertUserGroupResource(t, getTestUserGroup(), res)
+	assertLimits(t, getTestUserGroup(), res)
 }
 
 func TestAddAllocationAsk(t *testing.T) {
@@ -3081,7 +3154,7 @@ func TestAddAllocationAsk(t *testing.T) {
 	if !resources.Equals(app.GetPendingResource(), res) {
 		t.Fatal("app not updated by adding ask, no error thrown")
 	}
-	assertUserGroupResource(t, getTestUserGroup(), nil)
+	assertLimits(t, getTestUserGroup(), nil)
 }
 
 func TestRemoveAllocationAsk(t *testing.T) {
@@ -3134,7 +3207,7 @@ func TestRemoveAllocationAsk(t *testing.T) {
 	release.TerminationType = si.TerminationType_STOPPED_BY_RM
 	partition.removeAllocationAsk(release)
 	assert.Assert(t, resources.IsZero(app.GetPendingResource()), "app should not have pending asks")
-	assertUserGroupResource(t, getTestUserGroup(), nil)
+	assertLimits(t, getTestUserGroup(), nil)
 }
 
 func TestUpdateNodeSortingPolicy(t *testing.T) {

--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -65,6 +65,18 @@ func (gt *GroupTracker) getTrackedApplications() map[string]bool {
 	return gt.applications
 }
 
+func (gt *GroupTracker) setMaxApplications(count uint64, queuePath string) error {
+	gt.Lock()
+	defer gt.Unlock()
+	return gt.queueTracker.setMaxApplications(count, queuePath)
+}
+
+func (gt *GroupTracker) setMaxResources(resource *resources.Resource, queuePath string) error {
+	gt.Lock()
+	defer gt.Unlock()
+	return gt.queueTracker.setMaxResources(resource, queuePath)
+}
+
 func (gt *GroupTracker) GetGroupResourceUsageDAOInfo() *dao.GroupResourceUsageDAOInfo {
 	gt.RLock()
 	defer gt.RUnlock()

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -24,6 +24,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/apache/yunikorn-core/pkg/common/configs"
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/common/security"
 )
@@ -97,6 +98,20 @@ func TestAddRemoveUserAndGroups(t *testing.T) {
 	assert.Equal(t, user1.User, manager.GetUserTracker(user1.User).userName)
 	assert.Equal(t, user1.Groups[0], manager.GetGroupTracker(user1.Groups[0]).groupName)
 
+	assert.Equal(t, true, manager.IsQueuePathTrackedCompletely(manager.GetUserTracker(user.User).queueTracker, queuePath1))
+	assert.Equal(t, true, manager.IsQueuePathTrackedCompletely(manager.GetUserTracker(user1.User).queueTracker, queuePath2))
+	assert.Equal(t, false, manager.IsQueuePathTrackedCompletely(manager.GetUserTracker(user1.User).queueTracker, queuePath1))
+	assert.Equal(t, false, manager.IsQueuePathTrackedCompletely(manager.GetUserTracker(user.User).queueTracker, queuePath2))
+	assert.Equal(t, false, manager.IsQueuePathTrackedCompletely(manager.GetUserTracker(user.User).queueTracker, queuePath3))
+	assert.Equal(t, false, manager.IsQueuePathTrackedCompletely(manager.GetUserTracker(user.User).queueTracker, queuePath4))
+
+	assert.Equal(t, true, manager.IsQueuePathTrackedCompletely(manager.GetUserTracker(user.Groups[0]).queueTracker, queuePath1))
+	assert.Equal(t, true, manager.IsQueuePathTrackedCompletely(manager.GetUserTracker(user1.Groups[0]).queueTracker, queuePath2))
+	assert.Equal(t, false, manager.IsQueuePathTrackedCompletely(manager.GetUserTracker(user1.Groups[0]).queueTracker, queuePath1))
+	assert.Equal(t, false, manager.IsQueuePathTrackedCompletely(manager.GetUserTracker(user.Groups[0]).queueTracker, queuePath2))
+	assert.Equal(t, false, manager.IsQueuePathTrackedCompletely(manager.GetUserTracker(user.Groups[0]).queueTracker, queuePath3))
+	assert.Equal(t, false, manager.IsQueuePathTrackedCompletely(manager.GetUserTracker(user.Groups[0]).queueTracker, queuePath4))
+
 	usage3, err := resources.NewResourceFromConf(map[string]string{"mem": "5M", "vcore": "5"})
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
@@ -129,6 +144,313 @@ func TestAddRemoveUserAndGroups(t *testing.T) {
 	assert.Assert(t, manager.GetGroupTracker(user.Groups[0]) == nil)
 }
 
+func TestIncreaseUserResourceWithInvalidConfig(t *testing.T) {
+	setupUGM()
+	// Queue setup:
+	// root->parent
+	user := security.UserGroup{User: "user1", Groups: []string{"group1"}}
+	manager := GetUserManager()
+
+	expectedResource, err := resources.NewResourceFromConf(map[string]string{"memory": "5", "vcores": "5"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, expectedResource)
+	}
+
+	m.userLimitsConfig[user.User] = make(map[string]map[string]interface{})
+	m.userLimitsConfig[user.User][queuePath1] = make(map[string]interface{})
+	m.userLimitsConfig[user.User][queuePath1][maxapplications] = -2
+	assert.Error(t, manager.IncreaseTrackedResource(queuePath1, TestApp1, expectedResource, user), "unable to set the max applications. user: "+user.User+", queuepath : "+queuePath1+", applicationid: "+TestApp1)
+
+	m.userLimitsConfig[user.User][queuePath1][maxapplications] = uint64(2)
+	m.userLimitsConfig[user.User][queuePath1][maxresources] = make(map[string]interface{})
+	assert.Error(t, manager.IncreaseTrackedResource(queuePath1, TestApp1, expectedResource, user), "unable to set the max resources. user: "+user.User+", queuepath : "+queuePath1+", applicationid: "+TestApp1)
+
+	m.userLimitsConfig[user.User][queuePath1][maxapplications] = uint64(2)
+	m.userLimitsConfig[user.User][queuePath1][maxresources] = map[string]string{"invalid": "-5", "vcores": "5"}
+	assert.Error(t, manager.IncreaseTrackedResource(queuePath1, TestApp1, expectedResource, user), "unable to set the max resources. user: "+user.User+", queuepath : "+queuePath1+", applicationid: "+TestApp1+", usage: map[memory:5 vcores:5], reason: invalid quantity")
+
+	m.userLimitsConfig[user.User][queuePath1][maxapplications] = uint64(2)
+	m.userLimitsConfig[user.User][queuePath1][maxresources] = map[string]string{"memory": "5", "vcores": "5"}
+	m.groupLimitsConfig[user.Groups[0]] = make(map[string]map[string]interface{})
+	m.groupLimitsConfig[user.Groups[0]][queuePath1] = make(map[string]interface{})
+	m.groupLimitsConfig[user.Groups[0]][queuePath1][maxapplications] = -2
+	assert.Error(t, manager.IncreaseTrackedResource(queuePath1, TestApp1, expectedResource, user), "unable to set the max applications. group: "+user.Groups[0]+", queuepath : "+queuePath1+", applicationid: "+TestApp1)
+
+	m.userLimitsConfig[user.User][queuePath1][maxapplications] = uint64(2)
+	m.userLimitsConfig[user.User][queuePath1][maxresources] = map[string]string{"memory": "5", "vcores": "5"}
+	m.groupLimitsConfig[user.Groups[0]][queuePath1][maxapplications] = uint64(2)
+	m.groupLimitsConfig[user.Groups[0]][queuePath1][maxresources] = make(map[string]interface{})
+	assert.Error(t, manager.IncreaseTrackedResource(queuePath1, TestApp1, expectedResource, user), "unable to set the max resources. group: "+user.Groups[0]+", queuepath : "+queuePath1+", applicationid: "+TestApp1)
+
+	m.userLimitsConfig[user.User][queuePath1][maxapplications] = uint64(2)
+	m.userLimitsConfig[user.User][queuePath1][maxresources] = map[string]string{"memory": "5", "vcores": "5"}
+	m.groupLimitsConfig[user.Groups[0]][queuePath1][maxapplications] = uint64(2)
+	m.groupLimitsConfig[user.Groups[0]][queuePath1][maxresources] = map[string]string{"invalid": "-5", "vcores": "5"}
+	assert.Error(t, manager.IncreaseTrackedResource(queuePath1, TestApp1, expectedResource, user), "unable to set the max resources. group: "+user.Groups[0]+", queuepath : "+queuePath1+", applicationid: "+TestApp1+", reason: invalid quantity")
+}
+
+func TestUpdateConfig(t *testing.T) {
+	setupUGM()
+	// Queue setup:
+	// root->parent
+	user := security.UserGroup{User: "user1", Groups: []string{"group1"}}
+	manager := GetUserManager()
+
+	expectedResource, err := resources.NewResourceFromConf(map[string]string{"memory": "5", "vcores": "5"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, expectedResource)
+	}
+
+	conf := createConfig(user.User, user.Groups[0], "memory", "-10")
+	assert.Error(t, manager.UpdateConfig(conf.Queues[0], "root"), "unable to set the limit for user user1 because invalid quantity")
+	conf = createConfig(user.User, user.Groups[0], "invalid", "invalidate")
+	assert.Error(t, manager.UpdateConfig(conf.Queues[0], "root"), "unable to set the limit for user user1 because invalid quantity")
+	conf = createUpdateConfig(user.User, user.Groups[0])
+
+	manager = GetUserManager()
+	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+
+	assertMaxLimits(t, user, expectedResource, 1)
+
+	for i := 1; i <= 2; i++ {
+		err = manager.IncreaseTrackedResource(queuePath1, TestApp1, expectedResource, user)
+		if err != nil {
+			t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, expectedResource, err)
+		}
+	}
+	assert.Error(t, manager.UpdateConfig(conf.Queues[0], "root"), "unable to set the limit for user user1 because current resource usage is greater than config max resource for root.parent")
+
+	err = manager.IncreaseTrackedResource(queuePath1, TestApp1, expectedResource, user)
+	if err != nil {
+		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, expectedResource, err)
+	}
+	assert.Error(t, manager.UpdateConfig(conf.Queues[0], "root"), "unable to set the limit for user user1 because current resource usage is greater than config max resource for root")
+}
+
+func TestUpdateConfigWithWildCardUsersAndGroups(t *testing.T) {
+	setupUGM()
+	// Queue setup:
+	// root->parent
+	user := security.UserGroup{User: "user1", Groups: []string{"group1"}}
+	conf := createUpdateConfig(user.User, user.Groups[0])
+	manager := GetUserManager()
+	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+
+	expectedResource, err := resources.NewResourceFromConf(map[string]string{"memory": "5", "vcores": "5"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, expectedResource)
+	}
+	assertMaxLimits(t, user, expectedResource, 1)
+
+	for i := 1; i <= 2; i++ {
+		err = manager.IncreaseTrackedResource(queuePath1, TestApp1, expectedResource, user)
+		if err != nil {
+			t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, expectedResource, err)
+		}
+	}
+	assert.Error(t, manager.UpdateConfig(conf.Queues[0], "root"), "unable to set the limit for user user1 because current resource usage is greater than config max resource for root.parent")
+
+	err = manager.IncreaseTrackedResource(queuePath1, TestApp1, expectedResource, user)
+	if err != nil {
+		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, expectedResource, err)
+	}
+	assert.Error(t, manager.UpdateConfig(conf.Queues[0], "root"), "unable to set the limit for user user1 because current resource usage is greater than config max resource for root")
+
+	user1 := security.UserGroup{User: "user2", Groups: []string{"group2"}}
+	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0])
+	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+}
+
+func createUpdateConfigWithWildCardUsersAndGroups(user string, group string) configs.PartitionConfig {
+	conf := configs.PartitionConfig{
+		Name: "test",
+		Queues: []configs.QueueConfig{
+			{
+				Name:      "root",
+				Parent:    true,
+				SubmitACL: "*",
+				Queues: []configs.QueueConfig{
+					{
+						Name:      "parent",
+						Parent:    true,
+						SubmitACL: "*",
+						Queues:    nil,
+						Limits: []configs.Limit{
+							{
+								Limit: "root queue limit",
+								Users: []string{
+									user, "*",
+								},
+								Groups: []string{
+									group, "*",
+								},
+								MaxResources: map[string]string{
+									"memory": "50",
+									"vcores": "50",
+								},
+								MaxApplications: 10,
+							},
+						},
+					},
+				},
+				Limits: []configs.Limit{
+					{
+						Limit: "root queue limit",
+						Users: []string{
+							user, "*",
+						},
+						Groups: []string{
+							group, "*",
+						},
+						MaxResources: map[string]string{
+							"memory": "100",
+							"vcores": "100",
+						},
+						MaxApplications: 20,
+					},
+				},
+			},
+		},
+	}
+	return conf
+}
+
+func createUpdateConfig(user string, group string) configs.PartitionConfig {
+	return createConfig(user, group, "memory", "10")
+}
+
+func createConfig(user string, group string, resourceKey string, resourceValue string) configs.PartitionConfig {
+	conf := configs.PartitionConfig{
+		Name: "test",
+		Queues: []configs.QueueConfig{
+			{
+				Name:      "root",
+				Parent:    true,
+				SubmitACL: "*",
+				Queues: []configs.QueueConfig{
+					{
+						Name:      "parent",
+						Parent:    true,
+						SubmitACL: "*",
+						Queues:    nil,
+						Limits: []configs.Limit{
+							{
+								Limit: "root queue limit",
+								Users: []string{
+									user,
+								},
+								Groups: []string{
+									group,
+								},
+								MaxResources: map[string]string{
+									"memory": "5",
+									"vcores": "5",
+								},
+								MaxApplications: 1,
+							},
+						},
+					},
+				},
+				Limits: []configs.Limit{
+					{
+						Limit: "root queue limit",
+						Users: []string{
+							user,
+						},
+						Groups: []string{
+							group,
+						},
+						MaxResources: map[string]string{
+							resourceKey: resourceValue,
+							"vcores":    "10",
+						},
+						MaxApplications: 2,
+					},
+				},
+			},
+		},
+	}
+	return conf
+}
+
+func TestUpdateConfigClearEarlierSetLimits(t *testing.T) {
+	setupUGM()
+	// Queue setup:
+	// root->parent
+	user := security.UserGroup{User: "user1", Groups: []string{"group1"}}
+	conf := createUpdateConfig(user.User, user.Groups[0])
+
+	manager := GetUserManager()
+	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+
+	expectedResource, err := resources.NewResourceFromConf(map[string]string{"memory": "5", "vcores": "5"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, expectedResource)
+	}
+	assertMaxLimits(t, user, expectedResource, 1)
+
+	user1 := security.UserGroup{User: "user2", Groups: []string{"group2"}}
+	conf = createUpdateConfig(user1.User, user1.Groups[0])
+	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+
+	expectedResource, err = resources.NewResourceFromConf(map[string]string{"memory": "5", "vcores": "5"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, expectedResource)
+	}
+	assertMaxLimits(t, user, resources.NewResource(), 0)
+	assertMaxLimits(t, user1, expectedResource, 1)
+}
+
+func TestSetMaxLimitsForRemovedUsers(t *testing.T) {
+	setupUGM()
+	// Queue setup:
+	// root->parent
+	user := security.UserGroup{User: "user1", Groups: []string{"group1"}}
+	conf := createUpdateConfig(user.User, user.Groups[0])
+	manager := GetUserManager()
+	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+
+	expectedResource, err := resources.NewResourceFromConf(map[string]string{"memory": "5", "vcores": "5"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, expectedResource)
+	}
+	assertMaxLimits(t, user, expectedResource, 1)
+
+	for i := 1; i <= 2; i++ {
+		err = manager.IncreaseTrackedResource(queuePath1, TestApp1, expectedResource, user)
+		if err != nil {
+			t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, expectedResource, err)
+		}
+	}
+	assert.Equal(t, manager.GetUserTracker(user.User) != nil, true)
+	assert.Equal(t, manager.GetGroupTracker(user.Groups[0]) != nil, true)
+
+	err = manager.DecreaseTrackedResource(queuePath1, TestApp1, expectedResource, user, false)
+	if err != nil {
+		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, expectedResource, err)
+	}
+	err = manager.DecreaseTrackedResource(queuePath1, TestApp1, expectedResource, user, true)
+	if err != nil {
+		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, expectedResource, err)
+	}
+	assert.Equal(t, manager.GetUserTracker(user.User) == nil, true)
+	assert.Equal(t, manager.GetGroupTracker(user.Groups[0]) == nil, true)
+
+	err = manager.IncreaseTrackedResource(queuePath1, TestApp1, expectedResource, user)
+	if err != nil {
+		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, expectedResource, err)
+	}
+	assert.Equal(t, manager.GetUserTracker(user.User) != nil, true)
+	assert.Equal(t, manager.GetGroupTracker(user.Groups[0]) != nil, true)
+	assertMaxLimits(t, user, expectedResource, 1)
+}
+
+func setupUGM() {
+	manager := GetUserManager()
+	manager.ClearUserTrackers()
+	manager.ClearGroupTrackers()
+}
+
 func assertUGM(t *testing.T, userGroup security.UserGroup, expected *resources.Resource, usersCount int) {
 	manager := GetUserManager()
 	assert.Equal(t, usersCount, len(manager.GetUsersResources()), "userTrackers count should be "+strconv.Itoa(usersCount))
@@ -137,4 +459,16 @@ func assertUGM(t *testing.T, userGroup security.UserGroup, expected *resources.R
 	assert.Equal(t, resources.Equals(userRes, expected), true)
 	groupRes := manager.GetGroupResources(userGroup.Groups[0])
 	assert.Equal(t, resources.Equals(groupRes, expected), true)
+}
+
+func assertMaxLimits(t *testing.T, userGroup security.UserGroup, expectedResource *resources.Resource, expectedMaxApps int) {
+	manager := GetUserManager()
+	assert.Equal(t, manager.GetUserTracker(userGroup.User).queueTracker.maxRunningApps, uint64(expectedMaxApps*2))
+	assert.Equal(t, manager.GetGroupTracker(userGroup.Groups[0]).queueTracker.maxRunningApps, uint64(expectedMaxApps*2))
+	assert.Equal(t, resources.Equals(manager.GetUserTracker(userGroup.User).queueTracker.maxResourceUsage, resources.Multiply(expectedResource, 2)), true)
+	assert.Equal(t, resources.Equals(manager.GetGroupTracker(userGroup.Groups[0]).queueTracker.maxResourceUsage, resources.Multiply(expectedResource, 2)), true)
+	assert.Equal(t, manager.GetUserTracker(userGroup.User).queueTracker.childQueueTrackers["parent"].maxRunningApps, uint64(expectedMaxApps))
+	assert.Equal(t, manager.GetGroupTracker(userGroup.Groups[0]).queueTracker.childQueueTrackers["parent"].maxRunningApps, uint64(expectedMaxApps))
+	assert.Equal(t, resources.Equals(manager.GetUserTracker(userGroup.User).queueTracker.childQueueTrackers["parent"].maxResourceUsage, expectedResource), true)
+	assert.Equal(t, resources.Equals(manager.GetGroupTracker(userGroup.Groups[0]).queueTracker.childQueueTrackers["parent"].maxResourceUsage, expectedResource), true)
 }

--- a/pkg/scheduler/ugm/queue_tracker_test.go
+++ b/pkg/scheduler/ugm/queue_tracker_test.go
@@ -184,20 +184,6 @@ func TestQTDecreaseTrackedResource(t *testing.T) {
 	}
 }
 
-func TestGetChildQueuePath(t *testing.T) {
-	childPath, immediateChildName := getChildQueuePath("root.parent.leaf")
-	assert.Equal(t, childPath, "parent.leaf")
-	assert.Equal(t, immediateChildName, "parent")
-
-	childPath, immediateChildName = getChildQueuePath("parent.leaf")
-	assert.Equal(t, childPath, "leaf")
-	assert.Equal(t, immediateChildName, "leaf")
-
-	childPath, immediateChildName = getChildQueuePath("leaf")
-	assert.Equal(t, childPath, "")
-	assert.Equal(t, immediateChildName, "")
-}
-
 func getQTResource(qt *QueueTracker) map[string]*resources.Resource {
 	resources := make(map[string]*resources.Resource)
 	usage := qt.getResourceUsageDAOInfo("")

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	"github.com/apache/yunikorn-core/pkg/common/resources"
-	"github.com/apache/yunikorn-core/pkg/common/security"
 	"github.com/apache/yunikorn-core/pkg/webservice/dao"
 )
 
@@ -39,10 +38,10 @@ type UserTracker struct {
 	sync.RWMutex
 }
 
-func newUserTracker(user security.UserGroup) *UserTracker {
+func newUserTracker(user string) *UserTracker {
 	queueTracker := newRootQueueTracker()
 	userTracker := &UserTracker{
-		userName:         user.User,
+		userName:         user,
 		appGroupTrackers: make(map[string]*GroupTracker),
 		queueTracker:     queueTracker,
 	}
@@ -82,6 +81,18 @@ func (ut *UserTracker) getTrackedApplications() map[string]*GroupTracker {
 	ut.RLock()
 	defer ut.RUnlock()
 	return ut.appGroupTrackers
+}
+
+func (ut *UserTracker) setMaxApplications(count uint64, queuePath string) error {
+	ut.Lock()
+	defer ut.Unlock()
+	return ut.queueTracker.setMaxApplications(count, queuePath)
+}
+
+func (ut *UserTracker) setMaxResources(resource *resources.Resource, queuePath string) error {
+	ut.Lock()
+	defer ut.Unlock()
+	return ut.queueTracker.setMaxResources(resource, queuePath)
 }
 
 func (ut *UserTracker) GetUserResourceUsageDAOInfo() *dao.UserResourceUsageDAOInfo {

--- a/pkg/scheduler/ugm/utilities.go
+++ b/pkg/scheduler/ugm/utilities.go
@@ -1,0 +1,38 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package ugm
+
+import (
+	"strings"
+
+	"github.com/apache/yunikorn-core/pkg/common/configs"
+)
+
+func getChildQueuePath(queuePath string) (string, string) {
+	idx := strings.Index(queuePath, configs.DOT)
+	if idx == -1 {
+		return "", ""
+	}
+	childQueuePath := queuePath[idx+1:]
+	idx = strings.Index(childQueuePath, configs.DOT)
+	if idx == -1 {
+		return childQueuePath, childQueuePath
+	}
+	return childQueuePath, childQueuePath[:idx]
+}

--- a/pkg/scheduler/ugm/utilities_test.go
+++ b/pkg/scheduler/ugm/utilities_test.go
@@ -19,6 +19,10 @@
 package ugm
 
 import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/webservice/dao"
 )
@@ -31,4 +35,18 @@ func internalGetResource(usage *dao.ResourceUsageDAOInfo, resources map[string]*
 		}
 	}
 	return resources
+}
+
+func TestGetChildQueuePath(t *testing.T) {
+	childPath, immediateChildName := getChildQueuePath("root.parent.leaf")
+	assert.Equal(t, childPath, "parent.leaf")
+	assert.Equal(t, immediateChildName, "parent")
+
+	childPath, immediateChildName = getChildQueuePath("parent.leaf")
+	assert.Equal(t, childPath, "leaf")
+	assert.Equal(t, immediateChildName, "leaf")
+
+	childPath, immediateChildName = getChildQueuePath("leaf")
+	assert.Equal(t, childPath, "")
+	assert.Equal(t, immediateChildName, "")
 }

--- a/pkg/webservice/dao/ugm_info.go
+++ b/pkg/webservice/dao/ugm_info.go
@@ -36,5 +36,7 @@ type ResourceUsageDAOInfo struct {
 	QueuePath           string                  `json:"queuePath"`
 	ResourceUsage       *resources.Resource     `json:"resourceUsage"`
 	RunningApplications []string                `json:"runningApplications"`
+	MaxResources        *resources.Resource     `json:"maxResources"`
+	MaxApplications     uint64                  `json:"maxApplications"`
 	Children            []*ResourceUsageDAOInfo `json:"children"`
 }

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 
 	"github.com/julienschmidt/httprouter"
-
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"


### PR DESCRIPTION
### What is this PR for?
Traverse the limits configuration (already passed through validation) for all queues recursively and set the user and groups limits in corresponding QueueTracker object.

### What type of PR is it?
* [ ] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1608

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
