### PR TITLE
[YUNIKORN-1858] Handle group resource usage properly during config ch…

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -681,6 +681,7 @@ func (sa *Application) AddAllocationAsk(ask *AllocationAsk) error {
 
 	log.Log(log.SchedApplication).Info("ask added successfully to application",
 		zap.String("appID", sa.ApplicationID),
+		zap.String("appID", sa.user.User),
 		zap.String("ask", ask.GetAllocationKey()),
 		zap.Bool("placeholder", ask.IsPlaceholder()),
 		zap.Stringer("pendingDelta", delta))

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -3527,6 +3527,26 @@ func TestUserHeadroom(t *testing.T) {
 	if alloc != nil {
 		t.Fatal("allocation should not happen on other nodes as well")
 	}
+	partition.removeApplication("app-5")
+
+	app6 := newApplicationWithUser("app-6", "default", "root.parent.sub-leaf", security.UserGroup{
+		User:   "testuser1",
+		Groups: []string{"testgroup1"},
+	})
+	res, err = resources.NewResourceFromConf(map[string]string{"memory": "3", "vcores": "3"})
+	assert.NilError(t, err, "failed to create resource")
+
+	err = partition.AddApplication(app6)
+	assert.NilError(t, err, "failed to add app-6 to partition")
+	err = app6.AddAllocationAsk(newAllocationAsk(allocID, "app-6", res))
+	assert.NilError(t, err, "failed to add ask alloc-1 to app-6")
+
+	// app 6 would be allocated as headroom is nil because no limits configured for 'testuser1' user an
+	alloc = partition.tryAllocate()
+	if alloc == nil {
+		t.Fatal("allocation did not return any allocation")
+	}
+	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
 }
 
 func TestPlaceholderAllocationTracking(t *testing.T) {

--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -138,7 +138,7 @@ func (gt *GroupTracker) decreaseAllTrackedResourceUsage(queuePath string) map[st
 	defer gt.Unlock()
 	applications := gt.queueTracker.decreaseTrackedResourceUsageDownwards(queuePath)
 	removedApplications := make(map[string]string)
-	for app, _ := range applications {
+	for app := range applications {
 		if u, ok := gt.applications[app]; ok {
 			removedApplications[app] = u
 		}

--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -123,15 +123,21 @@ func (gt *GroupTracker) canBeRemoved() bool {
 	return len(gt.queueTracker.childQueueTrackers) == 0 && len(gt.queueTracker.runningApplications) == 0
 }
 
-func (gt *GroupTracker) removeApp(applicationID string) {
-	gt.Lock()
-	defer gt.Unlock()
-	delete(gt.applications, applicationID)
-}
-
 func (gt *GroupTracker) getName() string {
 	if gt == nil {
 		return common.Empty
 	}
 	return gt.groupName
+}
+
+func (gt *GroupTracker) decreaseTrackedResourceUsage(applicationID string, removeApp bool) (bool, bool) {
+	if gt == nil {
+		return false, true
+	}
+	gt.Lock()
+	defer gt.Unlock()
+	if removeApp {
+		delete(gt.applications, applicationID)
+	}
+	return gt.queueTracker.decreaseTrackedResourceUsage(applicationID)
 }

--- a/pkg/scheduler/ugm/group_tracker_test.go
+++ b/pkg/scheduler/ugm/group_tracker_test.go
@@ -40,7 +40,7 @@ func TestGTIncreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
 	}
-	result := groupTracker.increaseTrackedResource(queuePath1, TestApp1, usage1)
+	result := groupTracker.increaseTrackedResource(queuePath1, TestApp1, usage1, user.User)
 	if !result {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, usage1)
 	}
@@ -49,7 +49,7 @@ func TestGTIncreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage2)
 	}
-	result = groupTracker.increaseTrackedResource(queuePath2, TestApp2, usage2)
+	result = groupTracker.increaseTrackedResource(queuePath2, TestApp2, usage2, user.User)
 	if !result {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath2, TestApp2, usage2)
 	}
@@ -58,7 +58,7 @@ func TestGTIncreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
-	result = groupTracker.increaseTrackedResource(queuePath3, TestApp3, usage3)
+	result = groupTracker.increaseTrackedResource(queuePath3, TestApp3, usage3, user.User)
 	if !result {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath3, TestApp3, usage3)
 	}
@@ -67,7 +67,7 @@ func TestGTIncreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
-	result = groupTracker.increaseTrackedResource(queuePath4, TestApp4, usage4)
+	result = groupTracker.increaseTrackedResource(queuePath4, TestApp4, usage4, user.User)
 	if !result {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath4, TestApp4, usage4)
 	}
@@ -92,7 +92,7 @@ func TestGTDecreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
 	}
-	result := groupTracker.increaseTrackedResource(queuePath1, TestApp1, usage1)
+	result := groupTracker.increaseTrackedResource(queuePath1, TestApp1, usage1, user.User)
 	if !result {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, usage1)
 	}
@@ -102,7 +102,7 @@ func TestGTDecreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage2)
 	}
-	result = groupTracker.increaseTrackedResource(queuePath2, TestApp2, usage2)
+	result = groupTracker.increaseTrackedResource(queuePath2, TestApp2, usage2, user.User)
 	if !result {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath2, TestApp2, usage2)
 	}
@@ -172,7 +172,7 @@ func TestGTSetMaxLimits(t *testing.T) {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
 	}
 
-	result := groupTracker.increaseTrackedResource(queuePath1, TestApp1, usage1)
+	result := groupTracker.increaseTrackedResource(queuePath1, TestApp1, usage1, user.User)
 	if !result {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, usage1)
 	}
@@ -180,11 +180,11 @@ func TestGTSetMaxLimits(t *testing.T) {
 	groupTracker.setLimits(queuePath1, resources.Multiply(usage1, 5), 5)
 	groupTracker.setLimits("root.parent", resources.Multiply(usage1, 10), 10)
 
-	result = groupTracker.increaseTrackedResource(queuePath1, TestApp2, usage1)
+	result = groupTracker.increaseTrackedResource(queuePath1, TestApp2, usage1, user.User)
 	if !result {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp2, usage1)
 	}
-	result = groupTracker.increaseTrackedResource(queuePath1, TestApp3, usage1)
+	result = groupTracker.increaseTrackedResource(queuePath1, TestApp3, usage1, user.User)
 	if !result {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp2, usage1)
 	}

--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -408,6 +408,10 @@ func (m *Manager) processGroupConfig(group string, limitConfig *LimitConfig, que
 
 // clearEarlierSetLimits Clear already configured limits of users and groups for which limits have been configured before but not now
 func (m *Manager) clearEarlierSetLimits(userLimits map[string]bool, groupLimits map[string]bool, queuePath string) error {
+	// Clear already configured limits of group for which limits have been configured before but not now
+	for _, gt := range m.groupTrackers {
+		m.clearEarlierSetGroupLimits(gt, queuePath, groupLimits)
+	}
 	// Clear already configured limits of user for which limits have been configured before but not now
 	for u, ut := range m.userTrackers {
 		// Is this user already tracked for the queue path?
@@ -423,31 +427,24 @@ func (m *Manager) clearEarlierSetLimits(userLimits map[string]bool, groupLimits 
 							zap.String("group", gt.groupName),
 							zap.String("application id", appID),
 							zap.String("queue path", queuePath))
-						// removing the linkage only happens here by setting it to nil and deleting app id
-						// but group resource usage so far remains as it is because we don't have app id wise resource usage with in group as of now.
-						// YUNIKORN-1858 handles the group resource usage properly
-						// In case of only one (last) application, group tracker would be removed from the manager.
+						// simply remove the linkage between the user and group by setting gt to nil for the given app.
+						// but in case of group, specific app resource usage has to be decremented
 						ut.setGroupForApp(appID, nil)
-						gt.removeApp(appID)
-						if len(gt.getTrackedApplications()) == 0 {
-							log.Log(log.SchedUGM).Debug("Is this app the only running application in group?",
-								zap.String("user", u),
-								zap.String("group", gt.groupName),
-								zap.Int("no. of applications", len(gt.getTrackedApplications())),
-								zap.String("application id", appID),
-								zap.String("queue path", queuePath))
-							delete(m.groupTrackers, g)
+						removeQT, decreased := gt.decreaseTrackedResourceUsage(appID, true)
+						if decreased {
+							if removeQT {
+								log.Log(log.SchedUGM).Debug("Removing group from manager",
+									zap.String("group", gt.groupName),
+									zap.String("queue path", queuePath),
+									zap.String("application", appID))
+								delete(m.groupTrackers, gt.groupName)
+							}
 						}
 					}
 				}
 			}
 		}
 		m.clearEarlierSetUserLimits(ut, queuePath, userLimits)
-	}
-
-	// Clear already configured limits of group for which limits have been configured before but not now
-	for _, gt := range m.groupTrackers {
-		m.clearEarlierSetGroupLimits(gt, queuePath, groupLimits)
 	}
 	return nil
 }

--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -410,40 +410,17 @@ func (m *Manager) processGroupConfig(group string, limitConfig *LimitConfig, que
 func (m *Manager) clearEarlierSetLimits(userLimits map[string]bool, groupLimits map[string]bool, queuePath string) error {
 	// Clear already configured limits of group for which limits have been configured before but not now
 	for _, gt := range m.groupTrackers {
-		m.clearEarlierSetGroupLimits(gt, queuePath, groupLimits)
-	}
-	// Clear already configured limits of user for which limits have been configured before but not now
-	for u, ut := range m.userTrackers {
-		// Is this user already tracked for the queue path?
-		if ut.IsQueuePathTrackedCompletely(queuePath) {
-			// Traverse all the group trackers linked to user through different applications and remove the linkage
-			for appID, gt := range ut.appGroupTrackers {
-				if gt != nil {
-					g := gt.groupName
-					// Is there any limit config set for group in the current configuration? If not, then remove the linkage by setting it to nil
-					if ok := groupLimits[g]; !ok {
-						log.Log(log.SchedUGM).Debug("Removed the linkage between user and group through applications",
-							zap.String("user", u),
-							zap.String("group", gt.groupName),
-							zap.String("application id", appID),
-							zap.String("queue path", queuePath))
-						// simply remove the linkage between the user and group by setting gt to nil for the given app.
-						// but in case of group, specific app resource usage has to be decremented
-						ut.setGroupForApp(appID, nil)
-						removeQT, decreased := gt.decreaseTrackedResourceUsage(appID, true)
-						if decreased {
-							if removeQT {
-								log.Log(log.SchedUGM).Debug("Removing group from manager",
-									zap.String("group", gt.groupName),
-									zap.String("queue path", queuePath),
-									zap.String("application", appID))
-								delete(m.groupTrackers, gt.groupName)
-							}
-						}
-					}
-				}
+		appUsersMap := m.clearEarlierSetGroupLimits(gt, queuePath, groupLimits)
+		if len(appUsersMap) > 0 {
+			for app, user := range appUsersMap {
+				ut := m.userTrackers[user]
+				ut.setGroupForApp(app, nil)
 			}
 		}
+	}
+
+	// Clear already configured limits of user for which limits have been configured before but not now
+	for _, ut := range m.userTrackers {
 		m.clearEarlierSetUserLimits(ut, queuePath, userLimits)
 	}
 	return nil
@@ -477,7 +454,8 @@ func (m *Manager) clearEarlierSetUserLimits(ut *UserTracker, queuePath string, u
 	}
 }
 
-func (m *Manager) clearEarlierSetGroupLimits(gt *GroupTracker, queuePath string, groupLimits map[string]bool) {
+func (m *Manager) clearEarlierSetGroupLimits(gt *GroupTracker, queuePath string, groupLimits map[string]bool) map[string]string {
+	appUsersMap := make(map[string]string)
 	// Is this group already tracked for the queue path?
 	if gt.IsQueuePathTrackedCompletely(queuePath) {
 		g := gt.groupName
@@ -486,6 +464,7 @@ func (m *Manager) clearEarlierSetGroupLimits(gt *GroupTracker, queuePath string,
 			log.Log(log.SchedUGM).Debug("Need to clear earlier set configs for group",
 				zap.String("group", g),
 				zap.String("queue path", queuePath))
+			appUsersMap = gt.decreaseAllTrackedResourceUsage(queuePath)
 			// Is there any running applications in end queue of this queue path? If not, then remove the linkage between end queue and its immediate parent
 			if gt.IsUnlinkRequired(queuePath) {
 				gt.UnlinkQT(queuePath)
@@ -503,6 +482,7 @@ func (m *Manager) clearEarlierSetGroupLimits(gt *GroupTracker, queuePath string,
 			}
 		}
 	}
+	return appUsersMap
 }
 
 func (m *Manager) setUserLimits(user string, limitConfig *LimitConfig, queuePath string) error {

--- a/pkg/scheduler/ugm/queue_tracker_test.go
+++ b/pkg/scheduler/ugm/queue_tracker_test.go
@@ -78,6 +78,15 @@ func TestQTIncreaseTrackedResource(t *testing.T) {
 	assert.Equal(t, "map[mem:20000000 vcore:20000]", actualResources["root.parent.child2"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:20000000 vcore:20000]", actualResources["root.parent.child12"].String(), "wrong resource")
 	assert.Equal(t, 4, len(queueTracker.runningApplications))
+
+	app1ResourceUsage := queueTracker.runningApplications[TestApp1]
+	assert.Equal(t, "map[mem:10000000 vcore:10000]", app1ResourceUsage.String(), "wrong resource")
+	app2ResourceUsage := queueTracker.runningApplications[TestApp2]
+	assert.Equal(t, "map[mem:20000000 vcore:20000]", app2ResourceUsage.String(), "wrong resource")
+	app3ResourceUsage := queueTracker.runningApplications[TestApp3]
+	assert.Equal(t, "map[mem:30000000 vcore:30000]", app3ResourceUsage.String(), "wrong resource")
+	app4ResourceUsage := queueTracker.runningApplications[TestApp4]
+	assert.Equal(t, "map[mem:20000000 vcore:20000]", app4ResourceUsage.String(), "wrong resource")
 }
 
 func TestQTDecreaseTrackedResource(t *testing.T) {
@@ -113,6 +122,11 @@ func TestQTDecreaseTrackedResource(t *testing.T) {
 	assert.Equal(t, "map[mem:70000000 vcore:70000]", actualResources["root.parent.child1"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:20000000 vcore:20000]", actualResources["root.parent.child2"].String(), "wrong resource")
 
+	app1ResourceUsage := queueTracker.runningApplications[TestApp1]
+	assert.Equal(t, "map[mem:70000000 vcore:70000]", app1ResourceUsage.String(), "wrong resource")
+	app2ResourceUsage := queueTracker.runningApplications[TestApp2]
+	assert.Equal(t, "map[mem:20000000 vcore:20000]", app2ResourceUsage.String(), "wrong resource")
+
 	usage3, err := resources.NewResourceFromConf(map[string]string{"mem": "10M", "vcore": "10"})
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
@@ -136,6 +150,11 @@ func TestQTDecreaseTrackedResource(t *testing.T) {
 	assert.Equal(t, "map[mem:60000000 vcore:60000]", actualResources1["root.parent.child1"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:10000000 vcore:10000]", actualResources1["root.parent.child2"].String(), "wrong resource")
 	assert.Equal(t, len(queueTracker.childQueueTrackers["parent"].childQueueTrackers), 2)
+
+	app1ResourceUsage = queueTracker.runningApplications[TestApp1]
+	assert.Equal(t, "map[mem:60000000 vcore:60000]", app1ResourceUsage.String(), "wrong resource")
+	app2ResourceUsage = queueTracker.runningApplications[TestApp2]
+	assert.Equal(t, "map[mem:10000000 vcore:10000]", app2ResourceUsage.String(), "wrong resource")
 
 	usage4, err := resources.NewResourceFromConf(map[string]string{"mem": "60M", "vcore": "60"})
 	if err != nil {
@@ -163,6 +182,11 @@ func TestQTDecreaseTrackedResource(t *testing.T) {
 	assert.Equal(t, len(queueTracker.childQueueTrackers), 0)
 	assert.Equal(t, removeQT, true, "wrong remove queue tracker value")
 
+	app1ResourceUsage = queueTracker.runningApplications[TestApp1]
+	assert.Equal(t, resources.Equals(nil, app1ResourceUsage), true)
+	app2ResourceUsage = queueTracker.runningApplications[TestApp2]
+	assert.Equal(t, resources.Equals(nil, app2ResourceUsage), true)
+
 	// Test parent queueTracker has not zero usage, but child queueTrackers has all deleted
 	result = queueTracker.increaseTrackedResource(queuePath1, TestApp1, user, usage1)
 	if !result {
@@ -178,6 +202,17 @@ func TestQTDecreaseTrackedResource(t *testing.T) {
 	if !result {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", "root.parent", TestApp2, usage2)
 	}
+
+	app2ResourceUsage = queueTracker.runningApplications[TestApp2]
+	assert.Equal(t, "map[mem:20000000 vcore:20000]", app2ResourceUsage.String(), "wrong resource")
+
+	_, decreased = queueTracker.decreaseTrackedResourceUsage(TestApp2)
+	if !decreased {
+		t.Fatalf("unable to decrease tracked resource: app %s", TestApp2)
+	}
+
+	app2ResourceUsage = queueTracker.runningApplications[TestApp2]
+	assert.Equal(t, resources.Equals(nil, app2ResourceUsage), true)
 }
 
 func TestQTQuotaEnforcement(t *testing.T) {

--- a/pkg/scheduler/ugm/queue_tracker_test.go
+++ b/pkg/scheduler/ugm/queue_tracker_test.go
@@ -78,15 +78,6 @@ func TestQTIncreaseTrackedResource(t *testing.T) {
 	assert.Equal(t, "map[mem:20000000 vcore:20000]", actualResources["root.parent.child2"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:20000000 vcore:20000]", actualResources["root.parent.child12"].String(), "wrong resource")
 	assert.Equal(t, 4, len(queueTracker.runningApplications))
-
-	app1ResourceUsage := queueTracker.runningApplications[TestApp1]
-	assert.Equal(t, "map[mem:10000000 vcore:10000]", app1ResourceUsage.String(), "wrong resource")
-	app2ResourceUsage := queueTracker.runningApplications[TestApp2]
-	assert.Equal(t, "map[mem:20000000 vcore:20000]", app2ResourceUsage.String(), "wrong resource")
-	app3ResourceUsage := queueTracker.runningApplications[TestApp3]
-	assert.Equal(t, "map[mem:30000000 vcore:30000]", app3ResourceUsage.String(), "wrong resource")
-	app4ResourceUsage := queueTracker.runningApplications[TestApp4]
-	assert.Equal(t, "map[mem:20000000 vcore:20000]", app4ResourceUsage.String(), "wrong resource")
 }
 
 func TestQTDecreaseTrackedResource(t *testing.T) {
@@ -122,11 +113,6 @@ func TestQTDecreaseTrackedResource(t *testing.T) {
 	assert.Equal(t, "map[mem:70000000 vcore:70000]", actualResources["root.parent.child1"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:20000000 vcore:20000]", actualResources["root.parent.child2"].String(), "wrong resource")
 
-	app1ResourceUsage := queueTracker.runningApplications[TestApp1]
-	assert.Equal(t, "map[mem:70000000 vcore:70000]", app1ResourceUsage.String(), "wrong resource")
-	app2ResourceUsage := queueTracker.runningApplications[TestApp2]
-	assert.Equal(t, "map[mem:20000000 vcore:20000]", app2ResourceUsage.String(), "wrong resource")
-
 	usage3, err := resources.NewResourceFromConf(map[string]string{"mem": "10M", "vcore": "10"})
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
@@ -150,11 +136,6 @@ func TestQTDecreaseTrackedResource(t *testing.T) {
 	assert.Equal(t, "map[mem:60000000 vcore:60000]", actualResources1["root.parent.child1"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:10000000 vcore:10000]", actualResources1["root.parent.child2"].String(), "wrong resource")
 	assert.Equal(t, len(queueTracker.childQueueTrackers["parent"].childQueueTrackers), 2)
-
-	app1ResourceUsage = queueTracker.runningApplications[TestApp1]
-	assert.Equal(t, "map[mem:60000000 vcore:60000]", app1ResourceUsage.String(), "wrong resource")
-	app2ResourceUsage = queueTracker.runningApplications[TestApp2]
-	assert.Equal(t, "map[mem:10000000 vcore:10000]", app2ResourceUsage.String(), "wrong resource")
 
 	usage4, err := resources.NewResourceFromConf(map[string]string{"mem": "60M", "vcore": "60"})
 	if err != nil {
@@ -182,11 +163,6 @@ func TestQTDecreaseTrackedResource(t *testing.T) {
 	assert.Equal(t, len(queueTracker.childQueueTrackers), 0)
 	assert.Equal(t, removeQT, true, "wrong remove queue tracker value")
 
-	app1ResourceUsage = queueTracker.runningApplications[TestApp1]
-	assert.Equal(t, resources.Equals(nil, app1ResourceUsage), true)
-	app2ResourceUsage = queueTracker.runningApplications[TestApp2]
-	assert.Equal(t, resources.Equals(nil, app2ResourceUsage), true)
-
 	// Test parent queueTracker has not zero usage, but child queueTrackers has all deleted
 	result = queueTracker.increaseTrackedResource(queuePath1, TestApp1, user, usage1)
 	if !result {
@@ -202,17 +178,6 @@ func TestQTDecreaseTrackedResource(t *testing.T) {
 	if !result {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", "root.parent", TestApp2, usage2)
 	}
-
-	app2ResourceUsage = queueTracker.runningApplications[TestApp2]
-	assert.Equal(t, "map[mem:20000000 vcore:20000]", app2ResourceUsage.String(), "wrong resource")
-
-	_, decreased = queueTracker.decreaseTrackedResourceUsage(TestApp2)
-	if !decreased {
-		t.Fatalf("unable to decrease tracked resource: app %s", TestApp2)
-	}
-
-	app2ResourceUsage = queueTracker.runningApplications[TestApp2]
-	assert.Equal(t, resources.Equals(nil, app2ResourceUsage), true)
 }
 
 func TestQTQuotaEnforcement(t *testing.T) {

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -63,7 +63,7 @@ func (ut *UserTracker) increaseTrackedResource(queuePath, applicationID string, 
 			zap.String("queue path", queuePath),
 			zap.String("application", applicationID),
 			zap.Stringer("resource", usage))
-		increasedGroupUsage := gt.increaseTrackedResource(queuePath, applicationID, usage)
+		increasedGroupUsage := gt.increaseTrackedResource(queuePath, applicationID, usage, ut.userName)
 		if !increasedGroupUsage {
 			_, decreased := ut.queueTracker.decreaseTrackedResource(queuePath, applicationID, usage, false)
 			if !decreased {

--- a/pkg/scheduler/utilities_test.go
+++ b/pkg/scheduler/utilities_test.go
@@ -426,6 +426,10 @@ func newApplication(appID, partition, queueName string) *objects.Application {
 		User:   "testuser",
 		Groups: []string{"testgroup"},
 	}
+	return newApplicationWithUser(appID, partition, queueName, user)
+}
+
+func newApplicationWithUser(appID, partition, queueName string, user security.UserGroup) *objects.Application {
 	siApp := &si.AddApplicationRequest{
 		ApplicationID: appID,
 		QueueName:     queueName,


### PR DESCRIPTION
…anges

### What is this PR for?
1. App wise usage accounting with in queue tracker object.
2. With help of above changes#1, group resource usage can be decremented for the specific app during config changes. For example, Whenever earlier used group removed from config, all users mapped to that removed group through some application has to handled properly. So far, we just remove the linkage between the user and group in appGroupTrackers map by setting group tracker object to nil. With this pr, even group resource usage also has been handled properly by decrementing that app resource usage. 
3. Used zap.stringer instead of zap.string for resources, removed unnecessary logs etc


### What type of PR is it?
* [ ] - Feature

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1858

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
