### PR TITLE
[YUNIKORN-1896] CalculateAbsUsedCapacity must be consistent

### DIFF
--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -1504,25 +1504,37 @@ func TestCalculateAbsUsedCapacity(t *testing.T) {
 			used:     partialResource,
 			expected: NewResourceFromMap(map[string]Quantity{"memory": 50}),
 		},
-		"positive overflow": {
-			capacity: NewResourceFromMap(map[string]Quantity{"memory": 10}),
+		"positive limit": {
+			capacity: NewResourceFromMap(map[string]Quantity{"memory": 1}),
 			used:     NewResourceFromMap(map[string]Quantity{"memory": math.MaxInt64}),
-			expected: NewResourceFromMap(map[string]Quantity{"memory": math.MinInt64}),
+			expected: NewResourceFromMap(map[string]Quantity{"memory": math.MaxInt32}),
 		},
 		"negative overflow": {
 			capacity: NewResourceFromMap(map[string]Quantity{"memory": 10}),
 			used:     NewResourceFromMap(map[string]Quantity{"memory": math.MinInt64}),
-			expected: NewResourceFromMap(map[string]Quantity{"memory": math.MinInt64}),
+			expected: NewResourceFromMap(map[string]Quantity{"memory": 0}),
 		},
 		"zero resource, non zero used": {
 			capacity: zeroResource,
 			used:     usageSet,
-			expected: NewResourceFromMap(map[string]Quantity{"memory": math.MinInt64, "vcores": math.MinInt64}),
+			expected: NewResourceFromMap(map[string]Quantity{"memory": 100, "vcores": 100}),
+		},
+		"min used": {
+			capacity: NewResourceFromMap(map[string]Quantity{"memory": math.MinInt64}),
+			used:     NewResourceFromMap(map[string]Quantity{"memory": 10}),
+			expected: NewResourceFromMap(map[string]Quantity{"memory": 100}),
+		},
+		"max used": {
+			capacity: NewResourceFromMap(map[string]Quantity{"memory": math.MaxInt64}),
+			used:     NewResourceFromMap(map[string]Quantity{"memory": math.MaxInt64}),
+			expected: NewResourceFromMap(map[string]Quantity{"memory": 100}),
 		},
 	}
-	for _, test := range tests {
-		absCapacity := CalculateAbsUsedCapacity(test.capacity, test.used)
-		assert.DeepEqual(t, test.expected, absCapacity)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			absCapacity := CalculateAbsUsedCapacity(test.capacity, test.used)
+			assert.Assert(t, Equals(test.expected, absCapacity), name)
+		})
 	}
 }
 


### PR DESCRIPTION
### What is this PR for?
The overflow detection is still showing different results on ARM vs Intel. Simplifying the calculation in CalculateAbsUsedCapacity to always return the same result on all architectures.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-1896

### How should this be tested?
new unit tests, must all pass on ARM and intel
mixed set of reviewers: some with Intel and some with ARM local systems