### PR TITLE
[YUNIKORN-1883] Implement CREATE_DRAIN semantics for node addition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ module github.com/apache/yunikorn-core
 go 1.20
 
 require (
-	github.com/apache/yunikorn-scheduler-interface v0.0.0-20230621102204-bcadd461d275
+	github.com/apache/yunikorn-scheduler-interface v0.0.0-20230731151735-8931af4dda26
 	github.com/google/btree v1.1.2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20230621102204-bcadd461d275 h1:rohcBe0tzmokyo8QTzSni4SeH8pHJb+Hxo4XEh5wsDY=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20230621102204-bcadd461d275/go.mod h1:HZl8aYm89D3VUuBbMvxzYbra84XVfgSjJWQat0kD1cE=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20230731151735-8931af4dda26 h1:78Ow8OCXd7eSKN6tnpG27sdP2rUh//vcxFHaRDYc31Y=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20230731151735-8931af4dda26/go.mod h1:/n67iTTOytyVor6wETVjleqzsp/NxCUmPslHcTvJ+Nw=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -128,6 +128,7 @@ type CoreSchedulerMetrics interface {
 	SetActiveNodes(value int)
 	IncDrainingNodes()
 	DecDrainingNodes()
+	GetDrainingNodes() (int, error)
 	IncUnhealthyNodes()
 	DecUnhealthyNodes()
 	IncTotalDecommissionedNodes()

--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -396,6 +396,15 @@ func (m *SchedulerMetrics) DecDrainingNodes() {
 	m.node.With(prometheus.Labels{"state": "draining"}).Dec()
 }
 
+func (m *SchedulerMetrics) GetDrainingNodes() (int, error) {
+	metricDto := &dto.Metric{}
+	err := m.node.With(prometheus.Labels{"state": "draining"}).Write(metricDto)
+	if err == nil {
+		return int(*metricDto.Gauge.Value), nil
+	}
+	return -1, err
+}
+
 func (m *SchedulerMetrics) IncTotalDecommissionedNodes() {
 	m.node.With(prometheus.Labels{"state": "decommissioned"}).Inc()
 }


### PR DESCRIPTION
### What is this PR for?
As part of the recovery refactoring, we want to be able to register all nodes, then all applications, and finally all existing allocations. To support this, it will be useful to allow creation of nodes that are initially in an unschedulable (i.e. draining) state.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1883

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
