### PR TITLE
[YUNIKORN-1864] Apply wild card group limit settings for users without any matching group

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -51,6 +51,6 @@ func CreateNodeEventRecord(objectID, message, referenceID string, changeType si.
 	return createEventRecord(si.EventRecord_NODE, objectID, referenceID, message, changeType, changeDetail, resource)
 }
 
-func CreateQueueEventRecord(objectID, referenceID, message string, changeType si.EventRecord_ChangeType, changeDetail si.EventRecord_ChangeDetail, resource *resources.Resource) *si.EventRecord {
+func CreateQueueEventRecord(objectID, message, referenceID string, changeType si.EventRecord_ChangeType, changeDetail si.EventRecord_ChangeDetail, resource *resources.Resource) *si.EventRecord {
 	return createEventRecord(si.EventRecord_QUEUE, objectID, referenceID, message, changeType, changeDetail, resource)
 }

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -56,6 +56,6 @@ func TestCreateEventRecordTypes(t *testing.T) {
 	record = CreateNodeEventRecord("node", "message", "ask", si.EventRecord_NONE, si.EventRecord_DETAILS_NONE, nil)
 	assert.Equal(t, record.Type, si.EventRecord_NODE)
 
-	record = CreateQueueEventRecord("queue", "app", "message", si.EventRecord_NONE, si.EventRecord_DETAILS_NONE, nil)
+	record = CreateQueueEventRecord("queue", "message", "app", si.EventRecord_NONE, si.EventRecord_DETAILS_NONE, nil)
 	assert.Equal(t, record.Type, si.EventRecord_QUEUE)
 }

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -267,23 +267,25 @@ func TestAppAllocReservation(t *testing.T) {
 	}
 
 	// wait for events to be processed
+	noEvents := 0
 	err = common.WaitFor(10*time.Millisecond, time.Second, func() bool {
 		fmt.Printf("checking event length: %d\n", eventSystem.Store.CountStoredEvents())
-		return eventSystem.Store.CountStoredEvents() == 2
+		noEvents = eventSystem.Store.CountStoredEvents()
+		return noEvents == 3
 	})
-	assert.NilError(t, err, "the event should have been processed")
+	assert.NilError(t, err, "expected 3 events, got %d", noEvents)
 	records := eventSystem.Store.CollectEvents()
 	if records == nil {
 		t.Fatal("collecting eventChannel should return something")
 	}
-	assert.Equal(t, 2, len(records), "expecting 2 events: 1 new alloc ask and 1 alloc ask cancel")
-	allocAskRecord := records[0]
+	assert.Equal(t, 3, len(records))
+	allocAskRecord := records[1]
 	assert.Equal(t, si.EventRecord_APP, allocAskRecord.Type, "incorrect event type, expect app")
 	assert.Equal(t, ask.applicationID, allocAskRecord.ObjectID, "incorrect object ID, expected application ID")
 	assert.Equal(t, ask.allocationKey, allocAskRecord.ReferenceID, "incorrect reference ID, expected alloc ask ID")
 	assert.Equal(t, si.EventRecord_ADD, allocAskRecord.EventChangeType, "incorrect change type, expected add")
 	assert.Equal(t, si.EventRecord_APP_REQUEST, allocAskRecord.EventChangeDetail, "incorrect change detail, expected new alloc ask")
-	allocAskCancelRecord := records[1]
+	allocAskCancelRecord := records[2]
 	assert.Equal(t, si.EventRecord_APP, allocAskCancelRecord.Type, "incorrect event type, expect app")
 	assert.Equal(t, ask.applicationID, allocAskCancelRecord.ObjectID, "incorrect object ID, expected application ID")
 	assert.Equal(t, ask.allocationKey, allocAskCancelRecord.ReferenceID, "incorrect reference ID, expected alloc ask ID")
@@ -383,17 +385,19 @@ func TestAddAllocAsk(t *testing.T) {
 	}
 
 	// test add alloc ask event
+	noEvents := 0
 	err = common.WaitFor(10*time.Millisecond, time.Second, func() bool {
 		fmt.Printf("checking event length: %d\n", eventSystem.Store.CountStoredEvents())
-		return eventSystem.Store.CountStoredEvents() == 1
+		noEvents = eventSystem.Store.CountStoredEvents()
+		return noEvents == 2
 	})
-	assert.NilError(t, err, "the events should have been processed")
+	assert.NilError(t, err, "expected 2 events, got %d", noEvents)
 	records := eventSystem.Store.CollectEvents()
 	if records == nil {
 		t.Fatal("collecting eventChannel should return something")
 	}
-	assert.Equal(t, 1, len(records), "expecting add alloc ask event")
-	record := records[0]
+	assert.Equal(t, 2, len(records))
+	record := records[1]
 	assert.Equal(t, si.EventRecord_APP, record.Type, "incorrect event type, expect app")
 	assert.Equal(t, appID1, record.ObjectID, "incorrect object ID, expected application ID")
 	assert.Equal(t, aKey, record.ReferenceID, "incorrect reference ID, expected placeholder alloc ID")
@@ -1990,17 +1994,17 @@ func TestAskEvents(t *testing.T) {
 	noEvents := 0
 	err = common.WaitFor(10*time.Millisecond, time.Second, func() bool {
 		noEvents = eventSystem.Store.CountStoredEvents()
-		return noEvents == 2
+		return noEvents == 3
 	})
-	assert.NilError(t, err, "expected 2 events, got %d", noEvents)
+	assert.NilError(t, err, "expected 3 events, got %d", noEvents)
 	records := eventSystem.Store.CollectEvents()
-	assert.Equal(t, 2, len(records), "number of events")
-	assert.Equal(t, si.EventRecord_APP, records[0].Type)
-	assert.Equal(t, si.EventRecord_ADD, records[0].EventChangeType)
-	assert.Equal(t, si.EventRecord_APP_REQUEST, records[0].EventChangeDetail)
+	assert.Equal(t, 3, len(records), "number of events")
 	assert.Equal(t, si.EventRecord_APP, records[1].Type)
-	assert.Equal(t, si.EventRecord_REMOVE, records[1].EventChangeType)
-	assert.Equal(t, si.EventRecord_REQUEST_CANCEL, records[1].EventChangeDetail)
+	assert.Equal(t, si.EventRecord_ADD, records[1].EventChangeType)
+	assert.Equal(t, si.EventRecord_APP_REQUEST, records[1].EventChangeDetail)
+	assert.Equal(t, si.EventRecord_APP, records[2].Type)
+	assert.Equal(t, si.EventRecord_REMOVE, records[2].EventChangeType)
+	assert.Equal(t, si.EventRecord_REQUEST_CANCEL, records[2].EventChangeDetail)
 
 	ask2 := newAllocationAsk("alloc-2", appID1, res)
 	ask3 := newAllocationAsk("alloc-3", appID1, res)
@@ -2060,32 +2064,32 @@ func TestAllocationEvents(t *testing.T) { //nolint:funlen
 	noEvents := 0
 	err = common.WaitFor(10*time.Millisecond, time.Second, func() bool {
 		noEvents = eventSystem.Store.CountStoredEvents()
-		return noEvents == 4
+		return noEvents == 5
 	})
-	assert.NilError(t, err, "expected 4 events, got %d", noEvents)
+	assert.NilError(t, err, "expected 5 events, got %d", noEvents)
 	records := eventSystem.Store.CollectEvents()
 
-	assert.Equal(t, 4, len(records), "number of events")
-	assert.Equal(t, si.EventRecord_APP, records[0].Type)
-	assert.Equal(t, si.EventRecord_ADD, records[0].EventChangeType)
-	assert.Equal(t, si.EventRecord_APP_ALLOC, records[0].EventChangeDetail)
-	assert.Equal(t, "uuid-1", records[0].ReferenceID)
-	assert.Equal(t, "app-1", records[0].ObjectID)
+	assert.Equal(t, 5, len(records), "number of events")
 	assert.Equal(t, si.EventRecord_APP, records[1].Type)
 	assert.Equal(t, si.EventRecord_ADD, records[1].EventChangeType)
 	assert.Equal(t, si.EventRecord_APP_ALLOC, records[1].EventChangeDetail)
-	assert.Equal(t, "uuid-2", records[1].ReferenceID)
+	assert.Equal(t, "uuid-1", records[1].ReferenceID)
 	assert.Equal(t, "app-1", records[1].ObjectID)
 	assert.Equal(t, si.EventRecord_APP, records[2].Type)
-	assert.Equal(t, si.EventRecord_REMOVE, records[2].EventChangeType)
-	assert.Equal(t, si.EventRecord_ALLOC_CANCEL, records[2].EventChangeDetail)
-	assert.Equal(t, "uuid-1", records[2].ReferenceID)
+	assert.Equal(t, si.EventRecord_ADD, records[2].EventChangeType)
+	assert.Equal(t, si.EventRecord_APP_ALLOC, records[2].EventChangeDetail)
+	assert.Equal(t, "uuid-2", records[2].ReferenceID)
 	assert.Equal(t, "app-1", records[2].ObjectID)
 	assert.Equal(t, si.EventRecord_APP, records[3].Type)
 	assert.Equal(t, si.EventRecord_REMOVE, records[3].EventChangeType)
-	assert.Equal(t, si.EventRecord_ALLOC_REPLACED, records[3].EventChangeDetail)
-	assert.Equal(t, "uuid-2", records[3].ReferenceID)
+	assert.Equal(t, si.EventRecord_ALLOC_CANCEL, records[3].EventChangeDetail)
+	assert.Equal(t, "uuid-1", records[3].ReferenceID)
 	assert.Equal(t, "app-1", records[3].ObjectID)
+	assert.Equal(t, si.EventRecord_APP, records[4].Type)
+	assert.Equal(t, si.EventRecord_REMOVE, records[4].EventChangeType)
+	assert.Equal(t, si.EventRecord_ALLOC_REPLACED, records[4].EventChangeDetail)
+	assert.Equal(t, "uuid-2", records[4].ReferenceID)
+	assert.Equal(t, "app-1", records[4].ObjectID)
 
 	// add + replace
 	alloc1.placeholder = true
@@ -2181,14 +2185,14 @@ func TestPlaceholderLargerEvent(t *testing.T) {
 	noEvents := 0
 	err = common.WaitFor(10*time.Millisecond, time.Second, func() bool {
 		noEvents = eventSystem.Store.CountStoredEvents()
-		return noEvents == 3
+		return noEvents == 4
 	})
-	assert.NilError(t, err, "expected 3 events, got %d", noEvents)
+	assert.NilError(t, err, "expected 4 events, got %d", noEvents)
 	records := eventSystem.Store.CollectEvents()
-	assert.Equal(t, si.EventRecord_REQUEST, records[2].Type)
-	assert.Equal(t, si.EventRecord_NONE, records[2].EventChangeType)
-	assert.Equal(t, si.EventRecord_DETAILS_NONE, records[2].EventChangeDetail)
-	assert.Equal(t, "app-1", records[2].ReferenceID)
+	assert.Equal(t, si.EventRecord_REQUEST, records[3].Type)
+	assert.Equal(t, si.EventRecord_NONE, records[3].EventChangeType)
+	assert.Equal(t, si.EventRecord_DETAILS_NONE, records[3].EventChangeDetail)
+	assert.Equal(t, "app-1", records[3].ReferenceID)
 }
 
 func TestAppDoesNotFitEvent(t *testing.T) {
@@ -2223,15 +2227,15 @@ func TestAppDoesNotFitEvent(t *testing.T) {
 	noEvents := 0
 	err = common.WaitFor(10*time.Millisecond, time.Second, func() bool {
 		noEvents = eventSystem.Store.CountStoredEvents()
-		return noEvents == 1
+		return noEvents == 2
 	})
-	assert.NilError(t, err, "expected 1 event, got %d", noEvents)
+	assert.NilError(t, err, "expected 2 event, got %d", noEvents)
 	records := eventSystem.Store.CollectEvents()
-	assert.Equal(t, si.EventRecord_REQUEST, records[0].Type)
-	assert.Equal(t, si.EventRecord_NONE, records[0].EventChangeType)
-	assert.Equal(t, si.EventRecord_DETAILS_NONE, records[0].EventChangeDetail)
-	assert.Equal(t, "app-1", records[0].ReferenceID)
-	assert.Equal(t, "alloc-0", records[0].ObjectID)
+	assert.Equal(t, si.EventRecord_REQUEST, records[1].Type)
+	assert.Equal(t, si.EventRecord_NONE, records[1].EventChangeType)
+	assert.Equal(t, si.EventRecord_DETAILS_NONE, records[1].EventChangeDetail)
+	assert.Equal(t, "app-1", records[1].ReferenceID)
+	assert.Equal(t, "alloc-0", records[1].ObjectID)
 }
 
 func (sa *Application) addPlaceholderDataWithLocking(ask *AllocationAsk) {

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -1602,34 +1602,34 @@ func TestIncAndDecUserResourceUsageInSameGroup(t *testing.T) {
 
 	// Increase testuser
 	app.incUserResourceUsage(res)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), res, res, 0)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), nil, res, 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), res, nil, 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), nil, nil, 0)
 
 	// Increase both testuser and testuser2 with the same group testgroup
 	app.incUserResourceUsage(res)
 	app2.incUserResourceUsage(resources.Multiply(res, 2))
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), resources.Multiply(res, 2), resources.Multiply(res, 4), 0)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), resources.Multiply(res, 2), resources.Multiply(res, 4), 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), resources.Multiply(res, 2), nil, 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), resources.Multiply(res, 2), nil, 0)
 
 	// Increase nil
 	app.decUserResourceUsage(nil, false)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), resources.Multiply(res, 2), resources.Multiply(res, 4), 0)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), resources.Multiply(res, 2), resources.Multiply(res, 4), 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), resources.Multiply(res, 2), nil, 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), resources.Multiply(res, 2), nil, 0)
 
 	// Decrease testuser
 	app.decUserResourceUsage(res, false)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), res, resources.Multiply(res, 3), 0)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), resources.Multiply(res, 2), resources.Multiply(res, 3), 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), res, nil, 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), resources.Multiply(res, 2), nil, 0)
 
 	// Decrease testuser2
 	app2.decUserResourceUsage(res, false)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), res, resources.Multiply(res, 2), 0)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), res, resources.Multiply(res, 2), 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), res, nil, 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser2", testgroups), res, nil, 0)
 
 	// Decrease testuser and testuser2 to 0
 	app.decUserResourceUsage(res, false)
 	app2.decUserResourceUsage(res, false)
-	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}), 0)
+	assertUserResourcesAndGroupResources(t, getUserGroup("testuser", testgroups), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}), nil, 0)
 }
 
 func TestGetAllRequests(t *testing.T) {

--- a/pkg/scheduler/objects/queue_events.go
+++ b/pkg/scheduler/objects/queue_events.go
@@ -1,0 +1,123 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package objects
+
+import (
+	"github.com/apache/yunikorn-core/pkg/common"
+	"github.com/apache/yunikorn-core/pkg/events"
+	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
+)
+
+type queueEvents struct {
+	enabled     bool
+	eventSystem events.EventSystem
+	queue       *Queue
+}
+
+func (q *queueEvents) sendNewQueueEvent() {
+	if !q.enabled {
+		return
+	}
+
+	detail := si.EventRecord_QUEUE_DYNAMIC
+	if q.queue.IsManaged() {
+		detail = si.EventRecord_DETAILS_NONE
+	}
+	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, common.Empty, si.EventRecord_ADD,
+		detail, nil)
+	q.eventSystem.AddEvent(event)
+}
+
+func (q *queueEvents) sendNewApplicationEvent(appID string) {
+	if !q.enabled {
+		return
+	}
+
+	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, appID, si.EventRecord_ADD,
+		si.EventRecord_QUEUE_APP, nil)
+	q.eventSystem.AddEvent(event)
+}
+
+func (q *queueEvents) sendRemoveQueueEvent() {
+	if !q.enabled {
+		return
+	}
+
+	detail := si.EventRecord_QUEUE_DYNAMIC
+	if q.queue.IsManaged() {
+		detail = si.EventRecord_DETAILS_NONE
+	}
+
+	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, common.Empty, si.EventRecord_REMOVE,
+		detail, nil)
+	q.eventSystem.AddEvent(event)
+}
+
+func (q *queueEvents) sendRemoveApplicationEvent(appID string) {
+	if !q.enabled {
+		return
+	}
+
+	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, appID, si.EventRecord_REMOVE,
+		si.EventRecord_QUEUE_APP, nil)
+	q.eventSystem.AddEvent(event)
+}
+
+func (q *queueEvents) sendMaxResourceChangedEvent() {
+	if !q.enabled {
+		return
+	}
+
+	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, common.Empty, si.EventRecord_SET,
+		si.EventRecord_QUEUE_MAX, q.queue.maxResource)
+	q.eventSystem.AddEvent(event)
+}
+
+func (q *queueEvents) sendGuaranteedResourceChangedEvent() {
+	if !q.enabled {
+		return
+	}
+
+	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, common.Empty, si.EventRecord_SET,
+		si.EventRecord_QUEUE_GUARANTEED, q.queue.guaranteedResource)
+	q.eventSystem.AddEvent(event)
+}
+
+func (q *queueEvents) sendTypeChangedEvent() {
+	if !q.enabled {
+		return
+	}
+
+	message := "leaf queue: false"
+	if q.queue.isLeaf {
+		message = "leaf queue: true"
+	}
+
+	event := events.CreateQueueEventRecord(q.queue.QueuePath, message, common.Empty, si.EventRecord_SET,
+		si.EventRecord_QUEUE_TYPE, nil)
+	q.eventSystem.AddEvent(event)
+}
+
+func newQueueEvents(queue *Queue, evt events.EventSystem) *queueEvents {
+	return &queueEvents{
+		eventSystem: evt,
+		enabled:     evt != nil,
+		queue:       queue,
+	}
+}

--- a/pkg/scheduler/objects/queue_events_test.go
+++ b/pkg/scheduler/objects/queue_events_test.go
@@ -1,0 +1,243 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package objects
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/apache/yunikorn-core/pkg/common"
+	"github.com/apache/yunikorn-core/pkg/common/resources"
+	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
+)
+
+const (
+	testQueuePath = "root.test"
+)
+
+func TestNewQueueEvents(t *testing.T) {
+	queue := &Queue{
+		QueuePath: testQueuePath,
+	}
+
+	// not enabled
+	nq := newQueueEvents(queue, nil)
+	assert.Assert(t, nq.eventSystem == nil, "event system should be nil")
+	assert.Assert(t, !nq.enabled, "event system should be disabled")
+
+	// enabled
+	nq = newQueueEvents(queue, newEventSystemMock())
+	assert.Assert(t, nq.eventSystem != nil, "event system should not be nil")
+	assert.Assert(t, nq.enabled, "event system should be enabled")
+}
+
+func TestSendNewQueueEvent(t *testing.T) {
+	queue := &Queue{
+		QueuePath: testQueuePath,
+		isManaged: true,
+	}
+
+	// not enabled
+	nq := newQueueEvents(queue, nil)
+	nq.sendNewQueueEvent()
+
+	// enabled
+	mock := newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
+	nq.sendNewQueueEvent()
+	assert.Equal(t, 1, len(mock.events), "event was not generated")
+	event := mock.events[0]
+	assert.Equal(t, si.EventRecord_QUEUE, event.Type)
+	assert.Equal(t, testQueuePath, event.ObjectID)
+	assert.Equal(t, common.Empty, event.ReferenceID)
+	assert.Equal(t, common.Empty, event.Message)
+	assert.Equal(t, si.EventRecord_ADD, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
+	assert.Equal(t, 0, len(event.Resource.Resources))
+	mock = newEventSystemMock()
+	nq = newQueueEvents(&Queue{
+		QueuePath: testQueuePath,
+		isManaged: false,
+	}, mock)
+	nq.sendNewQueueEvent()
+	event = mock.events[0]
+	assert.Equal(t, si.EventRecord_QUEUE_DYNAMIC, event.EventChangeDetail)
+}
+
+func TestSendRemoveQueueEvent(t *testing.T) {
+	queue := &Queue{
+		QueuePath: testQueuePath,
+		isManaged: true,
+	}
+
+	// not enabled
+	nq := newQueueEvents(queue, nil)
+	nq.sendRemoveQueueEvent()
+
+	// enabled
+	mock := newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
+	nq.sendRemoveQueueEvent()
+	assert.Equal(t, 1, len(mock.events), "event was not generated")
+	event := mock.events[0]
+	assert.Equal(t, si.EventRecord_QUEUE, event.Type)
+	assert.Equal(t, testQueuePath, event.ObjectID)
+	assert.Equal(t, common.Empty, event.ReferenceID)
+	assert.Equal(t, common.Empty, event.Message)
+	assert.Equal(t, si.EventRecord_REMOVE, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
+	assert.Equal(t, 0, len(event.Resource.Resources))
+	mock = newEventSystemMock()
+	nq = newQueueEvents(&Queue{
+		QueuePath: testQueuePath,
+		isManaged: false,
+	}, mock)
+	nq.sendRemoveQueueEvent()
+	event = mock.events[0]
+	assert.Equal(t, si.EventRecord_QUEUE_DYNAMIC, event.EventChangeDetail)
+}
+
+func TestNewApplicationEvent(t *testing.T) {
+	queue := &Queue{
+		QueuePath: testQueuePath,
+	}
+
+	// not enabled
+	nq := newQueueEvents(queue, nil)
+	nq.sendNewApplicationEvent(appID0)
+
+	// enabled
+	mock := newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
+	nq.sendNewApplicationEvent(appID0)
+	assert.Equal(t, 1, len(mock.events), "event was not generated")
+	event := mock.events[0]
+	assert.Equal(t, si.EventRecord_QUEUE, event.Type)
+	assert.Equal(t, testQueuePath, event.ObjectID)
+	assert.Equal(t, appID0, event.ReferenceID)
+	assert.Equal(t, common.Empty, event.Message)
+	assert.Equal(t, si.EventRecord_ADD, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_QUEUE_APP, event.EventChangeDetail)
+	assert.Equal(t, 0, len(event.Resource.Resources))
+}
+
+func TestRemoveApplicationEvent(t *testing.T) {
+	queue := &Queue{
+		QueuePath: testQueuePath,
+	}
+
+	// not enabled
+	nq := newQueueEvents(queue, nil)
+	nq.sendRemoveApplicationEvent(appID0)
+
+	// enabled
+	mock := newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
+	nq.sendRemoveApplicationEvent(appID0)
+	assert.Equal(t, 1, len(mock.events), "event was not generated")
+	event := mock.events[0]
+	assert.Equal(t, si.EventRecord_QUEUE, event.Type)
+	assert.Equal(t, testQueuePath, event.ObjectID)
+	assert.Equal(t, appID0, event.ReferenceID)
+	assert.Equal(t, common.Empty, event.Message)
+	assert.Equal(t, si.EventRecord_REMOVE, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_QUEUE_APP, event.EventChangeDetail)
+	assert.Equal(t, 0, len(event.Resource.Resources))
+}
+
+func TestTypeChangedEvent(t *testing.T) {
+	queue := &Queue{
+		QueuePath: testQueuePath,
+	}
+
+	// not enabled
+	nq := newQueueEvents(queue, nil)
+	nq.sendTypeChangedEvent()
+
+	// enabled
+	mock := newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
+	nq.sendTypeChangedEvent()
+	assert.Equal(t, 1, len(mock.events), "event was not generated")
+	event := mock.events[0]
+	assert.Equal(t, si.EventRecord_QUEUE, event.Type)
+	assert.Equal(t, testQueuePath, event.ObjectID)
+	assert.Equal(t, common.Empty, event.ReferenceID)
+	assert.Equal(t, "leaf queue: false", event.Message)
+	assert.Equal(t, si.EventRecord_SET, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_QUEUE_TYPE, event.EventChangeDetail)
+	assert.Equal(t, 0, len(event.Resource.Resources))
+}
+
+func TestSendMaxResourceChangedEvent(t *testing.T) {
+	max := getTestResource()
+	queue := &Queue{
+		QueuePath:   testQueuePath,
+		maxResource: max,
+	}
+
+	// not enabled
+	nq := newQueueEvents(queue, nil)
+	nq.sendMaxResourceChangedEvent()
+
+	// enabled
+	mock := newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
+	nq.sendMaxResourceChangedEvent()
+	assert.Equal(t, 1, len(mock.events), "event was not generated")
+	event := mock.events[0]
+	assert.Equal(t, si.EventRecord_QUEUE, event.Type)
+	assert.Equal(t, testQueuePath, event.ObjectID)
+	assert.Equal(t, common.Empty, event.ReferenceID)
+	assert.Equal(t, common.Empty, event.Message)
+	assert.Equal(t, si.EventRecord_SET, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_QUEUE_MAX, event.EventChangeDetail)
+	assert.Equal(t, 1, len(event.Resource.Resources))
+	protoRes := resources.NewResourceFromProto(event.Resource)
+	assert.DeepEqual(t, max, protoRes)
+}
+
+func TestSendGuaranteedResourceChangedEvent(t *testing.T) {
+	guaranteed := getTestResource()
+	queue := &Queue{
+		QueuePath:          testQueuePath,
+		guaranteedResource: guaranteed,
+	}
+
+	// not enabled
+	nq := newQueueEvents(queue, nil)
+	nq.sendGuaranteedResourceChangedEvent()
+
+	// enabled
+	mock := newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
+	nq.sendGuaranteedResourceChangedEvent()
+	assert.Equal(t, 1, len(mock.events), "event was not generated")
+	event := mock.events[0]
+	assert.Equal(t, si.EventRecord_QUEUE, event.Type)
+	assert.Equal(t, testQueuePath, event.ObjectID)
+	assert.Equal(t, common.Empty, event.ReferenceID)
+	assert.Equal(t, common.Empty, event.Message)
+	assert.Equal(t, si.EventRecord_SET, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_QUEUE_GUARANTEED, event.EventChangeDetail)
+	assert.Equal(t, 1, len(event.Resource.Resources))
+	protoRes := resources.NewResourceFromProto(event.Resource)
+	assert.DeepEqual(t, guaranteed, protoRes)
+}

--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -264,7 +264,7 @@ func assertUserGroupResource(t *testing.T, userGroup security.UserGroup, expecte
 	userResource := ugm.GetUserResources(userGroup)
 	groupResource := ugm.GetGroupResources(userGroup.Groups[0])
 	assert.Equal(t, resources.Equals(userResource, expected), true)
-	assert.Equal(t, resources.Equals(groupResource, expected), true)
+	assert.Equal(t, resources.Equals(groupResource, nil), true)
 }
 
 func assertUserResourcesAndGroupResources(t *testing.T, userGroup security.UserGroup, expectedUserResources *resources.Resource, expectedGroupResources *resources.Resource, i int) {

--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -115,3 +115,9 @@ func (gt *GroupTracker) canBeRemoved() bool {
 	defer gt.RUnlock()
 	return len(gt.queueTracker.childQueueTrackers) == 0 && len(gt.queueTracker.runningApplications) == 0
 }
+
+func (gt *GroupTracker) removeApp(applicationID string) {
+	gt.Lock()
+	defer gt.Unlock()
+	delete(gt.applications, applicationID)
+}

--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -418,54 +418,18 @@ func (m *Manager) internalProcessConfig(cur configs.QueueConfig, queuePath strin
 }
 
 func (m *Manager) processUserConfig(user string, limitConfig *LimitConfig, queuePath string, userLimits map[string]bool) error {
-	if user == "*" {
-		// traverse all tracked users
-		for u, ut := range m.userTrackers {
-			// Is this user already tracked for the queue path?
-			if ut.IsQueuePathTrackedCompletely(queuePath) {
-				log.Log(log.SchedUGM).Debug("Processing wild card user limits configuration for all existing users",
-					zap.String("user", u),
-					zap.String("queue path", queuePath),
-					zap.Uint64("max application", limitConfig.maxApplications),
-					zap.Any("max resources", limitConfig.maxResources))
-				if err := m.setUserLimits(u, limitConfig, queuePath); err != nil {
-					return err
-				}
-				userLimits[u] = true
-			}
-		}
-	} else if user != "" {
-		if err := m.setUserLimits(user, limitConfig, queuePath); err != nil {
-			return err
-		}
-		userLimits[user] = true
+	if err := m.setUserLimits(user, limitConfig, queuePath); err != nil {
+		return err
 	}
+	userLimits[user] = true
 	return nil
 }
 
 func (m *Manager) processGroupConfig(group string, limitConfig *LimitConfig, queuePath string, groupLimits map[string]bool) error {
-	if group == "*" {
-		// traverse all tracked groups
-		for g, gt := range m.groupTrackers {
-			// Is this group already tracked for the queue path?
-			if gt.IsQueuePathTrackedCompletely(queuePath) {
-				log.Log(log.SchedUGM).Debug("Processing wild card user limits configuration for all existing groups",
-					zap.String("group", g),
-					zap.String("queue path", queuePath),
-					zap.Uint64("max application", limitConfig.maxApplications),
-					zap.Any("max resources", limitConfig.maxResources))
-				if err := m.setGroupLimits(g, limitConfig, queuePath); err != nil {
-					return err
-				}
-				groupLimits[g] = true
-			}
-		}
-	} else if group != "" {
-		if err := m.setGroupLimits(group, limitConfig, queuePath); err != nil {
-			return err
-		}
-		groupLimits[group] = true
+	if err := m.setGroupLimits(group, limitConfig, queuePath); err != nil {
+		return err
 	}
+	groupLimits[group] = true
 	return nil
 }
 

--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -669,8 +669,8 @@ func (m *Manager) Headroom(queuePath string, user security.UserGroup) *resources
 			zap.String("queue path", queuePath),
 			zap.String("user headroom", userHeadroom.String()))
 	}
-	group, err := m.getGroup(user)
-	if err == nil {
+	group := m.internalEnsureGroup(user, queuePath)
+	if group != "" {
 		if m.groupTrackers[group] != nil {
 			groupHeadroom = m.groupTrackers[group].headroom(queuePath)
 			log.Log(log.SchedUGM).Debug("Calculated headroom for group",

--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -486,8 +486,9 @@ func (m *Manager) clearEarlierSetLimits(userLimits map[string]bool, groupLimits 
 							zap.String("group", gt.groupName),
 							zap.String("application id", appID),
 							zap.String("queue path", queuePath))
-						// to do: removing the linkage only happens here by setting it to nil and deleting app id
+						// removing the linkage only happens here by setting it to nil and deleting app id
 						// but group resource usage so far remains as it is because we don't have app id wise resource usage with in group as of now.
+						// YUNIKORN-1858 handles the group resource usage properly
 						// In case of only one (last) application, group tracker would be removed from the manager.
 						ut.setGroupForApp(appID, nil)
 						gt.removeApp(appID)

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -383,13 +383,13 @@ func TestUpdateConfigWithWildCardUsersAndGroups(t *testing.T) {
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
 	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user1)
-	if increased {
+	if !increased {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user1)
 	}
 
 	// configure max resource for user2 * root.parent (map[memory:70 vcores:70]) higher than wild card user * root.parent settings (map[memory:10 vcores:10])
 	// ensure user's specific settings has been used for enforcement checks as specific limits always has higher precedence when compared to wild card user limit settings
-	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, "", "*", "*", "10", "10")
+	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, "", "*", "", "10", "10")
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
 	// can be allowed to run upto resource usage map[memory:70 vcores:70]
@@ -405,6 +405,37 @@ func TestUpdateConfigWithWildCardUsersAndGroups(t *testing.T) {
 	if increased {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
 	}
+
+	user3 := security.UserGroup{User: "user3", Groups: []string{"group3"}}
+	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0], "", "*", "10", "10")
+	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+
+	// user3 should be able to run app as group3 uses wild card group limit settings map[memory:10 vcores:10]
+	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user3)
+	if !increased {
+		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
+	}
+
+	// user4 (though belongs to different group, group4) should not be able to run app as group4 also
+	// uses wild card group limit settings map[memory:10 vcores:10]
+	user4 := security.UserGroup{User: "user4", Groups: []string{"group4"}}
+	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user4)
+	assert.Equal(t, increased, false)
+
+	conf = createUpdateConfigWithWildCardUsersAndGroups(user4.User, user4.Groups[0], "", "*", "10", "10")
+	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+
+	// can be allowed to run upto resource usage map[memory:70 vcores:70]
+	for i := 1; i <= 7; i++ {
+		increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user4)
+		if !increased {
+			t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user1)
+		}
+	}
+
+	// user4 should not be able to run app as user4 max limit is map[memory:70 vcores:70] and usage so far is map[memory:70 vcores:70]
+	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user4)
+	assert.Equal(t, increased, false)
 }
 
 func TestUpdateConfigClearEarlierSetLimits(t *testing.T) {

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -49,7 +49,7 @@ func TestGetGroup(t *testing.T) {
 	user1 := security.UserGroup{User: "test", Groups: []string{"test1", "test"}}
 	group = manager.ensureGroup(user1, "root.parent")
 	assert.Equal(t, group, "test")
-	
+
 	conf = createConfigWithoutLimits()
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -40,16 +40,19 @@ func TestGetGroup(t *testing.T) {
 	user := security.UserGroup{User: "test", Groups: []string{"test", "test1"}}
 	manager := GetUserManager()
 
+	// create config with limits for "test" group and ensure picked up group is "test"
 	conf := createUpdateConfig(user.User, user.Groups[0])
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
 	group := manager.ensureGroup(user, "root.parent.leaf")
 	assert.Equal(t, group, "test")
 
+	// Even though ordering of groups has been changed in UserGroup obj, still "test" should be picked up
 	user1 := security.UserGroup{User: "test", Groups: []string{"test1", "test"}}
 	group = manager.ensureGroup(user1, "root.parent")
 	assert.Equal(t, group, "test")
 
+	// clear all configs and ensure there is no tracking for "test" group as there is no matching
 	conf = createConfigWithoutLimits()
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
@@ -58,10 +61,12 @@ func TestGetGroup(t *testing.T) {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
 	}
 
-	increased := manager.IncreaseTrackedResource("root.parent.leaf", TestApp1, usage1, user)
+	increased := manager.IncreaseTrackedResource("root.parent.leaf", TestApp1, usage1, user1)
 	if !increased {
 		t.Errorf("unable to increase tracked resource. queuepath: root.parent.leaf, application id: %s, resource usage: %s, user: %s", TestApp1, usage1.String(), user.User)
 	}
+	assert.Equal(t, len(manager.userTrackers), 1)
+	assert.Equal(t, len(manager.groupTrackers), 0)
 
 	group = manager.ensureGroup(user1, "root.parent.leaf")
 	assert.Equal(t, group, "")
@@ -70,6 +75,9 @@ func TestGetGroup(t *testing.T) {
 	group = manager.ensureGroup(user1, "root")
 	assert.Equal(t, group, "")
 
+	// create config with groups as "test_root" for root queue path and "test_parent" for root.parent queue path but no group defined for
+	// "root.parent.leaf" queue path. ensure immediate parent queue path "root.parent" has been used for group matching and picked.
+	// once group has been matched, it doesn't change for other queue paths and should not change because lowest level queue group should be used
 	user = security.UserGroup{User: "test1", Groups: []string{"test", "test_root", "test_parent"}}
 	conf = createConfigWithDifferentGroups(user.User, user.Groups[0], "memory", "10", 50, 5)
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
@@ -77,11 +85,18 @@ func TestGetGroup(t *testing.T) {
 	assert.Equal(t, group, "test_parent")
 	group = manager.ensureGroup(user, "root.parent")
 	assert.Equal(t, group, "test_parent")
+	group = manager.ensureGroup(user, "root")
+	assert.Equal(t, group, "test_parent")
+
+	// create config with groups as "test_root" for root queue path and "test_parent" for root.parent queue path but no group defined for
+	// "root.parent.leaf" queue path. Passing just "root" as queue path returns "test_root" as searching starts from lowest level queue in entire queue path
 	conf = createConfigWithDifferentGroups(user.User, user.Groups[0], "memory", "10", 50, 5)
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 	group = manager.ensureGroup(user, "root")
 	assert.Equal(t, group, "test_root")
 
+	// create config with groups as "test_root" for root queue path and "test_parent" for root.parent queue path but no group defined for
+	// "root.parent.leaf" queue path. since "test_parent" group is not defined in UserGroup obj, "test_root" would be matched and picked.
 	user = security.UserGroup{User: "test1", Groups: []string{"test", "test_root"}}
 	conf = createConfigWithDifferentGroups(user.User, user.Groups[0], "memory", "10", 50, 5)
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
@@ -90,15 +105,49 @@ func TestGetGroup(t *testing.T) {
 	group = manager.ensureGroup(user, "root")
 	assert.Equal(t, group, "test_root")
 
-	user = security.UserGroup{User: "test1", Groups: []string{}}
-	conf = createConfigWithDifferentGroups(user.User, "", "memory", "10", 50, 5)
+	// do some activities with different users - user "test1" and "test2" belongs to "test_root" group
+	// ensure user "test1" and "test2" and its group linkage is intact through appGroupTrackers map
+	increased = manager.IncreaseTrackedResource("root.parent.leaf", TestApp1, usage1, user)
+	if !increased {
+		t.Errorf("unable to increase tracked resource. queuepath: root.parent.leaf, application id: %s, resource usage: %s, user: %s", TestApp1, usage1.String(), user.User)
+	}
+	assert.Equal(t, len(manager.userTrackers), 2)
+
+	user2 := security.UserGroup{User: "test2", Groups: []string{"test", "test_root"}}
+	increased = manager.IncreaseTrackedResource("root.parent.leaf", TestApp2, usage1, user2)
+	if !increased {
+		t.Errorf("unable to increase tracked resource. queuepath: root.parent.leaf, application id: %s, resource usage: %s, user: %s", TestApp2, usage1.String(), user2.User)
+	}
+	assert.Equal(t, len(manager.userTrackers), 3)
+
+	ut := manager.getUserTracker(user.User, false)
+	actualGT := ut.appGroupTrackers[TestApp1]
+	expectedGT := manager.getGroupTracker("test_root", false)
+	assert.Equal(t, manager.getGroupTracker("test_root", false) != nil, true)
+	assert.Equal(t, actualGT, expectedGT)
+	assert.Equal(t, actualGT.groupName, "test_root")
+
+	ut = manager.getUserTracker(user2.User, false)
+	actualGT = ut.appGroupTrackers[TestApp2]
+	expectedGT = manager.getGroupTracker("test_root", false)
+	assert.Equal(t, manager.getGroupTracker("test_root", false) != nil, true)
+	assert.Equal(t, actualGT, expectedGT)
+	assert.Equal(t, actualGT.groupName, "test_root")
+
+	assert.Equal(t, len(manager.userTrackers), 3)
+	assert.Equal(t, len(manager.groupTrackers), 2)
+
+	// create config without any limit settings for groups and
+	// since earlier group (test_root) limit settings has been cleared, ensure earlier user and group linkage through appGroupTrackers map has been removed
+	// and cleared as necessary
+	conf = createConfigWithDifferentGroups(user2.User, "", "memory", "10", 50, 5)
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
-	group = manager.ensureGroup(user, "root.parent.leaf")
-	assert.Equal(t, group, "")
-	group = manager.ensureGroup(user, "root.parent")
-	assert.Equal(t, group, "")
-	group = manager.ensureGroup(user, "root")
-	assert.Equal(t, group, "")
+	assert.Equal(t, len(manager.userTrackers), 3)
+	assert.Equal(t, len(manager.groupTrackers), 0)
+
+	ut = manager.getUserTracker(user.User, false)
+	assert.Equal(t, ut.appGroupTrackers[TestApp1] == nil, true)
+	assert.Equal(t, manager.getGroupTracker("test_root", false) == nil, true)
 }
 
 func TestAddRemoveUserAndGroups(t *testing.T) {
@@ -288,66 +337,59 @@ func TestUpdateConfigWithWildCardUsersAndGroups(t *testing.T) {
 		}
 	}
 
-	// configure max resource for root.parent to allow one more application to run
+	// configure max resource for root.parent as map[memory:60 vcores:60] to allow one more application to run
 	conf = createConfig(user.User, user.Groups[0], "memory", "50", 60, 6)
 	err = manager.UpdateConfig(conf.Queues[0], "root")
 	assert.NilError(t, err, "unable to set the limit for user user1 because current resource usage is greater than config max resource for root.parent")
 
 	// should run as user 'user' setting is map[memory:60 vcores:60] and total usage of "root.parent" is map[memory:50 vcores:50]
-	increased := manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user)
+	increased := manager.IncreaseTrackedResource(queuePath1, TestApp2, usage, user)
 	if !increased {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
 	}
 
 	// should not run as user 'user' setting is map[memory:60 vcores:60] and total usage of "root.parent" is map[memory:60 vcores:60]
-	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user)
+	increased = manager.IncreaseTrackedResource(queuePath1, TestApp3, usage, user)
 	if increased {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
 	}
 
 	// configure max resource for root.parent to allow one more application to run through wild card user settings (not through specific user)
-	user1 := security.UserGroup{User: "user2", Groups: []string{"group2"}}
+	// configure limits for user2 only. However, user1 should not be cleared as it has running applications
+	user1 := security.UserGroup{User: "user2", Groups: []string{"group1"}}
 	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0], "*", "*", "70", "70")
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+	// ensure both user1 & group1 has not been removed from local maps
+	assert.Equal(t, manager.GetUserTracker(user.User) != nil, true)
+	assert.Equal(t, manager.GetGroupTracker(user.Groups[0]) != nil, true)
 
-	// should run as wild card user '*' setting is map[memory:70 vcores:70] and total usage of "root.parent" is map[memory:60 vcores:60]
-	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user)
+	// user1 still should be able to run app as wild card user '*' setting is map[memory:70 vcores:70] for "root.parent" and
+	// total usage of "root.parent" is map[memory:60 vcores:60]
+	increased = manager.IncreaseTrackedResource(queuePath1, TestApp2, usage, user)
 	if !increased {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
+		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp2, user1)
 	}
 
-	// should not run as wild card user '*' setting is map[memory:70 vcores:70] and total usage of "root.parent" is map[memory:70 vcores:70]
-	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user)
+	// user1 should not be able to run app as wild card user '*' setting is map[memory:70 vcores:70] for "root.parent"
+	// and total usage of "root.parent" is map[memory:70 vcores:70]
+	increased = manager.IncreaseTrackedResource(queuePath1, TestApp3, usage, user)
 	if increased {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
+		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp3, user1)
 	}
 
-	// configure max resource for root.parent to allow one more application to run through wild card group settings (not through specific group)
-	// also wild card user limit settings not set
-	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0], "", "*", "80", "80")
+	// configure max resource for group1 * root.parent (map[memory:70 vcores:70]) higher than wild card group * root.parent settings (map[memory:10 vcores:10])
+	// ensure group's specific settings has been used for enforcement checks as specific limits always has higher precedence when compared to wild card group limit settings
+	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0], "*", "*", "10", "10")
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
-	// should run as wild card group '*' setting is map[memory:80 vcores:80] and total usage of "root.parent" is map[memory:70 vcores:70]
-	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user)
-	if !increased {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
-	}
-
-	// should not run as wild card group '*' setting is map[memory:80 vcores:80] and total usage of "root.parent" is map[memory:80 vcores:80]
-	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user)
-	if increased {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
-	}
-
-	// should run as wild card group '*' setting is map[memory:80 vcores:80] and total usage of "root.parent" is map[memory:70 vcores:70]
 	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user1)
-	if !increased {
+	if increased {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user1)
 	}
 
 	// configure max resource for user2 * root.parent (map[memory:70 vcores:70]) higher than wild card user * root.parent settings (map[memory:10 vcores:10])
-	// ensure user's specific settings overrides the wild card user limit settings
-	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0], "*", "*", "10", "10")
+	// ensure user's specific settings has been used for enforcement checks as specific limits always has higher precedence when compared to wild card user limit settings
+	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, "", "*", "*", "10", "10")
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
 	// can be allowed to run upto resource usage map[memory:70 vcores:70]
@@ -358,7 +400,7 @@ func TestUpdateConfigWithWildCardUsersAndGroups(t *testing.T) {
 		}
 	}
 
-	// should not run as user2 max limit is map[memory:70 vcores:70] and usage so far is map[memory:70 vcores:70]
+	// user2 should not be able to run app as user2 max limit is map[memory:70 vcores:70] and usage so far is map[memory:70 vcores:70]
 	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user1)
 	if increased {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
@@ -381,7 +423,8 @@ func TestUpdateConfigClearEarlierSetLimits(t *testing.T) {
 	}
 	assertMaxLimits(t, user, expectedResource, 5)
 
-	// create config user2 * root.parent with [50, 50] and maxapps as 5 (twice for root), but not user1. so user1 should not be there as it doesn't have any running applications
+	// create config user2 * root.parent with [50, 50] and maxapps as 5 (twice for root), but not user1.
+	// so user1 should not be there as it doesn't have any running applications
 	user1 := security.UserGroup{User: "user2", Groups: []string{"group2"}}
 	conf = createUpdateConfig(user1.User, user1.Groups[0])
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
@@ -404,8 +447,8 @@ func TestUpdateConfigClearEarlierSetLimits(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, expectedResource)
 	}
-	assert.Equal(t, manager.GetUserTracker(user.User) == nil, true)
-	assert.Equal(t, manager.GetGroupTracker(user.Groups[0]) == nil, true)
+	assert.Equal(t, manager.GetUserTracker(user1.User) != nil, true)
+	assert.Equal(t, manager.GetGroupTracker(user1.Groups[0]) != nil, true)
 	assertMaxLimits(t, user1, expectedResource, 6)
 
 	expectedResource, err = resources.NewResourceFromConf(map[string]string{"memory": "70", "vcores": "70"})
@@ -417,8 +460,8 @@ func TestUpdateConfigClearEarlierSetLimits(t *testing.T) {
 	// and wild card settings
 	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0], "*", "*", "10", "10")
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
-	assert.Equal(t, manager.GetUserTracker(user.User) == nil, true)
-	assert.Equal(t, manager.GetGroupTracker(user.Groups[0]) == nil, true)
+	assert.Equal(t, manager.GetUserTracker(user1.User) != nil, true)
+	assert.Equal(t, manager.GetGroupTracker(user1.Groups[0]) != nil, true)
 	assertMaxLimits(t, user1, expectedResource, 10)
 	assertWildCardLimits(t, m.userWildCardLimitsConfig, expectedResource)
 	assertWildCardLimits(t, m.groupWildCardLimitsConfig, expectedResource)
@@ -701,6 +744,16 @@ func createConfig(user string, group string, resourceKey string, resourceValue s
 }
 
 func createConfigWithDifferentGroups(user string, group string, resourceKey string, resourceValue string, mem int, maxApps uint64) configs.PartitionConfig {
+	var rootGroups []string
+	var parentGroups []string
+	if group != "" {
+		parentGroups = []string{
+			group + "_parent",
+		}
+		rootGroups = []string{
+			group + "_root",
+		}
+	}
 	conf := configs.PartitionConfig{
 		Name: "test",
 		Queues: []configs.QueueConfig{
@@ -720,9 +773,7 @@ func createConfigWithDifferentGroups(user string, group string, resourceKey stri
 								Users: []string{
 									user,
 								},
-								Groups: []string{
-									group + "_parent",
-								},
+								Groups: parentGroups,
 								MaxResources: map[string]string{
 									"memory": strconv.Itoa(mem),
 									"vcores": strconv.Itoa(mem),
@@ -738,9 +789,7 @@ func createConfigWithDifferentGroups(user string, group string, resourceKey stri
 						Users: []string{
 							user,
 						},
-						Groups: []string{
-							group + "_root",
-						},
+						Groups: rootGroups,
 						MaxResources: map[string]string{
 							"memory": strconv.Itoa(mem * 2),
 							"vcores": strconv.Itoa(mem * 2),

--- a/pkg/scheduler/ugm/queue_tracker.go
+++ b/pkg/scheduler/ugm/queue_tracker.go
@@ -152,6 +152,7 @@ func (qt *QueueTracker) increaseTrackedResource(queuePath string, applicationID 
 	log.Log(log.SchedUGM).Debug("Successfully increased resource usage",
 		zap.Int("tracking type", int(trackType)),
 		zap.String("queue path", queuePath),
+		zap.String("qt queue path", qt.queuePath),
 		zap.String("application", applicationID),
 		zap.Bool("existing app", existingApp),
 		zap.Stringer("resource", usage),

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -34,6 +34,10 @@ type UserTracker struct {
 	// and group tracker object as value.
 	appGroupTrackers map[string]*GroupTracker
 	queueTracker     *QueueTracker // Holds the actual resource usage of queue path where application runs
+	// Group selected by matching the list of groups stored in security.UserGroup against the list of groups [Manager.configuredGroups] configured with limit settings.
+	// Manager.configuredGroups holds group only for which limit has been configured in bottom up queue hierarchical order starting from leaf to root.
+	// First matched group would be picked and stored in this variable
+	matchedGroup string
 
 	sync.RWMutex
 }
@@ -75,6 +79,18 @@ func (ut *UserTracker) setGroupForApp(applicationID string, groupTrack *GroupTra
 	if ut.appGroupTrackers[applicationID] == nil {
 		ut.appGroupTrackers[applicationID] = groupTrack
 	}
+}
+
+func (ut *UserTracker) getMatchedGroup() string {
+	ut.RLock()
+	defer ut.RUnlock()
+	return ut.matchedGroup
+}
+
+func (ut *UserTracker) setMatchedGroup(group string) {
+	ut.Lock()
+	defer ut.Unlock()
+	ut.matchedGroup = group
 }
 
 func (ut *UserTracker) getTrackedApplications() map[string]*GroupTracker {

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -76,9 +76,13 @@ func (ut *UserTracker) hasGroupForApp(applicationID string) bool {
 func (ut *UserTracker) setGroupForApp(applicationID string, groupTrack *GroupTracker) {
 	ut.Lock()
 	defer ut.Unlock()
-	if ut.appGroupTrackers[applicationID] == nil {
-		ut.appGroupTrackers[applicationID] = groupTrack
-	}
+	ut.appGroupTrackers[applicationID] = groupTrack
+}
+
+func (ut *UserTracker) getGroupForApp(applicationID string) *GroupTracker {
+	ut.Lock()
+	defer ut.Unlock()
+	return ut.appGroupTrackers[applicationID]
 }
 
 func (ut *UserTracker) getMatchedGroup() string {

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -119,7 +119,9 @@ func (ut *UserTracker) GetUserResourceUsageDAOInfo() *dao.UserResourceUsageDAOIn
 	}
 	userResourceUsage.UserName = ut.userName
 	for app, gt := range ut.appGroupTrackers {
-		userResourceUsage.Groups[app] = gt.groupName
+		if gt != nil {
+			userResourceUsage.Groups[app] = gt.groupName
+		}
 	}
 	userResourceUsage.Queues = ut.queueTracker.getResourceUsageDAOInfo("")
 	return userResourceUsage

--- a/pkg/scheduler/ugm/utilities.go
+++ b/pkg/scheduler/ugm/utilities.go
@@ -36,3 +36,16 @@ func getChildQueuePath(queuePath string) (string, string) {
 	}
 	return childQueuePath, childQueuePath[:idx]
 }
+
+func getParentQueuePath(queuePath string) (string, string) {
+	idx := strings.LastIndex(queuePath, configs.DOT)
+	if idx == -1 {
+		return "", ""
+	}
+	parentQueuePath := queuePath[:idx]
+	idx = strings.LastIndex(parentQueuePath, configs.DOT)
+	if idx == -1 {
+		return parentQueuePath, parentQueuePath
+	}
+	return parentQueuePath, parentQueuePath[idx+1:]
+}

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 
 	"github.com/julienschmidt/httprouter"
-
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/yaml.v3"
 	"gotest.tools/v3/assert"
@@ -1280,8 +1279,7 @@ func TestSpecificUserAndGroupResourceUsage(t *testing.T) {
 	getGroupResourceUsage(resp, req)
 	err = json.Unmarshal(resp.outputBytes, &groupResourceUsageDao)
 	assert.NilError(t, err, "failed to unmarshal group resource usage dao response from response body: %s", string(resp.outputBytes))
-	assert.Equal(t, groupResourceUsageDao.Queues.ResourceUsage.String(),
-		resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1}).String())
+	assert.DeepEqual(t, groupResourceUsageDao, &dao.GroupResourceUsageDAOInfo{GroupName: "", Applications: nil, Queues: nil})
 
 	// Test non-existing group query
 	req, err = http.NewRequest("GET", "/ws/v1/partition/default/usage/group/", strings.NewReader(""))
@@ -1322,15 +1320,14 @@ func TestUsersAndGroupsResourceUsage(t *testing.T) {
 	assert.NilError(t, err, "Get Groups Resource Usage Handler request failed")
 
 	var groupsResourceUsageDao []*dao.GroupResourceUsageDAOInfo
+	var expGroupsResourceUsageDao []*dao.GroupResourceUsageDAOInfo
 	getGroupsResourceUsage(resp, req)
 	err = json.Unmarshal(resp.outputBytes, &groupsResourceUsageDao)
 	assert.NilError(t, err, "failed to unmarshal groups resource usage dao response from response body: %s", string(resp.outputBytes))
-	assert.Equal(t, groupsResourceUsageDao[0].Queues.ResourceUsage.String(),
-		resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1}).String())
+	assert.DeepEqual(t, groupsResourceUsageDao, expGroupsResourceUsageDao)
 
 	// Assert existing groups
-	assert.Equal(t, len(groupsResourceUsageDao), 1)
-	assert.Equal(t, groupsResourceUsageDao[0].GroupName, "testgroup")
+	assert.Equal(t, len(groupsResourceUsageDao), 0)
 }
 
 func prepareSchedulerContext(t *testing.T, stateDumpConf bool) *scheduler.ClusterContext {


### PR DESCRIPTION
### What is this PR for?

At times, config may have limits only for users but not for its group. Additionally, if there are any limit settings explicitly configured for wild card group, then wild card group limit settings should be applied for those users. In this case, group tracker object would be created for "*" and mapped to the user in appGroupTrackers map like any other named group.

Also, this PR ensures user tracking changes would be reverted in case of any issues(group quota exceeded etc) in group tracking flow.

### What type of PR is it?
* [ ] - Feature

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1864

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
