### PR TITLE
[YUNIKORN-1870] update depguard config to new format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,14 +42,15 @@ linters-settings:
     lines: 120
     statements: 80
   depguard:
-    list-type: blacklist
-    include-go-root: false
-    packages:
-      - github.com/sirupsen/logrus
-      - github.com/stretchr/testify
-    packages-with-error-messages:
-      github.com/sirupsen/logrus: "logging is standardised via yunikorn logger and zap"
-      github.com/stretchr/testify: "test assertions must use gotest.tools/v3/assert"
+    rules:
+      main:
+        files:
+          - $all
+        deny:
+          - pkg: "github.com/sirupsen/logrus"
+            desc: "logging is standardised via yunikorn logger and zap"
+          - pkg: "github.com/stretchr/testify"
+            desc: "test assertions must use gotest.tools/v3/assert"
 
 # linters to use
 linters:


### PR DESCRIPTION
### What is this PR for?

We update golangci-lint from v1.51.2 to v1.53.3. In this update, upstream migrated depguard to v2, and changed the default configuration. We also need to update it, or `./tools/golangci-lint run` will show depguard errors like:

```
import 'github.com/apache/yunikorn-core/pkg/common/resources' is not allowed from list 'Main'
```

Upstream reference: https://github.com/golangci/golangci-lint/commit/fb746c4b04c3a2f2f55400d22d40192b7e659b3b

### What type of PR is it?
* [ ] - Bug Fix
* [X] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-1870

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
