### PR TITLE
[YUNIKORN-1731] Allow service account user and group names in filters

### DIFF
--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -66,10 +66,10 @@ var QueueNameRegExp = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
 
 // User and group name check: systems allow different things POSIX is the base but we need to be lenient and allow more.
 // allow upper and lower case, add the @ and . (dot) and officially no length.
-var UserRegExp = regexp.MustCompile(`^[_a-zA-Z][a-zA-Z0-9_.@-]*[$]?$`)
+var UserRegExp = regexp.MustCompile(`^[_a-zA-Z][a-zA-Z0-9:_.@-]*[$]?$`)
 
 // Groups should have a slightly more restrictive regexp (no @ . or $ at the end)
-var GroupRegExp = regexp.MustCompile(`^[_a-zA-Z][a-zA-Z0-9_-]*$`)
+var GroupRegExp = regexp.MustCompile(`^[_a-zA-Z][a-zA-Z0-9:_.-]*$`)
 
 // all characters that make a name different from a regexp
 var SpecialRegExp = regexp.MustCompile(`[\^$*+?()\[{}|]`)
@@ -284,21 +284,23 @@ func checkPlacementFilter(filter Filter) error {
 	// anything that does not parse in a list of users is ignored (like ACL list)
 	if len(filter.Users) == 1 {
 		// for a length of 1 we could either have regexp or username
-		isUser := UserRegExp.MatchString(filter.Users[0])
+		user := filter.Users[0]
+		isUser := UserRegExp.MatchString(user)
 		// if it is not a user name it must be a regexp
 		// two step check: first compile if that fails it is
 		if !isUser {
-			if _, err := regexp.Compile(filter.Users[0]); err != nil || !SpecialRegExp.MatchString(filter.Users[0]) {
+			if _, err := regexp.Compile(user); err != nil || !SpecialRegExp.MatchString(user) {
 				return fmt.Errorf("invalid rule filter user list is not a proper list or regexp: %v", filter.Users)
 			}
 		}
 	}
 	if len(filter.Groups) == 1 {
 		// for a length of 1 we could either have regexp or groupname
-		isGroup := GroupRegExp.MatchString(filter.Groups[0])
+		group := filter.Groups[0]
+		isGroup := GroupRegExp.MatchString(group)
 		// if it is not a group name it must be a regexp
 		if !isGroup {
-			if _, err := regexp.Compile(filter.Groups[0]); err != nil || !SpecialRegExp.MatchString(filter.Groups[0]) {
+			if _, err := regexp.Compile(group); err != nil || !SpecialRegExp.MatchString(group) {
 				return fmt.Errorf("invalid rule filter group list is not a proper list or regexp: %v", filter.Groups)
 			}
 		}

--- a/pkg/scheduler/placement/filter.go
+++ b/pkg/scheduler/placement/filter.go
@@ -99,16 +99,17 @@ func newFilter(conf configs.Filter) Filter {
 	var err error
 	// create the user list or regexp
 	if len(conf.Users) == 1 {
+		user := conf.Users[0]
 		// check for regexp characters that cannot be in a user
-		if configs.SpecialRegExp.MatchString(conf.Users[0]) {
-			filter.userExp, err = regexp.Compile(conf.Users[0])
+		if configs.SpecialRegExp.MatchString(user) {
+			filter.userExp, err = regexp.Compile(user)
 			if err != nil {
 				log.Logger().Debug("Filter user expression does not compile", zap.Any("userFilter", conf.Users))
 			}
-		} else if configs.UserRegExp.MatchString(conf.Users[0]) {
+		} else if configs.UserRegExp.MatchString(user) {
 			// regexp not found consider this a user, sanity check the entry
 			// single entry just a user
-			filter.userList[conf.Users[0]] = true
+			filter.userList[user] = true
 		}
 		filter.empty = false
 	}
@@ -133,16 +134,17 @@ func newFilter(conf configs.Filter) Filter {
 
 	// create the group list or regexp
 	if len(conf.Groups) == 1 {
+		group := conf.Groups[0]
 		// check for regexp characters that cannot be in a group
-		if configs.SpecialRegExp.MatchString(conf.Groups[0]) {
-			filter.groupExp, err = regexp.Compile(conf.Groups[0])
+		if configs.SpecialRegExp.MatchString(group) {
+			filter.groupExp, err = regexp.Compile(group)
 			if err != nil {
 				log.Logger().Debug("Filter group expression does not compile", zap.Any("groupFilter", conf.Groups))
 			}
-		} else if configs.GroupRegExp.MatchString(conf.Groups[0]) {
+		} else if configs.GroupRegExp.MatchString(group) {
 			// regexp not found consider this a group, sanity check the entry
 			// single entry just a group
-			filter.groupList[conf.Groups[0]] = true
+			filter.groupList[group] = true
 		}
 		filter.empty = false
 	}


### PR DESCRIPTION
### What is this PR for?
Allow service account user and group names in which has a ":" character inside. After YUNIKORN-1306, it's valid to define service account names in filters of placement rules.
The PR is a simple regexp modification. We don't perform a strict format check.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1731

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
