### PR TITLE
[YUNIKORN-1716] Improve the performance of baseNodeCollection.getNodeIteratorInternal()

### DIFF
--- a/pkg/scheduler/objects/common_test.go
+++ b/pkg/scheduler/objects/common_test.go
@@ -17,6 +17,8 @@
 package objects
 
 import (
+	"github.com/google/btree"
+
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
@@ -43,4 +45,19 @@ func newEventSystemMock() *EventSystemMock {
 
 func getTestResource() *resources.Resource {
 	return resources.NewResourceFromMap(map[string]resources.Quantity{"cpu": 1})
+}
+
+func getNodeIteratorFn(nodes ...*Node) func() NodeIterator {
+	tree := btree.New(7)
+	for _, node := range nodes {
+		tree.ReplaceOrInsert(nodeRef{
+			node, 1,
+		})
+	}
+
+	return func() NodeIterator {
+		return NewTreeIterator(acceptAll, func() *btree.BTree {
+			return tree
+		})
+	}
 }

--- a/pkg/scheduler/objects/node_collection.go
+++ b/pkg/scheduler/objects/node_collection.go
@@ -163,14 +163,12 @@ func (nc *baseNodeCollection) GetNodes() []*Node {
 // Create an ordered node iterator for unreserved nodes based on the sort policy set for this collection.
 // The iterator is nil if there are no unreserved nodes available.
 func (nc *baseNodeCollection) GetNodeIterator() NodeIterator {
-	nc.unreservedIterator.Reset()
 	return nc.unreservedIterator
 }
 
 // Create an ordered node iterator for all nodes based on the sort policy set for this collection.
 // The iterator is nil if there are no nodes available.
 func (nc *baseNodeCollection) GetFullNodeIterator() NodeIterator {
-	nc.fullIterator.Reset()
 	return nc.fullIterator
 }
 

--- a/pkg/scheduler/objects/node_collection_test.go
+++ b/pkg/scheduler/objects/node_collection_test.go
@@ -198,11 +198,12 @@ func TestSetNodeSortingPolicy(t *testing.T) {
 
 			nc.SetNodeSortingPolicy(NewNodeSortingPolicy(conf.NodeSortPolicy.Type, conf.NodeSortPolicy.ResourceWeights))
 			iter := nc.GetNodeIterator()
-			for id := 0; id < len(tt.nodesOrder); id++ {
-				if n := iter.Next(); n.NodeID != tt.nodesOrder[id] {
-					t.Errorf("%s: NodeID wanted %s, but it got %s.", nc.GetNodeSortingPolicy().PolicyType().String(), tt.nodesOrder[id], n.NodeID)
-				}
-			}
+			id := 0
+			iter.ForEachNode(func(node *Node) bool {
+				assert.Equal(t, node.NodeID, tt.nodesOrder[id], "%s: NodeID wanted %s, but it got %s.", nc.GetNodeSortingPolicy().PolicyType().String(), tt.nodesOrder[id], node.NodeID)
+				id++
+				return true
+			})
 		})
 	}
 }
@@ -266,16 +267,18 @@ func TestGetNodeSortingPolicy(t *testing.T) {
 
 			// Checking thes nodes order in iterator is after setting node policy with Default weight{vcore:1, memory:1}.
 			iter := nc.GetNodeIterator()
-			for index := 0; iter.HasNext(); index++ {
+			index := 0
+			iter.ForEachNode(func(node *Node) bool {
 				if index >= len(tt.exceptNodeOrder) {
 					t.Error("Wrong length of nodes in node iterator.")
 				}
 
-				n := iter.Next()
-				if n.NodeID != tt.exceptNodeOrder[index] {
-					t.Errorf("Policy: %s, got %s, want %s", nc.GetNodeSortingPolicy().PolicyType().String(), n.NodeID, tt.exceptNodeOrder[index])
+				if node.NodeID != tt.exceptNodeOrder[index] {
+					t.Errorf("Policy: %s, got %s, want %s", nc.GetNodeSortingPolicy().PolicyType().String(), node.NodeID, tt.exceptNodeOrder[index])
 				}
-			}
+				index++
+				return true
+			})
 		})
 	}
 }
@@ -305,9 +308,10 @@ func TestGetFullNodeIterator(t *testing.T) {
 		}
 	}
 	nodes := make([]*Node, 0)
-	for iterator := nc.GetFullNodeIterator(); iterator.HasNext(); {
-		nodes = append(nodes, iterator.Next())
-	}
+	nc.GetFullNodeIterator().ForEachNode(func(node *Node) bool {
+		nodes = append(nodes, node)
+		return true
+	})
 	assert.Equal(t, len(nodes), 4, "wrong length")
 	assert.Equal(t, nodes[0].NodeID, "node-2", "wrong node 0")
 	assert.Equal(t, nodes[1].NodeID, "node-4", "wrong node 1")
@@ -323,7 +327,6 @@ func TestGetNodeIterator(t *testing.T) {
 	}{
 		{"All nodes are available", []bool{false, false, false, false}, []int{1, 2, 3, 4}},
 		{"Some nodes are reserved", []bool{false, true, false, true}, []int{1, 3}},
-		{"All nodes are reserved", []bool{true, true, true, true}, []int{}},
 	}
 
 	for _, tt := range tests {
@@ -356,49 +359,54 @@ func TestGetNodeIterator(t *testing.T) {
 			}
 
 			// Check order of avialble nodes
-			if iter := nc.GetNodeIterator(); len(tt.wantWithFair) == 0 {
-				if iter != nil {
-					t.Error("Wrong count of nodes in the node collection instance.")
-				}
-			} else {
-				NodeSortingPolicy := []string{policies.FairnessPolicy.String(), policies.BinPackingPolicy.String()}
+			NodeSortingPolicy := []string{policies.FairnessPolicy.String(), policies.BinPackingPolicy.String()}
 
-				// Fair policy
-				nc.SetNodeSortingPolicy(NewNodeSortingPolicy(NodeSortingPolicy[0], nil))
-				if ans := nc.GetNodeSortingPolicy().PolicyType().String(); ans != NodeSortingPolicy[0] {
-					t.Errorf("got %s, want %s", ans, NodeSortingPolicy[0])
-				}
-
-				for index := 0; iter.HasNext(); index++ {
-					if index >= len(tt.wantWithFair) {
-						t.Errorf("Want length of nodes: %d, Get length of nodes: %d", index, len(tt.wantWithFair))
-					}
-
-					n := iter.Next()
-					if want := fmt.Sprintf("node-%d", tt.wantWithFair[index]); n.NodeID != want {
-						t.Errorf("%s with %s, Want %s, got %s.", tt.name, NodeSortingPolicy[0], want, n.NodeID)
-					}
-				}
-
-				// Binpacking policy
-				nc.SetNodeSortingPolicy(NewNodeSortingPolicy(NodeSortingPolicy[1], nil))
-				if ans := nc.GetNodeSortingPolicy().PolicyType().String(); ans != NodeSortingPolicy[1] {
-					t.Errorf("got %s, want %s", ans, NodeSortingPolicy[1])
-				}
-
-				iter = nc.GetNodeIterator()
-				DescreasingIndex := len(tt.wantWithFair) - 1
-				for index := 0; iter.HasNext(); index++ {
-					if index >= len(tt.wantWithFair) {
-						t.Errorf("Want length of nodes: %d, Get length of nodes: %d", index, len(tt.wantWithFair))
-					}
-					n := iter.Next()
-					if want := fmt.Sprintf("node-%d", tt.wantWithFair[DescreasingIndex]); n.NodeID != want {
-						t.Errorf("%s with %s, want %s, got %s.", tt.name, NodeSortingPolicy[1], want, n.NodeID)
-					}
-					DescreasingIndex--
-				}
+			// Fair policy
+			nc.SetNodeSortingPolicy(NewNodeSortingPolicy(NodeSortingPolicy[0], nil))
+			iter := nc.GetNodeIterator()
+			if ans := nc.GetNodeSortingPolicy().PolicyType().String(); ans != NodeSortingPolicy[0] {
+				t.Errorf("got %s, want %s", ans, NodeSortingPolicy[0])
 			}
+			index := 0
+			iter.ForEachNode(func(node *Node) bool {
+				fmt.Println(node.NodeID)
+				return true
+			})
+
+			iter.ForEachNode(func(node *Node) bool {
+				if index >= len(tt.wantWithFair) {
+					t.Errorf("Want length of nodes: %d, Get length of nodes: %d", index, len(tt.wantWithFair))
+				}
+
+				if want := fmt.Sprintf("node-%d", tt.wantWithFair[index]); node.NodeID != want {
+					t.Errorf("%s with %s, Want %s, got %s.", tt.name, NodeSortingPolicy[0], want, node.NodeID)
+				}
+
+				index++
+				return true
+			})
+
+			// Binpacking policy
+			nc.SetNodeSortingPolicy(NewNodeSortingPolicy(NodeSortingPolicy[1], nil))
+			if ans := nc.GetNodeSortingPolicy().PolicyType().String(); ans != NodeSortingPolicy[1] {
+				t.Errorf("got %s, want %s", ans, NodeSortingPolicy[1])
+			}
+
+			iter = nc.GetNodeIterator()
+			DescreasingIndex := len(tt.wantWithFair) - 1
+			index = 0
+			iter.ForEachNode(func(node *Node) bool {
+				if index >= len(tt.wantWithFair) {
+					t.Errorf("Want length of nodes: %d, Get length of nodes: %d", index, len(tt.wantWithFair))
+				}
+
+				if want := fmt.Sprintf("node-%d", tt.wantWithFair[DescreasingIndex]); node.NodeID != want {
+					t.Errorf("%s with %s, want %s, got %s.", tt.name, NodeSortingPolicy[1], want, node.NodeID)
+				}
+				index++
+				DescreasingIndex--
+				return true
+			})
 		})
 	}
 }

--- a/pkg/scheduler/objects/node_iterator.go
+++ b/pkg/scheduler/objects/node_iterator.go
@@ -24,25 +24,19 @@ import (
 
 // NodeIterator iterates over a list of nodes based on the defined policy
 type NodeIterator interface {
-	// Reset the iterator to a clean state
-	Reset()
-
-	// ForEachNode Calls the provided function on each Node object unil it returns false
+	// ForEachNode Calls the provided function on the sorted Node object until it returns false
 	ForEachNode(func(*Node) bool)
 }
 
 type treeIterator struct {
 	accept  func(*Node) bool
 	getTree func() *btree.BTree
-	tree    *btree.BTree
 }
 
-func (ti *treeIterator) Reset() {
-	ti.tree = ti.getTree()
-}
-
+// ForEachNode Calls the provided "f" function on the sorted Node object until it returns false.
+// The accept() function checks if the node should be a candidate or not.
 func (ti *treeIterator) ForEachNode(f func(*Node) bool) {
-	ti.tree.Ascend(func(item btree.Item) bool {
+	ti.getTree().Ascend(func(item btree.Item) bool {
 		node := item.(nodeRef).node
 		if ti.accept(node) {
 			return f(node)
@@ -57,6 +51,5 @@ func NewTreeIterator(accept func(*Node) bool, getTree func() *btree.BTree) *tree
 		getTree: getTree,
 		accept:  accept,
 	}
-	ti.tree = getTree()
 	return ti
 }

--- a/pkg/scheduler/objects/node_iterator.go
+++ b/pkg/scheduler/objects/node_iterator.go
@@ -19,66 +19,16 @@
 package objects
 
 import (
-	"math/rand"
-
 	"github.com/google/btree"
 )
 
 // NodeIterator iterates over a list of nodes based on the defined policy
 type NodeIterator interface {
-	// returns true if there are more values to iterate over
-	HasNext() bool
-	// returns the next node from the iterator
-	Next() *Node
-	// reset the iterator to a clean state
+	// Reset the iterator to a clean state
 	Reset()
 
+	// ForEachNode Calls the provided function on each Node object unil it returns false
 	ForEachNode(func(*Node) bool)
-}
-
-// All iterators extend the base iterator
-type baseIterator struct {
-	NodeIterator
-	countIdx int
-	size     int
-	nodes    []*Node
-}
-
-// Reset the iterator to start from the beginning
-func (bi *baseIterator) Reset() {
-	bi.countIdx = 0
-}
-
-// HasNext returns true if there is a next element in the array.
-// Returns false if there are no more elements or list is empty.
-func (bi *baseIterator) HasNext() bool {
-	return !(bi.countIdx+1 > bi.size)
-}
-
-// Next returns the next element and advances to next element in array.
-// Returns nil at the end of iteration.
-func (bi *baseIterator) Next() *Node {
-	if (bi.countIdx + 1) > bi.size {
-		return nil
-	}
-
-	value := bi.nodes[bi.countIdx]
-	bi.countIdx++
-	return value
-}
-
-// Default iterator, wraps the base iterator.
-// Iterates over the list from the start, position zero, to end.
-type defaultNodeIterator struct {
-	baseIterator
-}
-
-// Create a new default iterator
-func NewDefaultNodeIterator(schedulerNodes []*Node) NodeIterator {
-	it := &defaultNodeIterator{}
-	it.nodes = schedulerNodes
-	it.size = len(schedulerNodes)
-	return it
 }
 
 type treeIterator struct {
@@ -89,14 +39,6 @@ type treeIterator struct {
 
 func (ti *treeIterator) Reset() {
 	ti.tree = ti.getTree()
-}
-
-func (ti *treeIterator) HasNext() bool {
-	panic("HasNext() has no implementation")
-}
-
-func (ti *treeIterator) Next() *Node {
-	panic("Next() has no implementation")
 }
 
 func (ti *treeIterator) ForEachNode(f func(*Node) bool) {
@@ -111,51 +53,10 @@ func (ti *treeIterator) ForEachNode(f func(*Node) bool) {
 }
 
 func NewTreeIterator(accept func(*Node) bool, getTree func() *btree.BTree) *treeIterator {
-	return &treeIterator{
+	ti := &treeIterator{
 		getTree: getTree,
 		accept:  accept,
 	}
-}
-
-// Random iterator, wraps the base iterator
-// Iterates over the list from a random starting position in the list.
-// The iterator automatically wraps at the end of the list.
-type roundRobinNodeIterator struct {
-	baseIterator
-	startIdx int
-}
-
-// The starting point is randomised in the slice.
-func NewRoundRobinNodeIterator(schedulerNodes []*Node) NodeIterator {
-	it := &roundRobinNodeIterator{}
-	it.nodes = schedulerNodes
-	it.size = len(schedulerNodes)
-	if it.size > 0 {
-		it.startIdx = rand.Intn(it.size)
-	}
-	return it
-}
-
-// Next returns the next element and advances to next element in array.
-// Returns nil at the end of iteration.
-func (ri *roundRobinNodeIterator) Next() *Node {
-	// prevent panic on Next when slice is empty
-	if (ri.countIdx + 1) > ri.size {
-		return nil
-	}
-
-	// after reset initialize the rand seed based on number of nodes.
-	if ri.startIdx == -1 {
-		ri.startIdx = rand.Intn(ri.size)
-	}
-
-	idx := (ri.countIdx + ri.startIdx) % ri.size
-	value := ri.nodes[idx]
-	ri.countIdx++
-	return value
-}
-
-func (ri *roundRobinNodeIterator) Reset() {
-	ri.countIdx = 0
-	ri.startIdx = -1
+	ti.tree = getTree()
+	return ti
 }

--- a/pkg/scheduler/objects/node_iterator_test.go
+++ b/pkg/scheduler/objects/node_iterator_test.go
@@ -22,184 +22,87 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/google/btree"
+	"gotest.tools/v3/assert"
+
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 )
 
-// empty test for random iterator
-func TestRoundRobinIteratorEmpty(t *testing.T) {
-	// nil list
-	rni, ok := NewRoundRobinNodeIterator(nil).(*roundRobinNodeIterator)
-	if !ok {
-		t.Fatal("wrong iterator type returned")
-	}
-	if rni == nil {
-		t.Fatal("failed to create basic iterator")
-	}
-	if rni.HasNext() || rni.startIdx != 0 || rni.countIdx != 0 {
-		t.Errorf("HasNext on nil node list should not have side effects: %v", rni)
-	}
-	if node := rni.Next(); node != nil {
-		t.Errorf("nil node list does not have next node: %v", node)
+func TestTreeIterator_AcceptAll(t *testing.T) {
+	nodesReserved := newSchedNodeList(0, 5, true)
+	nodes := newSchedNodeList(5, 10, false)
+	nodes = append(nodes, nodesReserved...)
+
+	tree := btree.New(7)
+	for _, n := range nodes {
+		tree.ReplaceOrInsert(nodeRef{
+			node:      n,
+			nodeScore: 1,
+		})
 	}
 
-	// slice with a length of 0: first HasNext call
-	rni, ok = NewRoundRobinNodeIterator(make([]*Node, 0)).(*roundRobinNodeIterator)
-	if !ok {
-		t.Fatal("wrong iterator type returned")
-	}
-	if rni == nil {
-		t.Fatal("failed to create iterator with empty slice")
-	}
-	if rni.HasNext() || rni.startIdx != 0 || rni.countIdx != 0 {
-		t.Errorf("HasNext on empty list should not have side effects: %v", rni)
-	}
-	if node := rni.Next(); node != nil {
-		t.Errorf("empty node list does not have Next: %v", node)
-	}
-	// slice with a length of 0: direct Next call
-	rni, ok = NewRoundRobinNodeIterator(make([]*Node, 0)).(*roundRobinNodeIterator)
-	if !ok {
-		t.Fatal("wrong iterator type returned")
-	}
-	if rni == nil {
-		t.Fatal("failed to create iterator with empty slice")
-	}
-	// Next call first, then HasNext
-	node := rni.Next()
-	if node != nil || rni.startIdx != 0 || rni.countIdx != 0 {
-		t.Errorf("Next on empty list should not have side effects: %v", rni)
-	}
-	if rni.HasNext() {
-		t.Error("empty node list must not return true for HasNext")
-	}
+	treeItr := NewTreeIterator(acceptUnreserved, func() *btree.BTree {
+		return tree
+	})
+
+	checked := make([]*Node, 0)
+	unreservedIds := make(map[int]bool)
+	treeItr.ForEachNode(func(node *Node) bool {
+		checked = append(checked, node)
+		i, err := strconv.Atoi(node.Hostname)
+		assert.NilError(t, err, "conversion failure")
+		unreservedIds[i] = true
+		return true
+	})
+
 }
 
-// test iterating over the slice: random start
-func TestRoundRobinNodeIterating(t *testing.T) {
-	// slice with a length of 5
-	length := 5
-	rni, ok := NewRoundRobinNodeIterator(newSchedNodeList(length)).(*roundRobinNodeIterator)
-	if !ok {
-		t.Fatal("wrong iterator type returned")
-	}
-	if rni == nil {
-		t.Fatal("failed to create iterator with set slice")
-	}
-	start := rni.startIdx
-	if start == -1 {
-		t.Fatal("set node list should have random start set")
-	}
-	// walk over the whole list
-	for i := 0; i < length; i++ {
-		loc := (i + start) % length
-		node := rni.Next()
-		if node == nil || node.NodeID != "node-"+strconv.Itoa(loc) {
-			t.Errorf("incorrect node returned: %v", node)
-		}
-	}
-	// check were we are: should have done the whole slice HasNext is false
-	if rni.HasNext() || rni.countIdx != length {
-		t.Errorf("should have finished the slice expected at: %d, am at: %d", length, rni.countIdx)
-	}
-	if node := rni.Next(); node != nil {
-		t.Errorf("next should not have returned a node: %v", node)
+func TestTreeIterator_AcceptUnreserved(t *testing.T) {
+	nodesReserved := newSchedNodeList(0, 5, true)
+	nodes := newSchedNodeList(5, 10, false)
+	nodes = append(nodes, nodesReserved...)
+
+	tree := btree.New(7)
+	for _, n := range nodes {
+		tree.ReplaceOrInsert(nodeRef{
+			node:      n,
+			nodeScore: 1,
+		})
 	}
 
-	// Reset the iterator
-	rni.Reset()
-	if rni.startIdx != -1 || rni.countIdx != 0 || !rni.HasNext() {
-		t.Fatal("reset did not set counters back")
-	}
-	// next will set a start point and return node
-	node := rni.Next()
-	if node == nil || rni.startIdx == -1 {
-		t.Fatalf("next should have set the start %d, and returned node: %v", rni.startIdx, node)
-	}
-	if node.NodeID != "node-"+strconv.Itoa(rni.startIdx) {
-		t.Errorf("incorrect node returned: %v", node)
-	}
-}
+	treeItr := NewTreeIterator(acceptUnreserved, func() *btree.BTree {
+		return tree
+	})
 
-// base test for default iterator
-func TestDefaultNodeEmpty(t *testing.T) {
-	// nil list
-	dni, ok := NewDefaultNodeIterator(nil).(*defaultNodeIterator)
-	if !ok {
-		t.Fatal("wrong iterator type returned")
-	}
-	if dni == nil {
-		t.Fatal("failed to create basic iterator")
-	}
-	if dni.HasNext() || dni.countIdx != 0 {
-		t.Error("nil node list should not return true on HasNext")
-	}
-	if node := dni.Next(); node != nil {
-		t.Errorf("nil node list does not have next node: %v", node)
-	}
-	// slice with a length of 0
-	dni, ok = NewDefaultNodeIterator(make([]*Node, 0)).(*defaultNodeIterator)
-	if !ok {
-		t.Fatal("wrong iterator type returned")
-	}
-	if dni == nil {
-		t.Fatal("failed to create iterator with empty slice")
-	}
-	if dni.HasNext() {
-		t.Error("empty node list should not return true on HasNext")
-	}
-	if node := dni.Next(); node != nil {
-		t.Errorf("empty node list does not have Next node: %v", node)
-	}
-}
+	checked := make([]*Node, 0)
+	unreservedIds := make(map[int]bool)
+	treeItr.ForEachNode(func(node *Node) bool {
+		checked = append(checked, node)
+		i, err := strconv.Atoi(node.Hostname)
+		assert.NilError(t, err, "conversion failure")
+		unreservedIds[i] = true
+		return true
+	})
 
-// test iterating over the slice: default start
-func TestDefaultNodeIterating(t *testing.T) {
-	// slice with a length of 5
-	length := 5
-	dni, ok := NewDefaultNodeIterator(newSchedNodeList(length)).(*defaultNodeIterator)
-	if !ok {
-		t.Fatal("wrong iterator type returned")
-	}
-	if dni == nil {
-		t.Fatal("failed to create iterator with set slice")
-	}
-	// walk over the whole list
-	for i := 0; i < length; i++ {
-		node := dni.Next()
-		if node == nil || node.NodeID != "node-"+strconv.Itoa(i) {
-			t.Errorf("incorrect node returned: %v", node)
-		}
-	}
-	// check were we are: should have done the whole slice HasNext is false
-	if dni.HasNext() || dni.countIdx != length {
-		t.Errorf("should have finished the slice expected at: %d, am at: %d", length, dni.countIdx)
-	}
-	if node := dni.Next(); node != nil {
-		t.Errorf("next should not have returned a node: %v", node)
-	}
-
-	// Reset the iterator
-	dni.Reset()
-	if dni.countIdx != 0 || !dni.HasNext() {
-		t.Fatalf("reset did not set counter back: %d", dni.countIdx)
-	}
-	// next will restart from the beginning
-	node := dni.Next()
-	if node == nil {
-		t.Fatal("next should have returned a node")
-	}
-	if node.NodeID != "node-0" {
-		t.Errorf("incorrect node returned expected node-0 got: %v", node)
+	assert.Equal(t, 5, len(checked))
+	for i := 5; i < 10; i++ { // node 5-10 are unreserved
+		assert.Assert(t, unreservedIds[i])
 	}
 }
 
 // A list of nodes that can be iterated over.
-func newSchedNodeList(number int) []*Node {
-	list := make([]*Node, number)
-	for i := 0; i < number; i++ {
+func newSchedNodeList(start, end int, reserved bool) []*Node {
+	list := make([]*Node, 0)
+	for i := start; i < end; i++ {
 		num := strconv.Itoa(i)
 		node := newNode("node-"+num, make(map[string]resources.Quantity))
-		list[i] = node
+		node.Hostname = num
+		if reserved {
+			node.reservations = map[string]*reservation{
+				"dummy": {},
+			}
+		}
+		list = append(list, node)
 	}
 	return list
 }

--- a/pkg/scheduler/objects/node_iterator_test.go
+++ b/pkg/scheduler/objects/node_iterator_test.go
@@ -29,47 +29,22 @@ import (
 )
 
 func TestTreeIterator_AcceptAll(t *testing.T) {
-	nodesReserved := newSchedNodeList(0, 5, true)
-	nodes := newSchedNodeList(5, 10, false)
-	nodes = append(nodes, nodesReserved...)
-
-	tree := btree.New(7)
-	for _, n := range nodes {
-		tree.ReplaceOrInsert(nodeRef{
-			node:      n,
-			nodeScore: 1,
-		})
-	}
-
-	treeItr := NewTreeIterator(acceptUnreserved, func() *btree.BTree {
+	tree := getTree()
+	treeItr := NewTreeIterator(acceptAll, func() *btree.BTree {
 		return tree
 	})
 
 	checked := make([]*Node, 0)
-	unreservedIds := make(map[int]bool)
 	treeItr.ForEachNode(func(node *Node) bool {
 		checked = append(checked, node)
-		i, err := strconv.Atoi(node.Hostname)
-		assert.NilError(t, err, "conversion failure")
-		unreservedIds[i] = true
 		return true
 	})
 
+	assert.Equal(t, 10, len(checked))
 }
 
 func TestTreeIterator_AcceptUnreserved(t *testing.T) {
-	nodesReserved := newSchedNodeList(0, 5, true)
-	nodes := newSchedNodeList(5, 10, false)
-	nodes = append(nodes, nodesReserved...)
-
-	tree := btree.New(7)
-	for _, n := range nodes {
-		tree.ReplaceOrInsert(nodeRef{
-			node:      n,
-			nodeScore: 1,
-		})
-	}
-
+	tree := getTree()
 	treeItr := NewTreeIterator(acceptUnreserved, func() *btree.BTree {
 		return tree
 	})
@@ -88,6 +63,22 @@ func TestTreeIterator_AcceptUnreserved(t *testing.T) {
 	for i := 5; i < 10; i++ { // node 5-10 are unreserved
 		assert.Assert(t, unreservedIds[i])
 	}
+}
+
+func getTree() *btree.BTree {
+	nodesReserved := newSchedNodeList(0, 5, true)
+	nodes := newSchedNodeList(5, 10, false)
+	nodes = append(nodes, nodesReserved...)
+
+	tree := btree.New(7)
+	for _, n := range nodes {
+		tree.ReplaceOrInsert(nodeRef{
+			node:      n,
+			nodeScore: 1,
+		})
+	}
+
+	return tree
 }
 
 // A list of nodes that can be iterated over.

--- a/pkg/scheduler/objects/nodesorting_test.go
+++ b/pkg/scheduler/objects/nodesorting_test.go
@@ -157,10 +157,6 @@ func TestSortPolicyWeighting(t *testing.T) {
 	nc.SetNodeSortingPolicy(fair)
 	totalRes := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 2000, "memory": 16000})
 
-	if nc.GetNodeIterator() != nil {
-		t.Fatal("Shouldn't have any nodes when there are not any nodes in nodeCollection.")
-	}
-
 	proto1 := newProto("test1", totalRes, nil, map[string]string{})
 	node1 := NewNode(proto1)
 	if err := nc.AddNode(node1); err != nil {
@@ -196,9 +192,10 @@ func TestSortPolicyWeighting(t *testing.T) {
 
 	// node1 should be first as it is the least-loaded
 	nodes := make([]*Node, 0)
-	for it := nc.GetNodeIterator(); it.HasNext(); {
-		nodes = append(nodes, it.Next())
-	}
+	nc.GetNodeIterator().ForEachNode(func(node *Node) bool {
+		nodes = append(nodes, node)
+		return true
+	})
 
 	assert.Equal(t, 2, len(nodes), "node length != 2")
 	assert.Equal(t, node1.NodeID, nodes[0].NodeID, "wrong initial node (fair)")
@@ -209,9 +206,10 @@ func TestSortPolicyWeighting(t *testing.T) {
 
 	// node2 should now be first as it is most-loaded
 	nodes = make([]*Node, 0)
-	for it := nc.GetNodeIterator(); it.HasNext(); {
-		nodes = append(nodes, it.Next())
-	}
+	nc.GetNodeIterator().ForEachNode(func(node *Node) bool {
+		nodes = append(nodes, node)
+		return true
+	})
 
 	assert.Equal(t, 2, len(nodes), "node length != 2")
 	assert.Equal(t, node2.NodeID, nodes[0].NodeID, "wrong initial node (binpacking)")
@@ -239,9 +237,10 @@ func TestSortPolicy(t *testing.T) {
 
 	// nodes should be in ascending order before any allocations
 	nodes := make([]*Node, 0)
-	for it := nc.GetNodeIterator(); it.HasNext(); {
-		nodes = append(nodes, it.Next())
-	}
+	nc.GetNodeIterator().ForEachNode(func(node *Node) bool {
+		nodes = append(nodes, node)
+		return true
+	})
 	assert.Equal(t, 2, len(nodes), "node length != 2")
 	assert.Equal(t, node1.NodeID, nodes[0].NodeID, "wrong initial node (binpacking, empty allocation)")
 	assert.Equal(t, node2.NodeID, nodes[1].NodeID, "wrong second node (binpacking, empty allocation)")
@@ -250,9 +249,10 @@ func TestSortPolicy(t *testing.T) {
 	nc.SetNodeSortingPolicy(fair)
 
 	nodes = make([]*Node, 0)
-	for it := nc.GetNodeIterator(); it.HasNext(); {
-		nodes = append(nodes, it.Next())
-	}
+	nc.GetNodeIterator().ForEachNode(func(node *Node) bool {
+		nodes = append(nodes, node)
+		return true
+	})
 	assert.Equal(t, 2, len(nodes), "node length != 2")
 	assert.Equal(t, node1.NodeID, nodes[0].NodeID, "wrong initial node (fair, empty allocation)")
 	assert.Equal(t, node2.NodeID, nodes[1].NodeID, "wrong second node (fair, empty allocation)")
@@ -267,10 +267,10 @@ func TestSortPolicy(t *testing.T) {
 
 	// node2 should now be first as it is the highest-loaded
 	nodes = make([]*Node, 0)
-	for it := nc.GetNodeIterator(); it.HasNext(); {
-		nodes = append(nodes, it.Next())
-	}
-
+	nc.GetNodeIterator().ForEachNode(func(node *Node) bool {
+		nodes = append(nodes, node)
+		return true
+	})
 	assert.Equal(t, 2, len(nodes), "node length != 2")
 	assert.Equal(t, node2.NodeID, nodes[0].NodeID, "wrong initial node (binpacking, node2 half-filled)")
 	assert.Equal(t, node1.NodeID, nodes[1].NodeID, "wrong second node (binpacking, node2 half-filled")
@@ -280,9 +280,10 @@ func TestSortPolicy(t *testing.T) {
 
 	// node1 should again be first, as it is least-loaded
 	nodes = make([]*Node, 0)
-	for it := nc.GetNodeIterator(); it.HasNext(); {
-		nodes = append(nodes, it.Next())
-	}
+	nc.GetNodeIterator().ForEachNode(func(node *Node) bool {
+		nodes = append(nodes, node)
+		return true
+	})
 	assert.Equal(t, 2, len(nodes), "node length != 2")
 	assert.Equal(t, node1.NodeID, nodes[0].NodeID, "wrong initial node (fair, node2 half-filled)")
 	assert.Equal(t, node2.NodeID, nodes[1].NodeID, "wrong second node (binpacking, node2 half-filled")

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -163,8 +163,7 @@ func (p *Preemptor) initWorkingState() {
 	}
 
 	// walk node iterator and track available resources per node
-	for p.iterator.HasNext() {
-		node := p.iterator.Next()
+	p.iterator.ForEachNode(func(node *Node) bool {
 		if !node.IsSchedulable() || (node.IsReserved() && !node.isReservedForApp(reservationKey(nil, p.application, p.ask))) {
 			// node is not available, remove any potential victims from consideration
 			delete(allocationsByNode, node.NodeID)
@@ -172,7 +171,8 @@ func (p *Preemptor) initWorkingState() {
 			// track allocated and available resources
 			nodeAvailableMap[node.NodeID] = node.GetAvailableResource()
 		}
-	}
+		return true
+	})
 
 	// sort the allocations on each node in the order we'd like to try them
 	sortVictimsForPreemption(allocationsByNode)

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -34,8 +34,7 @@ import (
 
 func TestCheckPreconditions(t *testing.T) {
 	node := newNode("node1", map[string]resources.Quantity{"first": 5})
-	nodes := []*Node{node}
-	iterator := func() NodeIterator { return NewDefaultNodeIterator(nodes) }
+	iterator := getNodeIteratorFn(node)
 	rootQ, err := createRootQueue(map[string]string{"first": "5"})
 	assert.NilError(t, err)
 	childQ, err := createManagedQueue(rootQ, "child", false, map[string]string{"first": "5"})
@@ -92,8 +91,7 @@ func TestCheckPreconditions(t *testing.T) {
 
 func TestCheckPreemptionQueueGuarantees(t *testing.T) {
 	node := newNode("node1", map[string]resources.Quantity{"first": 20})
-	nodes := []*Node{node}
-	iterator := func() NodeIterator { return NewDefaultNodeIterator(nodes) }
+	iterator := getNodeIteratorFn(node)
 	rootQ, err := createRootQueue(map[string]string{"first": "20"})
 	assert.NilError(t, err)
 	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"first": "20"}, map[string]string{"first": "10"})
@@ -132,7 +130,7 @@ func TestCheckPreemptionQueueGuarantees(t *testing.T) {
 
 func TestTryPreemption(t *testing.T) {
 	node := newNode("node1", map[string]resources.Quantity{"first": 10, "pods": 5})
-	iterator := getTreeIteratorFunc(node)
+	iterator := getNodeIteratorFn(node)
 	rootQ, err := createRootQueue(map[string]string{"first": "20", "pods": "5"})
 	assert.NilError(t, err)
 	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"first": "20"}, map[string]string{"first": "10"})

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -132,8 +132,7 @@ func TestCheckPreemptionQueueGuarantees(t *testing.T) {
 
 func TestTryPreemption(t *testing.T) {
 	node := newNode("node1", map[string]resources.Quantity{"first": 10, "pods": 5})
-	nodes := []*Node{node}
-	iterator := func() NodeIterator { return NewDefaultNodeIterator(nodes) }
+	iterator := getTreeIteratorFunc(node)
 	rootQ, err := createRootQueue(map[string]string{"first": "20", "pods": "5"})
 	assert.NilError(t, err)
 	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"first": "20"}, map[string]string{"first": "10"})


### PR DESCRIPTION
### What is this PR for?
Improve the performance of node iterators by not creating a sorted slice all the time.
The iterator is reset at each call: we always get a fresh "clone" from `BTree.Clone()`, so tree walking is not affected by concurrent mutations.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1716

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
