### PR TITLE
[YUNIKORN-1864] Apply wild card group limit settings for users withou…

### DIFF
--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -21,6 +21,7 @@ package ugm
 import (
 	"sync"
 
+	"github.com/apache/yunikorn-core/pkg/common"
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/webservice/dao"
 )
@@ -93,7 +94,7 @@ func (gt *GroupTracker) GetGroupResourceUsageDAOInfo() *dao.GroupResourceUsageDA
 	for app := range gt.applications {
 		groupResourceUsage.Applications = append(groupResourceUsage.Applications, app)
 	}
-	groupResourceUsage.Queues = gt.queueTracker.getResourceUsageDAOInfo("")
+	groupResourceUsage.Queues = gt.queueTracker.getResourceUsageDAOInfo(common.Empty)
 	return groupResourceUsage
 }
 
@@ -130,7 +131,7 @@ func (gt *GroupTracker) removeApp(applicationID string) {
 
 func (gt *GroupTracker) getName() string {
 	if gt == nil {
-		return ""
+		return common.Empty
 	}
 	return gt.groupName
 }

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -429,9 +429,15 @@ func TestUpdateConfigWithWildCardUsersAndGroups(t *testing.T) {
 	conf = createUpdateConfigWithWildCardUsersAndGroups(user4.User, user4.Groups[0], "", "*", "10", "10")
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
-	// can be allowed to run upto resource usage map[memory:70 vcores:70]
+	// Since app is TestApp1, gt of "*" would be used as it is already mapped. group4 won't be used
+	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user4)
+	if increased {
+		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user1)
+	}
+
+	// Now group4 would be used as user4 is running TestApp2 for the first time. So can be allowed to run upto resource usage map[memory:70 vcores:70]
 	for i := 1; i <= 7; i++ {
-		increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user4)
+		increased = manager.IncreaseTrackedResource(queuePath1, TestApp2, usage, user4)
 		if !increased {
 			t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user1)
 		}

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -393,7 +393,7 @@ func TestUpdateConfigWithWildCardUsersAndGroups(t *testing.T) {
 
 	// configure max resource for user2 * root.parent (map[memory:70 vcores:70]) higher than wild card user * root.parent settings (map[memory:10 vcores:10])
 	// ensure user's specific settings has been used for enforcement checks as specific limits always has higher precedence when compared to wild card user limit settings
-	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, "", "*", "*", "10", "10")
+	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, "", "*", "", "10", "10")
 	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
 	// can be allowed to run upto resource usage map[memory:70 vcores:70]
@@ -409,6 +409,37 @@ func TestUpdateConfigWithWildCardUsersAndGroups(t *testing.T) {
 	if increased {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user1)
 	}
+
+	user3 := security.UserGroup{User: "user3", Groups: []string{"group3"}}
+	conf = createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0], "", "*", "10", "10")
+	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+
+	// user3 should be able to run app as group3 uses wild card group limit settings map[memory:10 vcores:10]
+	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user3)
+	if !increased {
+		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user)
+	}
+
+	// user4 (though belongs to different group, group4) should not be able to run app as group4 also
+	// uses wild card group limit settings map[memory:10 vcores:10]
+	user4 := security.UserGroup{User: "user4", Groups: []string{"group4"}}
+	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user4)
+	assert.Equal(t, increased, false)
+
+	conf = createUpdateConfigWithWildCardUsersAndGroups(user4.User, user4.Groups[0], "", "*", "10", "10")
+	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+
+	// can be allowed to run upto resource usage map[memory:70 vcores:70]
+	for i := 1; i <= 7; i++ {
+		increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user4)
+		if !increased {
+			t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, user1)
+		}
+	}
+
+	// user4 should not be able to run app as user4 max limit is map[memory:70 vcores:70] and usage so far is map[memory:70 vcores:70]
+	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user4)
+	assert.Equal(t, increased, false)
 }
 
 func TestUpdateConfigClearEarlierSetLimits(t *testing.T) {

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -23,6 +23,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/apache/yunikorn-core/pkg/common"
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/log"
 	"github.com/apache/yunikorn-core/pkg/webservice/dao"
@@ -66,11 +67,10 @@ func (ut *UserTracker) increaseTrackedResource(queuePath, applicationID string, 
 		if !increasedGroupUsage {
 			_, decreased := ut.queueTracker.decreaseTrackedResource(queuePath, applicationID, usage, false)
 			if !decreased {
-				log.Log(log.SchedUGM).Error("Problem in increasing group resource usage. Hence tried to rollback user tracked usage, but failed to do.",
+				log.Log(log.SchedUGM).Error("User resource usage rollback has failed",
 					zap.String("queue path", queuePath),
 					zap.String("application", applicationID),
-					zap.String("user", ut.userName),
-					zap.Stringer("usage", usage))
+					zap.String("user", ut.userName))
 			}
 		}
 		return increasedGroupUsage
@@ -106,7 +106,7 @@ func (ut *UserTracker) getGroupForApp(applicationID string) string {
 	if ut.appGroupTrackers[applicationID] != nil {
 		return ut.appGroupTrackers[applicationID].groupName
 	}
-	return ""
+	return common.Empty
 }
 
 func (ut *UserTracker) getTrackedApplications() map[string]*GroupTracker {
@@ -139,7 +139,7 @@ func (ut *UserTracker) GetUserResourceUsageDAOInfo() *dao.UserResourceUsageDAOIn
 			userResourceUsage.Groups[app] = gt.groupName
 		}
 	}
-	userResourceUsage.Queues = ut.queueTracker.getResourceUsageDAOInfo("")
+	userResourceUsage.Queues = ut.queueTracker.getResourceUsageDAOInfo(common.Empty)
 	return userResourceUsage
 }
 


### PR DESCRIPTION
…t any matching group

### What is this PR for?

At times, config may have limits only for users but not for its group. Additionally, if there are any limit settings explicitly configured for wild card group, then wild card group limit settings should be applied for those users. In this case, group tracker object would be created for "*" and mapped to the user in appGroupTrackers map like any other named group.

Also, this PR ensures user tracking changes would be reverted in case of any issues(group quota exceeded etc) in group tracking flow.


### What type of PR is it?
* [ ] - Feature

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1864

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
