### PR TITLE
[YUNIKORN-1898] Allow to set guaranteed quota for the resource which are undefined for a parent

### DIFF
--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -128,7 +128,7 @@ func checkQueueResource(cur QueueConfig, parentM *resources.Resource) (*resource
 		}
 		sumG.AddTo(childG)
 	}
-	if !resources.IsZero(curG) && !resources.FitIn(curG, sumG) {
+	if !curG.FitInMaxUndef(sumG) {
 		return nil, fmt.Errorf("guaranteed resource of parent %s is smaller than sum of guaranteed resources %s of the children for queue %s", curG.String(), sumG.String(), cur.Name)
 	}
 	if !curM.FitInMaxUndef(sumG) {


### PR DESCRIPTION
### What is this PR for?
When a parent has no quota set for a guaranteed resource, then the child of that parent was not allowed to set guaranteed quota on that particular resource. This PR fixes that.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1898

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
