### PR TITLE
[YUNIKORN-1734] Missing headers in REST response

### DIFF
--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -483,12 +483,12 @@ func getPartitions(w http.ResponseWriter, r *http.Request) {
 }
 
 func getPartitionQueues(w http.ResponseWriter, r *http.Request) {
+	writeHeaders(w)
 	vars := httprouter.ParamsFromContext(r.Context())
 	if vars == nil {
 		buildJSONErrorResponse(w, MissingParamsName, http.StatusBadRequest)
 		return
 	}
-	writeHeaders(w)
 	partitionName := vars.ByName("partition")
 	var partitionQueuesDAOInfo dao.PartitionQueueDAOInfo
 	var partition = schedulerContext.GetPartitionWithoutClusterID(partitionName)
@@ -504,12 +504,12 @@ func getPartitionQueues(w http.ResponseWriter, r *http.Request) {
 }
 
 func getPartitionNodes(w http.ResponseWriter, r *http.Request) {
+	writeHeaders(w)
 	vars := httprouter.ParamsFromContext(r.Context())
 	if vars == nil {
 		buildJSONErrorResponse(w, MissingParamsName, http.StatusBadRequest)
 		return
 	}
-	writeHeaders(w)
 	partition := vars.ByName("partition")
 	partitionContext := schedulerContext.GetPartitionWithoutClusterID(partition)
 	if partitionContext != nil {
@@ -523,12 +523,12 @@ func getPartitionNodes(w http.ResponseWriter, r *http.Request) {
 }
 
 func getQueueApplications(w http.ResponseWriter, r *http.Request) {
+	writeHeaders(w)
 	vars := httprouter.ParamsFromContext(r.Context())
 	if vars == nil {
 		buildJSONErrorResponse(w, MissingParamsName, http.StatusBadRequest)
 		return
 	}
-	writeHeaders(w)
 	partition := vars.ByName("partition")
 	queueName := vars.ByName("queue")
 	queueErr := validateQueue(queueName)
@@ -558,12 +558,12 @@ func getQueueApplications(w http.ResponseWriter, r *http.Request) {
 }
 
 func getApplication(w http.ResponseWriter, r *http.Request) {
+	writeHeaders(w)
 	vars := httprouter.ParamsFromContext(r.Context())
 	if vars == nil {
 		buildJSONErrorResponse(w, MissingParamsName, http.StatusBadRequest)
 		return
 	}
-	writeHeaders(w)
 	partition := vars.ByName("partition")
 	queueName := vars.ByName("queue")
 	application := vars.ByName("application")
@@ -594,12 +594,12 @@ func getApplication(w http.ResponseWriter, r *http.Request) {
 }
 
 func setLogLevel(w http.ResponseWriter, r *http.Request) {
+	writeHeaders(w)
 	vars := httprouter.ParamsFromContext(r.Context())
 	if vars == nil {
 		buildJSONErrorResponse(w, MissingParamsName, http.StatusBadRequest)
 		return
 	}
-	writeHeaders(w)
 	level := vars.ByName("level")
 	if err := log.SetLogLevel(level); err != nil {
 		buildJSONErrorResponse(w, err.Error(), http.StatusBadRequest)
@@ -780,6 +780,7 @@ func getMetrics(w http.ResponseWriter, r *http.Request) {
 }
 
 func getUsersResourceUsage(w http.ResponseWriter, r *http.Request) {
+	writeHeaders(w)
 	userManager := ugm.GetUserManager()
 	usersResources := userManager.GetUsersResources()
 	var result []*dao.UserResourceUsageDAOInfo
@@ -792,6 +793,7 @@ func getUsersResourceUsage(w http.ResponseWriter, r *http.Request) {
 }
 
 func getUserResourceUsage(w http.ResponseWriter, r *http.Request) {
+	writeHeaders(w)
 	vars := httprouter.ParamsFromContext(r.Context())
 	if vars == nil {
 		buildJSONErrorResponse(w, MissingParamsName, http.StatusBadRequest)
@@ -814,6 +816,7 @@ func getUserResourceUsage(w http.ResponseWriter, r *http.Request) {
 }
 
 func getGroupsResourceUsage(w http.ResponseWriter, r *http.Request) {
+	writeHeaders(w)
 	userManager := ugm.GetUserManager()
 	groupsResources := userManager.GetGroupsResources()
 	var result []*dao.GroupResourceUsageDAOInfo
@@ -826,6 +829,7 @@ func getGroupsResourceUsage(w http.ResponseWriter, r *http.Request) {
 }
 
 func getGroupResourceUsage(w http.ResponseWriter, r *http.Request) {
+	writeHeaders(w)
 	vars := httprouter.ParamsFromContext(r.Context())
 	if vars == nil {
 		buildJSONErrorResponse(w, MissingParamsName, http.StatusBadRequest)


### PR DESCRIPTION
### What is this PR for?
REST responses should have the content type header set to JSON, this PR solve the following two problems:

1. The usage REST responses, users; user; groups and group, do not have any headers set as they do not call writeHeaders(w).

2. Also in case that the parameters are not set we return a JSON error response object without setting the header (introduced in [YUNIKORN-1472](https://issues.apache.org/jira/browse/YUNIKORN-1472)). The JSON error response is written before without ever calling writeHeaders(w).  

We should make sure writeHeaders(w) at the first of the function.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1734
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
