### PR TITLE
[YUNIKORN-1885] Update Go version filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ifeq ($(GO),)
 GO := go
 endif
 
-GO_VERSION := $(shell "$(GO)" version | awk '{print substr($$3, 3, 10)}')
+GO_VERSION := $(shell "$(GO)" version | awk '{print substr($$3, 3, 4)}')
 MOD_VERSION := $(shell cat .go_version) 
 
 GM := $(word 1,$(subst ., ,$(GO_VERSION)))


### PR DESCRIPTION
### What is this PR for?
The Go version filter pulls in patch release details which shows errors when running tests with pre-release (release candidate) go version to check for compatibility.

### What type of PR is it?
* [X] - Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-1885

### How should this be tested?
Install a rc for Go and set a Go version before running a test, example:
GO="go1.21rc3" make test