### PR TITLE
[YUNIKORN-1719] Improve the performance of Application.sortRequests()

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -514,6 +514,7 @@ func (sa *Application) removeAsksInternal(allocKey string) int {
 		deltaPendingResource = sa.pending
 		sa.pending = resources.NewResource()
 		sa.requests = make(map[string]*AllocationAsk)
+		sa.sortedRequests = nil
 		sa.askMaxPriority = configs.MinPriority
 		sa.queue.UpdateApplicationPriority(sa.ApplicationID, sa.askMaxPriority)
 	} else {
@@ -536,6 +537,7 @@ func (sa *Application) removeAsksInternal(allocKey string) int {
 			deltaPendingResource = resources.MultiplyBy(ask.GetAllocatedResource(), float64(ask.GetPendingAskRepeat()))
 			sa.pending = resources.Sub(sa.pending, deltaPendingResource)
 			delete(sa.requests, allocKey)
+			sa.sortRequests()
 			if priority := ask.GetPriority(); priority >= sa.askMaxPriority {
 				sa.updateAskMaxPriority()
 			}
@@ -619,7 +621,7 @@ func (sa *Application) AddAllocationAsk(ask *AllocationAsk) error {
 		zap.Bool("placeholder", ask.IsPlaceholder()),
 		zap.Stringer("pendingDelta", delta))
 
-	sa.sortRequests(false)
+	sa.sortRequests()
 
 	return nil
 }
@@ -844,7 +846,7 @@ func (sa *Application) canAskReserve(ask *AllocationAsk) bool {
 // Sort the request for the app in order based on the priority of the request.
 // The sorted list only contains candidates that have an outstanding repeat.
 // No locking must be called while holding the lock
-func (sa *Application) sortRequests(ascending bool) {
+func (sa *Application) sortRequests() {
 	sa.sortedRequests = nil
 	for _, request := range sa.requests {
 		if request.GetPendingAskRepeat() == 0 {
@@ -854,20 +856,21 @@ func (sa *Application) sortRequests(ascending bool) {
 	}
 	// we might not have any requests
 	if len(sa.sortedRequests) > 0 {
-		sortAskByPriority(sa.sortedRequests, ascending)
+		sortAskByPriority(sa.sortedRequests)
 	}
 }
 
 func (sa *Application) getOutstandingRequests(headRoom *resources.Resource, total *[]*AllocationAsk) {
-	// make sure the request are sorted
-	sa.Lock()
-	sa.sortRequests(false)
-	sa.Unlock()
-
 	sa.RLock()
 	defer sa.RUnlock()
+	if sa.sortedRequests == nil {
+		return
+	}
 
 	for _, request := range sa.sortedRequests {
+		if request.GetPendingAskRepeat() == 0 {
+			continue
+		}
 		// ignore nil checks resource function calls are nil safe
 		if headRoom.FitInMaxUndef(request.GetAllocatedResource()) {
 			// if headroom is still enough for the resources
@@ -1053,11 +1056,9 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 	sa.Lock()
 	defer sa.Unlock()
 	// nothing to do if we have no placeholders allocated
-	if resources.IsZero(sa.allocatedPlaceholder) {
+	if resources.IsZero(sa.allocatedPlaceholder) || sa.sortedRequests == nil {
 		return nil
 	}
-	// make sure the request are sorted
-	sa.sortRequests(false)
 	// keep the first fits for later
 	var phFit *Allocation
 	var reqFit *AllocationAsk
@@ -1065,7 +1066,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 	for _, request := range sa.sortedRequests {
 		// skip placeholders they follow standard allocation
 		// this should also be part of a task group just make sure it is
-		if request.IsPlaceholder() || request.GetTaskGroup() == "" {
+		if request.IsPlaceholder() || request.GetTaskGroup() == "" || request.GetPendingAskRepeat() == 0 {
 			continue
 		}
 		// walk over the placeholders, allow for processing all as we can have multiple task groups

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -658,6 +658,7 @@ func (sa *Application) UpdateAskRepeat(allocKey string, delta int32) (*resources
 	sa.Lock()
 	defer sa.Unlock()
 	if ask := sa.requests[allocKey]; ask != nil {
+
 		return sa.updateAskRepeatInternal(ask, delta)
 	}
 	return nil, fmt.Errorf("failed to locate ask with key %s", allocKey)
@@ -667,6 +668,11 @@ func (sa *Application) updateAskRepeatInternal(ask *AllocationAsk, delta int32) 
 	// updating with delta does error checking internally
 	if !ask.updatePendingAskRepeat(delta) {
 		return nil, fmt.Errorf("ask repaeat not updated resulting repeat less than zero for ask %s on app %s", ask.GetAllocationKey(), sa.ApplicationID)
+	}
+
+	if delta == 1 {
+		// adding request back, which was filtered out before
+		sa.sortRequests()
 	}
 
 	askPriority := ask.GetPriority()

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -674,7 +674,7 @@ func TestSortRequests(t *testing.T) {
 	if app.sortedRequests != nil {
 		t.Fatalf("new app create should not have sorted requests: %v", app)
 	}
-	app.sortRequests(true)
+	app.sortRequests()
 	if app.sortedRequests != nil {
 		t.Fatalf("after sort call (no pending resources) list must be nil: %v", app.sortedRequests)
 	}
@@ -686,13 +686,13 @@ func TestSortRequests(t *testing.T) {
 		ask.priority = int32(i)
 		app.requests[ask.GetAllocationKey()] = ask
 	}
-	app.sortRequests(true)
+	app.sortRequests()
 	if len(app.sortedRequests) != 3 {
 		t.Fatalf("app sorted requests not correct: %v", app.sortedRequests)
 	}
 	allocKey := app.sortedRequests[0].GetAllocationKey()
 	delete(app.requests, allocKey)
-	app.sortRequests(true)
+	app.sortRequests()
 	if len(app.sortedRequests) != 2 {
 		t.Fatalf("app sorted requests not correct after removal: %v", app.sortedRequests)
 	}

--- a/pkg/scheduler/objects/sorters.go
+++ b/pkg/scheduler/objects/sorters.go
@@ -230,7 +230,7 @@ func stateAwareFilter(apps map[string]*Application) []*Application {
 	return filteredApps
 }
 
-func sortAskByPriority(requests []*AllocationAsk, ascending bool) {
+func sortAskByPriority(requests []*AllocationAsk) {
 	sort.SliceStable(requests, func(i, j int) bool {
 		l := requests[i]
 		r := requests[j]
@@ -239,9 +239,6 @@ func sortAskByPriority(requests []*AllocationAsk, ascending bool) {
 			return l.GetCreateTime().Before(r.GetCreateTime())
 		}
 
-		if ascending {
-			return l.GetPriority() < r.GetPriority()
-		}
 		return l.GetPriority() > r.GetPriority()
 	})
 }

--- a/pkg/scheduler/objects/sorters_test.go
+++ b/pkg/scheduler/objects/sorters_test.go
@@ -402,24 +402,16 @@ func TestSortAsks(t *testing.T) {
 	list[0], list[2] = list[2], list[0]
 	list[1], list[3] = list[3], list[1]
 	assertAskList(t, list, []int{2, 3, 0, 1}, "moved 1")
-	sortAskByPriority(list, true)
-	// asks should come back in order: 0, 1, 2, 3
-	assertAskList(t, list, []int{0, 1, 2, 3}, "ascending")
-	// move things around
-	list[0], list[2] = list[2], list[0]
-	list[1], list[3] = list[3], list[1]
-	assertAskList(t, list, []int{2, 3, 0, 1}, "moved 2")
-	sortAskByPriority(list, false)
+
+	sortAskByPriority(list)
 	// asks should come back in order: 3, 2, 1, 0
 	assertAskList(t, list, []int{3, 2, 1, 0}, "descending")
+
 	// make asks with same priority
 	// ask-3 and ask-1 both with prio 1 do not change order
 	// ask-3 must always be earlier in the list
 	list[0].priority = 1
-	sortAskByPriority(list, true)
-	// asks should come back in order: 0, 2, 3, 1
-	assertAskList(t, list, []int{0, 1, 3, 2}, "ascending same prio")
-	sortAskByPriority(list, false)
+	sortAskByPriority(list)
 	// asks should come back in order: 3, 2, 0, 1
 	assertAskList(t, list, []int{3, 1, 0, 2}, "descending same prio")
 }


### PR DESCRIPTION
### What is this PR for?
Avoid calling `Application.sortRequests()` constantly. We only need to sort if a new request is added. If `pendingAskRepeat` becomes 0 for a request, we simply skip it.
After doing various benchmarks, this approach is simpler and even faster than maintaining requests in a sorted BTree (see #541).

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1719

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
