### PR TITLE
[YUNIKORN-1754] Data race in TestStoreWithLimitedSize

### DIFF
--- a/pkg/events/event_publisher_test.go
+++ b/pkg/events/event_publisher_test.go
@@ -82,8 +82,8 @@ func TestServiceStartStopInternal(t *testing.T) {
 	store := newEventStoreImpl()
 	publisher := createShimPublisherInternal(store)
 	publisher.StartService()
+	defer publisher.Stop()
 	assert.Equal(t, publisher.getEventStore(), store)
-	publisher.Stop()
 }
 
 func TestNoFillWithoutEventPluginRegistered(t *testing.T) {
@@ -92,6 +92,7 @@ func TestNoFillWithoutEventPluginRegistered(t *testing.T) {
 	store := newEventStoreImpl()
 	publisher := createShimPublisherWithParameters(store, pushEventInterval)
 	publisher.StartService()
+	defer publisher.Stop()
 
 	event := &si.EventRecord{
 		Type:          si.EventRecord_REQUEST,
@@ -118,6 +119,7 @@ func TestPublisherSendsEvent(t *testing.T) {
 	store := newEventStoreImpl()
 	publisher := createShimPublisherWithParameters(store, pushEventInterval)
 	publisher.StartService()
+	defer publisher.Stop()
 
 	event := &si.EventRecord{
 		Type:          si.EventRecord_REQUEST,
@@ -139,6 +141,4 @@ func TestPublisherSendsEvent(t *testing.T) {
 	assert.Equal(t, eventFromPlugin.Reason, "reason")
 	assert.Equal(t, eventFromPlugin.Message, "message")
 	assert.Equal(t, eventFromPlugin.TimestampNano, int64(123456))
-
-	publisher.Stop()
 }


### PR DESCRIPTION
### What is this PR for?
Data race can occur in a `TestStoreWithLimitedSize` because the event publisher is not closed properly.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1754

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
