### PR TITLE
[YUNIKORN-1770] Avoid resource clone in Application.tryNodes()

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -1456,7 +1456,7 @@ func (sa *Application) tryNodes(ask *AllocationAsk, iterator NodeIterator) *Allo
 				zap.Time("createTime", ask.GetCreateTime()),
 				zap.Duration("askAge", askAge),
 				zap.Duration("reservationDelay", reservationDelay))
-			score := ask.GetAllocatedResource().FitInScore(node.GetAvailableResource())
+			score := node.GetFitInScoreForAvailableResource(ask.GetAllocatedResource())
 			// Record the so-far best node to reserve
 			if score < scoreReserved {
 				scoreReserved = score

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -255,6 +255,14 @@ func (sn *Node) GetAvailableResource() *resources.Resource {
 	return sn.availableResource.Clone()
 }
 
+// GetFitInScoreForAvailableResource calculates a fit in score for "res" based on the current
+// available resources, avoiding cloning. The caller must ensure that "res" cannot change while this method is running.
+func (sn *Node) GetFitInScoreForAvailableResource(res *resources.Resource) float64 {
+	sn.RLock()
+	defer sn.RUnlock()
+	return res.FitInScore(sn.availableResource)
+}
+
 // Get the utilized resource on this node.
 func (sn *Node) GetUtilizedResource() *resources.Resource {
 	total := sn.GetCapacity()


### PR DESCRIPTION
### What is this PR for?
We can avoid cloning the Resource object in `Application.tryNodes()`. On a busy cluster where nodes are full, the "fit in" score calculation runs very often, resulting in allocating a lot of resource objects constantly. 


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1770

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
