### PR TITLE
[YUNIKORN-1737] Originator flag for AllocationAskDAOInfo don't assign for construct in getAllocationAskDAO.

### DIFF
--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -306,6 +306,7 @@ func getAllocationAskDAO(ask *objects.AllocationAsk) *dao.AllocationAskDAOInfo {
 		TaskGroupName:       ask.GetTaskGroup(),
 		AllocationLog:       getAllocationLogsDAO(ask.GetAllocationLog()),
 		TriggeredPreemption: ask.HasTriggeredPreemption(),
+		Originator:          ask.IsOriginator(),
 	}
 }
 


### PR DESCRIPTION
### What is this PR for?
We have Originator flag in the AllocationAskDAOInfo for restAPI.

But we don't assign the value for getAllocationAskDAO.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1737
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
