### PR TITLE
[YUNIKORN-1835] User belong to zero or multiple groups

### DIFF
--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -1602,34 +1602,34 @@ func TestIncAndDecUserResourceUsageInSameGroup(t *testing.T) {
 
 	// Increase testuser
 	app.incUserResourceUsage(res)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), res, res, 0)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), nil, res, 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), res, nil, 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), nil, nil, 0)
 
 	// Increase both testuser and testuser2 with the same group testgroup
 	app.incUserResourceUsage(res)
 	app2.incUserResourceUsage(resources.Multiply(res, 2))
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), resources.Multiply(res, 2), resources.Multiply(res, 4), 0)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), resources.Multiply(res, 2), resources.Multiply(res, 4), 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), resources.Multiply(res, 2), nil, 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), resources.Multiply(res, 2), nil, 0)
 
 	// Increase nil
 	app.decUserResourceUsage(nil, false)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), resources.Multiply(res, 2), resources.Multiply(res, 4), 0)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), resources.Multiply(res, 2), resources.Multiply(res, 4), 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), resources.Multiply(res, 2), nil, 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), resources.Multiply(res, 2), nil, 0)
 
 	// Decrease testuser
 	app.decUserResourceUsage(res, false)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), res, resources.Multiply(res, 3), 0)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), resources.Multiply(res, 2), resources.Multiply(res, 3), 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), res, nil, 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), resources.Multiply(res, 2), nil, 0)
 
 	// Decrease testuser2
 	app2.decUserResourceUsage(res, false)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), res, resources.Multiply(res, 2), 0)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), res, resources.Multiply(res, 2), 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), res, nil, 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), res, nil, 0)
 
 	// Decrease testuser and testuser2 to 0
 	app.decUserResourceUsage(res, false)
 	app2.decUserResourceUsage(res, false)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}), 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}), nil, 0)
 }
 
 func TestGetAllRequests(t *testing.T) {

--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -264,7 +264,7 @@ func assertUserGroupResource(t *testing.T, userGroup security.UserGroup, expecte
 	userResource := ugm.GetUserResources(userGroup)
 	groupResource := ugm.GetGroupResources(userGroup.Groups[0])
 	assert.Equal(t, resources.Equals(userResource, expected), true)
-	assert.Equal(t, resources.Equals(groupResource, expected), true)
+	assert.Equal(t, resources.Equals(groupResource, nil), true)
 }
 
 func assertUserResourcesAndGroupResources(t *testing.T, userGroup security.UserGroup, expectedUserResources *resources.Resource, expectedGroupResources *resources.Resource, i int) {

--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -44,6 +44,9 @@ func newGroupTracker(group string) *GroupTracker {
 }
 
 func (gt *GroupTracker) increaseTrackedResource(queuePath, applicationID string, usage *resources.Resource) bool {
+	if gt == nil {
+		return true
+	}
 	gt.Lock()
 	defer gt.Unlock()
 	gt.applications[applicationID] = true
@@ -51,6 +54,9 @@ func (gt *GroupTracker) increaseTrackedResource(queuePath, applicationID string,
 }
 
 func (gt *GroupTracker) decreaseTrackedResource(queuePath, applicationID string, usage *resources.Resource, removeApp bool) (bool, bool) {
+	if gt == nil {
+		return false, true
+	}
 	gt.Lock()
 	defer gt.Unlock()
 	if removeApp {
@@ -120,4 +126,11 @@ func (gt *GroupTracker) removeApp(applicationID string) {
 	gt.Lock()
 	defer gt.Unlock()
 	delete(gt.applications, applicationID)
+}
+
+func (gt *GroupTracker) getName() string {
+	if gt == nil {
+		return ""
+	}
+	return gt.groupName
 }

--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -115,3 +115,9 @@ func (gt *GroupTracker) canBeRemoved() bool {
 	defer gt.RUnlock()
 	return len(gt.queueTracker.childQueueTrackers) == 0 && len(gt.queueTracker.runningApplications) == 0
 }
+
+func (gt *GroupTracker) removeApp(applicationID string) {
+	gt.Lock()
+	defer gt.Unlock()
+	delete(gt.applications, applicationID)
+}

--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -669,8 +669,8 @@ func (m *Manager) Headroom(queuePath string, user security.UserGroup) *resources
 			zap.String("queue path", queuePath),
 			zap.String("user headroom", userHeadroom.String()))
 	}
-	group, err := m.getGroup(user)
-	if err == nil {
+	group := m.internalEnsureGroup(user, queuePath)
+	if group != "" {
 		if m.groupTrackers[group] != nil {
 			groupHeadroom = m.groupTrackers[group].headroom(queuePath)
 			log.Log(log.SchedUGM).Debug("Calculated headroom for group",

--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -486,8 +486,9 @@ func (m *Manager) clearEarlierSetLimits(userLimits map[string]bool, groupLimits 
 							zap.String("group", gt.groupName),
 							zap.String("application id", appID),
 							zap.String("queue path", queuePath))
-						// to do: removing the linkage only happens here by setting it to nil and deleting app id
+						// removing the linkage only happens here by setting it to nil and deleting app id
 						// but group resource usage so far remains as it is because we don't have app id wise resource usage with in group as of now.
+						// YUNIKORN-1858 handles the group resource usage properly
 						// In case of only one (last) application, group tracker would be removed from the manager.
 						ut.setGroupForApp(appID, nil)
 						gt.removeApp(appID)

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -49,7 +49,7 @@ func TestGetGroup(t *testing.T) {
 	user1 := security.UserGroup{User: "test", Groups: []string{"test1", "test"}}
 	group = manager.ensureGroup(user1, "root.parent")
 	assert.Equal(t, group, "test")
-	
+
 	conf = createConfigWithoutLimits()
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -40,16 +40,19 @@ func TestGetGroup(t *testing.T) {
 	user := security.UserGroup{User: "test", Groups: []string{"test", "test1"}}
 	manager := GetUserManager()
 
+	// create config with limits for "test" group and ensure picked up group is "test"
 	conf := createUpdateConfig(user.User, user.Groups[0])
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
 	group := manager.ensureGroup(user, "root.parent.leaf")
 	assert.Equal(t, group, "test")
 
+	// Even though ordering of groups has been changed in UserGroup obj, still "test" should be picked up
 	user1 := security.UserGroup{User: "test", Groups: []string{"test1", "test"}}
 	group = manager.ensureGroup(user1, "root.parent")
 	assert.Equal(t, group, "test")
 
+	// clear all configs and ensure there is no tracking for "test" group as there is no matching
 	conf = createConfigWithoutLimits()
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
@@ -58,10 +61,12 @@ func TestGetGroup(t *testing.T) {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
 	}
 
-	increased := manager.IncreaseTrackedResource("root.parent.leaf", TestApp1, usage1, user)
+	increased := manager.IncreaseTrackedResource("root.parent.leaf", TestApp1, usage1, user1)
 	if !increased {
 		t.Errorf("unable to increase tracked resource. queuepath: root.parent.leaf, application id: %s, resource usage: %s, user: %s", TestApp1, usage1.String(), user.User)
 	}
+	assert.Equal(t, len(manager.userTrackers), 1)
+	assert.Equal(t, len(manager.groupTrackers), 0)
 
 	group = manager.ensureGroup(user1, "root.parent.leaf")
 	assert.Equal(t, group, "")
@@ -70,6 +75,9 @@ func TestGetGroup(t *testing.T) {
 	group = manager.ensureGroup(user1, "root")
 	assert.Equal(t, group, "")
 
+	// create config with groups as "test_root" for root queue path and "test_parent" for root.parent queue path but no group defined for
+	// "root.parent.leaf" queue path. ensure immediate parent queue path "root.parent" has been used for group matching and picked.
+	// once group has been matched, it doesn't change for other queue paths and should not change because lowest level queue group should be used
 	user = security.UserGroup{User: "test1", Groups: []string{"test", "test_root", "test_parent"}}
 	conf = createConfigWithDifferentGroups(user.User, user.Groups[0], "memory", "10", 50, 5)
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
@@ -77,11 +85,18 @@ func TestGetGroup(t *testing.T) {
 	assert.Equal(t, group, "test_parent")
 	group = manager.ensureGroup(user, "root.parent")
 	assert.Equal(t, group, "test_parent")
+	group = manager.ensureGroup(user, "root")
+	assert.Equal(t, group, "test_parent")
+
+	// create config with groups as "test_root" for root queue path and "test_parent" for root.parent queue path but no group defined for
+	// "root.parent.leaf" queue path. Passing just "root" as queue path returns "test_root" as searching starts from lowest level queue in entire queue path
 	conf = createConfigWithDifferentGroups(user.User, user.Groups[0], "memory", "10", 50, 5)
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 	group = manager.ensureGroup(user, "root")
 	assert.Equal(t, group, "test_root")
 
+	// create config with groups as "test_root" for root queue path and "test_parent" for root.parent queue path but no group defined for
+	// "root.parent.leaf" queue path. since "test_parent" group is not defined in UserGroup obj, "test_root" would be matched and picked.
 	user = security.UserGroup{User: "test1", Groups: []string{"test", "test_root"}}
 	conf = createConfigWithDifferentGroups(user.User, user.Groups[0], "memory", "10", 50, 5)
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
@@ -90,15 +105,49 @@ func TestGetGroup(t *testing.T) {
 	group = manager.ensureGroup(user, "root")
 	assert.Equal(t, group, "test_root")
 
-	user = security.UserGroup{User: "test1", Groups: []string{}}
-	conf = createConfigWithDifferentGroups(user.User, "", "memory", "10", 50, 5)
+	// do some activities with different users - user "test1" and "test2" belongs to "test_root" group
+	// ensure user "test1" and "test2" and its group linkage is intact through appGroupTrackers map
+	increased = manager.IncreaseTrackedResource("root.parent.leaf", TestApp1, usage1, user)
+	if !increased {
+		t.Errorf("unable to increase tracked resource. queuepath: root.parent.leaf, application id: %s, resource usage: %s, user: %s", TestApp1, usage1.String(), user.User)
+	}
+	assert.Equal(t, len(manager.userTrackers), 2)
+
+	user2 := security.UserGroup{User: "test2", Groups: []string{"test", "test_root"}}
+	increased = manager.IncreaseTrackedResource("root.parent.leaf", TestApp2, usage1, user2)
+	if !increased {
+		t.Errorf("unable to increase tracked resource. queuepath: root.parent.leaf, application id: %s, resource usage: %s, user: %s", TestApp2, usage1.String(), user2.User)
+	}
+	assert.Equal(t, len(manager.userTrackers), 3)
+
+	ut := manager.getUserTracker(user.User, false)
+	actualGT := ut.appGroupTrackers[TestApp1]
+	expectedGT := manager.getGroupTracker("test_root", false)
+	assert.Equal(t, manager.getGroupTracker("test_root", false) != nil, true)
+	assert.Equal(t, actualGT, expectedGT)
+	assert.Equal(t, actualGT.groupName, "test_root")
+
+	ut = manager.getUserTracker(user2.User, false)
+	actualGT = ut.appGroupTrackers[TestApp2]
+	expectedGT = manager.getGroupTracker("test_root", false)
+	assert.Equal(t, manager.getGroupTracker("test_root", false) != nil, true)
+	assert.Equal(t, actualGT, expectedGT)
+	assert.Equal(t, actualGT.groupName, "test_root")
+
+	assert.Equal(t, len(manager.userTrackers), 3)
+	assert.Equal(t, len(manager.groupTrackers), 2)
+
+	// create config without any limit settings for groups and
+	// since earlier group (test_root) limit settings has been cleared, ensure earlier user and group linkage through appGroupTrackers map has been removed
+	// and cleared as necessary
+	conf = createConfigWithDifferentGroups(user2.User, "", "memory", "10", 50, 5)
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
-	group = manager.ensureGroup(user, "root.parent.leaf")
-	assert.Equal(t, group, "")
-	group = manager.ensureGroup(user, "root.parent")
-	assert.Equal(t, group, "")
-	group = manager.ensureGroup(user, "root")
-	assert.Equal(t, group, "")
+	assert.Equal(t, len(manager.userTrackers), 3)
+	assert.Equal(t, len(manager.groupTrackers), 0)
+
+	ut = manager.getUserTracker(user.User, false)
+	assert.Equal(t, ut.appGroupTrackers[TestApp1] == nil, true)
+	assert.Equal(t, manager.getGroupTracker("test_root", false) == nil, true)
 }
 
 func TestAddRemoveUserAndGroups(t *testing.T) {
@@ -288,66 +337,59 @@ func TestUpdateConfigWithWildCardUsersAndGroups(t *testing.T) {
 		}
 	}
 
-	// configure max resource for root.parent to allow one more application to run
+	// configure max resource for root.parent as map[memory:60 vcores:60] to allow one more application to run
 	conf = createConfig(user.User, user.Groups[0], "memory", "50", 60, 6)
 	err = manager.UpdateConfig(conf.Queues[0], "root")
 	assert.NilError(t, err, "unable to set the limit for user user1 because current resource usage is greater than config max resource for root.parent")
 
 	// should run as user 'user' setting is map[memory:60 vcores:60] and total usage of "root.parent" is map[memory:50 vcores:50]
-	increased := manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user)
+	increased := manager.IncreaseTrackedResource(queuePath1, TestApp2, usage, user)
 	if !increased {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
 	}
 
 	// should not run as user 'user' setting is map[memory:60 vcores:60] and total usage of "root.parent" is map[memory:60 vcores:60]
-	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user)
+	increased = manager.IncreaseTrackedResource(queuePath1, TestApp3, usage, user)
 	if increased {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
 	}
 
 	// configure max resource for root.parent to allow one more application to run through wild card user settings (not through specific user)
-	user1 := security.UserGroup{User: "user2", Groups: []string{"group2"}}
+	// configure limits for user2 only. However, user1 should not be cleared as it has running applications
+	user1 := security.UserGroup{User: "user2", Groups: []string{"group1"}}
 	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0], "*", "*", "70", "70")
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+	// ensure both user1 & group1 has not been removed from local maps
+	assert.Equal(t, manager.GetUserTracker(user.User) != nil, true)
+	assert.Equal(t, manager.GetGroupTracker(user.Groups[0]) != nil, true)
 
-	// should run as wild card user '*' setting is map[memory:70 vcores:70] and total usage of "root.parent" is map[memory:60 vcores:60]
-	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user)
+	// user1 still should be able to run app as wild card user '*' setting is map[memory:70 vcores:70] for "root.parent" and
+	// total usage of "root.parent" is map[memory:60 vcores:60]
+	increased = manager.IncreaseTrackedResource(queuePath1, TestApp2, usage, user)
 	if !increased {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
+		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp2, user1)
 	}
 
-	// should not run as wild card user '*' setting is map[memory:70 vcores:70] and total usage of "root.parent" is map[memory:70 vcores:70]
-	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user)
+	// user1 should not be able to run app as wild card user '*' setting is map[memory:70 vcores:70] for "root.parent"
+	// and total usage of "root.parent" is map[memory:70 vcores:70]
+	increased = manager.IncreaseTrackedResource(queuePath1, TestApp3, usage, user)
 	if increased {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
+		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp3, user1)
 	}
 
-	// configure max resource for root.parent to allow one more application to run through wild card group settings (not through specific group)
-	// also wild card user limit settings not set
-	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0], "", "*", "80", "80")
+	// configure max resource for group1 * root.parent (map[memory:70 vcores:70]) higher than wild card group * root.parent settings (map[memory:10 vcores:10])
+	// ensure group's specific settings has been used for enforcement checks as specific limits always has higher precedence when compared to wild card group limit settings
+	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0], "*", "*", "10", "10")
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
-	// should run as wild card group '*' setting is map[memory:80 vcores:80] and total usage of "root.parent" is map[memory:70 vcores:70]
-	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user)
-	if !increased {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
-	}
-
-	// should not run as wild card group '*' setting is map[memory:80 vcores:80] and total usage of "root.parent" is map[memory:80 vcores:80]
-	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user)
-	if increased {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
-	}
-
-	// should run as wild card group '*' setting is map[memory:80 vcores:80] and total usage of "root.parent" is map[memory:70 vcores:70]
 	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user1)
-	if !increased {
+	if increased {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user1)
 	}
 
 	// configure max resource for user2 * root.parent (map[memory:70 vcores:70]) higher than wild card user * root.parent settings (map[memory:10 vcores:10])
-	// ensure user's specific settings overrides the wild card user limit settings
-	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0], "*", "*", "10", "10")
+	// ensure user's specific settings has been used for enforcement checks as specific limits always has higher precedence when compared to wild card user limit settings
+	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, "", "*", "*", "10", "10")
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
 	// can be allowed to run upto resource usage map[memory:70 vcores:70]
@@ -358,7 +400,7 @@ func TestUpdateConfigWithWildCardUsersAndGroups(t *testing.T) {
 		}
 	}
 
-	// should not run as user2 max limit is map[memory:70 vcores:70] and usage so far is map[memory:70 vcores:70]
+	// user2 should not be able to run app as user2 max limit is map[memory:70 vcores:70] and usage so far is map[memory:70 vcores:70]
 	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user1)
 	if increased {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
@@ -381,7 +423,8 @@ func TestUpdateConfigClearEarlierSetLimits(t *testing.T) {
 	}
 	assertMaxLimits(t, user, expectedResource, 5)
 
-	// create config user2 * root.parent with [50, 50] and maxapps as 5 (twice for root), but not user1. so user1 should not be there as it doesn't have any running applications
+	// create config user2 * root.parent with [50, 50] and maxapps as 5 (twice for root), but not user1.
+	// so user1 should not be there as it doesn't have any running applications
 	user1 := security.UserGroup{User: "user2", Groups: []string{"group2"}}
 	conf = createUpdateConfig(user1.User, user1.Groups[0])
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
@@ -404,8 +447,8 @@ func TestUpdateConfigClearEarlierSetLimits(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, expectedResource)
 	}
-	assert.Equal(t, manager.GetUserTracker(user.User) == nil, true)
-	assert.Equal(t, manager.GetGroupTracker(user.Groups[0]) == nil, true)
+	assert.Equal(t, manager.GetUserTracker(user1.User) != nil, true)
+	assert.Equal(t, manager.GetGroupTracker(user1.Groups[0]) != nil, true)
 	assertMaxLimits(t, user1, expectedResource, 6)
 
 	expectedResource, err = resources.NewResourceFromConf(map[string]string{"memory": "70", "vcores": "70"})
@@ -417,8 +460,8 @@ func TestUpdateConfigClearEarlierSetLimits(t *testing.T) {
 	// and wild card settings
 	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0], "*", "*", "10", "10")
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
-	assert.Equal(t, manager.GetUserTracker(user.User) == nil, true)
-	assert.Equal(t, manager.GetGroupTracker(user.Groups[0]) == nil, true)
+	assert.Equal(t, manager.GetUserTracker(user1.User) != nil, true)
+	assert.Equal(t, manager.GetGroupTracker(user1.Groups[0]) != nil, true)
 	assertMaxLimits(t, user1, expectedResource, 10)
 	assertWildCardLimits(t, m.userWildCardLimitsConfig, expectedResource)
 	assertWildCardLimits(t, m.groupWildCardLimitsConfig, expectedResource)
@@ -701,6 +744,16 @@ func createConfig(user string, group string, resourceKey string, resourceValue s
 }
 
 func createConfigWithDifferentGroups(user string, group string, resourceKey string, resourceValue string, mem int, maxApps uint64) configs.PartitionConfig {
+	var rootGroups []string
+	var parentGroups []string
+	if group != "" {
+		parentGroups = []string{
+			group + "_parent",
+		}
+		rootGroups = []string{
+			group + "_root",
+		}
+	}
 	conf := configs.PartitionConfig{
 		Name: "test",
 		Queues: []configs.QueueConfig{
@@ -720,9 +773,7 @@ func createConfigWithDifferentGroups(user string, group string, resourceKey stri
 								Users: []string{
 									user,
 								},
-								Groups: []string{
-									group + "_parent",
-								},
+								Groups: parentGroups,
 								MaxResources: map[string]string{
 									"memory": strconv.Itoa(mem),
 									"vcores": strconv.Itoa(mem),
@@ -738,9 +789,7 @@ func createConfigWithDifferentGroups(user string, group string, resourceKey stri
 						Users: []string{
 							user,
 						},
-						Groups: []string{
-							group + "_root",
-						},
+						Groups: rootGroups,
 						MaxResources: map[string]string{
 							"memory": strconv.Itoa(mem * 2),
 							"vcores": strconv.Itoa(mem * 2),

--- a/pkg/scheduler/ugm/queue_tracker.go
+++ b/pkg/scheduler/ugm/queue_tracker.go
@@ -152,6 +152,7 @@ func (qt *QueueTracker) increaseTrackedResource(queuePath string, applicationID 
 	log.Log(log.SchedUGM).Debug("Successfully increased resource usage",
 		zap.Int("tracking type", int(trackType)),
 		zap.String("queue path", queuePath),
+		zap.String("qt queue path", qt.queuePath),
 		zap.String("application", applicationID),
 		zap.Bool("existing app", existingApp),
 		zap.Stringer("resource", usage),

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -21,7 +21,10 @@ package ugm
 import (
 	"sync"
 
+	"go.uber.org/zap"
+
 	"github.com/apache/yunikorn-core/pkg/common/resources"
+	"github.com/apache/yunikorn-core/pkg/log"
 	"github.com/apache/yunikorn-core/pkg/webservice/dao"
 )
 
@@ -34,10 +37,6 @@ type UserTracker struct {
 	// and group tracker object as value.
 	appGroupTrackers map[string]*GroupTracker
 	queueTracker     *QueueTracker // Holds the actual resource usage of queue path where application runs
-	// Group selected by matching the list of groups stored in security.UserGroup against the list of groups [Manager.configuredGroups] configured with limit settings.
-	// Manager.configuredGroups holds group only for which limit has been configured in bottom up queue hierarchical order starting from leaf to root.
-	// First matched group would be picked and stored in this variable
-	matchedGroup string
 
 	sync.RWMutex
 }
@@ -55,7 +54,28 @@ func newUserTracker(user string) *UserTracker {
 func (ut *UserTracker) increaseTrackedResource(queuePath, applicationID string, usage *resources.Resource) bool {
 	ut.Lock()
 	defer ut.Unlock()
-	return ut.queueTracker.increaseTrackedResource(queuePath, applicationID, user, usage)
+	increased := ut.queueTracker.increaseTrackedResource(queuePath, applicationID, user, usage)
+	if increased {
+		gt := ut.appGroupTrackers[applicationID]
+		log.Log(log.SchedUGM).Debug("Increasing resource usage for group",
+			zap.String("group", gt.getName()),
+			zap.String("queue path", queuePath),
+			zap.String("application", applicationID),
+			zap.Stringer("resource", usage))
+		increasedGroupUsage := gt.increaseTrackedResource(queuePath, applicationID, usage)
+		if !increasedGroupUsage {
+			_, decreased := ut.queueTracker.decreaseTrackedResource(queuePath, applicationID, usage, false)
+			if !decreased {
+				log.Log(log.SchedUGM).Error("Problem in increasing group resource usage. Hence tried to rollback user tracked usage, but failed to do.",
+					zap.String("queue path", queuePath),
+					zap.String("application", applicationID),
+					zap.String("user", ut.userName),
+					zap.Stringer("usage", usage))
+			}
+		}
+		return increasedGroupUsage
+	}
+	return increased
 }
 
 func (ut *UserTracker) decreaseTrackedResource(queuePath, applicationID string, usage *resources.Resource, removeApp bool) (bool, bool) {
@@ -70,7 +90,8 @@ func (ut *UserTracker) decreaseTrackedResource(queuePath, applicationID string, 
 func (ut *UserTracker) hasGroupForApp(applicationID string) bool {
 	ut.RLock()
 	defer ut.RUnlock()
-	return ut.appGroupTrackers[applicationID] != nil
+	_, ok := ut.appGroupTrackers[applicationID]
+	return ok
 }
 
 func (ut *UserTracker) setGroupForApp(applicationID string, groupTrack *GroupTracker) {
@@ -79,22 +100,13 @@ func (ut *UserTracker) setGroupForApp(applicationID string, groupTrack *GroupTra
 	ut.appGroupTrackers[applicationID] = groupTrack
 }
 
-func (ut *UserTracker) getGroupForApp(applicationID string) *GroupTracker {
+func (ut *UserTracker) getGroupForApp(applicationID string) string {
 	ut.Lock()
 	defer ut.Unlock()
-	return ut.appGroupTrackers[applicationID]
-}
-
-func (ut *UserTracker) getMatchedGroup() string {
-	ut.RLock()
-	defer ut.RUnlock()
-	return ut.matchedGroup
-}
-
-func (ut *UserTracker) setMatchedGroup(group string) {
-	ut.Lock()
-	defer ut.Unlock()
-	ut.matchedGroup = group
+	if ut.appGroupTrackers[applicationID] != nil {
+		return ut.appGroupTrackers[applicationID].groupName
+	}
+	return ""
 }
 
 func (ut *UserTracker) getTrackedApplications() map[string]*GroupTracker {

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -34,6 +34,10 @@ type UserTracker struct {
 	// and group tracker object as value.
 	appGroupTrackers map[string]*GroupTracker
 	queueTracker     *QueueTracker // Holds the actual resource usage of queue path where application runs
+	// Group selected by matching the list of groups stored in security.UserGroup against the list of groups [Manager.configuredGroups] configured with limit settings.
+	// Manager.configuredGroups holds group only for which limit has been configured in bottom up queue hierarchical order starting from leaf to root.
+	// First matched group would be picked and stored in this variable
+	matchedGroup string
 
 	sync.RWMutex
 }
@@ -75,6 +79,18 @@ func (ut *UserTracker) setGroupForApp(applicationID string, groupTrack *GroupTra
 	if ut.appGroupTrackers[applicationID] == nil {
 		ut.appGroupTrackers[applicationID] = groupTrack
 	}
+}
+
+func (ut *UserTracker) getMatchedGroup() string {
+	ut.RLock()
+	defer ut.RUnlock()
+	return ut.matchedGroup
+}
+
+func (ut *UserTracker) setMatchedGroup(group string) {
+	ut.Lock()
+	defer ut.Unlock()
+	ut.matchedGroup = group
 }
 
 func (ut *UserTracker) getTrackedApplications() map[string]*GroupTracker {

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -76,9 +76,13 @@ func (ut *UserTracker) hasGroupForApp(applicationID string) bool {
 func (ut *UserTracker) setGroupForApp(applicationID string, groupTrack *GroupTracker) {
 	ut.Lock()
 	defer ut.Unlock()
-	if ut.appGroupTrackers[applicationID] == nil {
-		ut.appGroupTrackers[applicationID] = groupTrack
-	}
+	ut.appGroupTrackers[applicationID] = groupTrack
+}
+
+func (ut *UserTracker) getGroupForApp(applicationID string) *GroupTracker {
+	ut.Lock()
+	defer ut.Unlock()
+	return ut.appGroupTrackers[applicationID]
 }
 
 func (ut *UserTracker) getMatchedGroup() string {

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -119,7 +119,9 @@ func (ut *UserTracker) GetUserResourceUsageDAOInfo() *dao.UserResourceUsageDAOIn
 	}
 	userResourceUsage.UserName = ut.userName
 	for app, gt := range ut.appGroupTrackers {
-		userResourceUsage.Groups[app] = gt.groupName
+		if gt != nil {
+			userResourceUsage.Groups[app] = gt.groupName
+		}
 	}
 	userResourceUsage.Queues = ut.queueTracker.getResourceUsageDAOInfo("")
 	return userResourceUsage

--- a/pkg/scheduler/ugm/utilities.go
+++ b/pkg/scheduler/ugm/utilities.go
@@ -36,3 +36,16 @@ func getChildQueuePath(queuePath string) (string, string) {
 	}
 	return childQueuePath, childQueuePath[:idx]
 }
+
+func getParentQueuePath(queuePath string) (string, string) {
+	idx := strings.LastIndex(queuePath, configs.DOT)
+	if idx == -1 {
+		return "", ""
+	}
+	parentQueuePath := queuePath[:idx]
+	idx = strings.LastIndex(parentQueuePath, configs.DOT)
+	if idx == -1 {
+		return parentQueuePath, parentQueuePath
+	}
+	return parentQueuePath, parentQueuePath[idx+1:]
+}

--- a/pkg/scheduler/ugm/utilities_test.go
+++ b/pkg/scheduler/ugm/utilities_test.go
@@ -50,3 +50,17 @@ func TestGetChildQueuePath(t *testing.T) {
 	assert.Equal(t, childPath, "")
 	assert.Equal(t, immediateChildName, "")
 }
+
+func TestGetParentQueuePath(t *testing.T) {
+	parentPath, immediateParentName := getParentQueuePath("root.parent.leaf")
+	assert.Equal(t, parentPath, "root.parent")
+	assert.Equal(t, immediateParentName, "parent")
+
+	parentPath, immediateParentName = getParentQueuePath("parent.leaf")
+	assert.Equal(t, parentPath, "parent")
+	assert.Equal(t, immediateParentName, "parent")
+
+	parentPath, immediateParentName = getParentQueuePath("leaf")
+	assert.Equal(t, parentPath, "")
+	assert.Equal(t, immediateParentName, "")
+}

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 
 	"github.com/julienschmidt/httprouter"
-
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/yaml.v3"
 	"gotest.tools/v3/assert"
@@ -1280,8 +1279,7 @@ func TestSpecificUserAndGroupResourceUsage(t *testing.T) {
 	getGroupResourceUsage(resp, req)
 	err = json.Unmarshal(resp.outputBytes, &groupResourceUsageDao)
 	assert.NilError(t, err, "failed to unmarshal group resource usage dao response from response body: %s", string(resp.outputBytes))
-	assert.Equal(t, groupResourceUsageDao.Queues.ResourceUsage.String(),
-		resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1}).String())
+	assert.DeepEqual(t, groupResourceUsageDao, &dao.GroupResourceUsageDAOInfo{GroupName: "", Applications: nil, Queues: nil})
 
 	// Test non-existing group query
 	req, err = http.NewRequest("GET", "/ws/v1/partition/default/usage/group/", strings.NewReader(""))
@@ -1322,15 +1320,14 @@ func TestUsersAndGroupsResourceUsage(t *testing.T) {
 	assert.NilError(t, err, "Get Groups Resource Usage Handler request failed")
 
 	var groupsResourceUsageDao []*dao.GroupResourceUsageDAOInfo
+	var expGroupsResourceUsageDao []*dao.GroupResourceUsageDAOInfo
 	getGroupsResourceUsage(resp, req)
 	err = json.Unmarshal(resp.outputBytes, &groupsResourceUsageDao)
 	assert.NilError(t, err, "failed to unmarshal groups resource usage dao response from response body: %s", string(resp.outputBytes))
-	assert.Equal(t, groupsResourceUsageDao[0].Queues.ResourceUsage.String(),
-		resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1}).String())
+	assert.DeepEqual(t, groupsResourceUsageDao, expGroupsResourceUsageDao)
 
 	// Assert existing groups
-	assert.Equal(t, len(groupsResourceUsageDao), 1)
-	assert.Equal(t, groupsResourceUsageDao[0].GroupName, "testgroup")
+	assert.Equal(t, len(groupsResourceUsageDao), 0)
 }
 
 func prepareSchedulerContext(t *testing.T, stateDumpConf bool) *scheduler.ClusterContext {


### PR DESCRIPTION
### What is this PR for?

User may belong to zero or multiple groups. On the other hand, Limits are configured for different groups at different queue hierarchy. Among these multiple groups stored in security.UserGroup, matching against group for which limit has been configured happens from leaf to root and first matching group would be picked and used as user's group for all activities in UGM module.

### What type of PR is it?
* [ ] - Feature

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1835

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
