### PR TITLE
[YUNIKORN-1764] Don't copy resource object in Node.preAllocateCheck()

### DIFF
--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -399,10 +399,10 @@ func (sn *Node) preAllocateCheck(res *resources.Resource, resKey string) bool {
 		}
 	}
 
-	// check if resources are available
-	available := sn.GetAvailableResource()
+	sn.RLock()
+	defer sn.RUnlock()
 	// returns true/false based on if the request fits in what we have calculated
-	return available.FitInMaxUndef(res)
+	return sn.availableResource.FitInMaxUndef(res)
 }
 
 // Return if the node has been reserved by any application


### PR DESCRIPTION
### What is this PR for?
`Node.preAllocateCheck()` calls `Node.GetAvailableResource()` very often because it's inside the scheduling cycle. This results in a lot of object cloning. This is not needed, a simple fix gets rid of the cloning.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1764

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
