### PR TITLE
[YUNIKORN-1893] fix DecreaseTrackedResource

### DIFF
--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -126,6 +126,9 @@ func (m *Manager) DecreaseTrackedResource(queuePath, applicationID string, usage
 			zap.String("user", user.User))
 		return false
 	}
+	group := userTracker.getGroupForApp(applicationID)
+	groupTracker := m.getGroupTracker(group, false)
+
 	log.Log(log.SchedUGM).Debug("Decreasing resource usage for user",
 		zap.String("user", user.User),
 		zap.String("queue path", queuePath),
@@ -145,8 +148,6 @@ func (m *Manager) DecreaseTrackedResource(queuePath, applicationID string, usage
 		delete(m.userTrackers, user.User)
 	}
 
-	group := m.ensureGroup(user, queuePath)
-	groupTracker := m.getGroupTracker(group, false)
 	if groupTracker != nil {
 		log.Log(log.SchedUGM).Debug("Decreasing resource usage for group",
 			zap.String("group", group),


### PR DESCRIPTION
### What is this PR for?

For a queue with group limits only like the following, if a user tracker can be removed in `DecreaseTrackedResource`, we will not decrease group resource usage correctly. It's because the user tracker is removed, we can't get the correct group name in `manager.ensureGroup`.

```
queues.yaml:
  partitions:
    - name: default
      queues:
        - name: root
          submitacl: '*'
          queues:
            - name: sandbox1
              submitacl: '*'
              limits:
                - limit: group-entry
                  groups:
                    - test-group
                  maxapplications: 2
                  maxresources:
                    memory: 100Mi
```

### What type of PR is it?
* [X] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1893

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
