### PR TITLE
[YUNIKORN-1899] Handle config reload in the event code

### DIFF
--- a/pkg/entrypoint/entrypoint.go
+++ b/pkg/entrypoint/entrypoint.go
@@ -36,7 +36,6 @@ type startupOptions struct {
 	manualScheduleFlag bool
 	startWebAppFlag    bool
 	metricsHistorySize int
-	eventSystemEnabled bool
 }
 
 func StartAllServices() *ServiceContext {
@@ -46,7 +45,6 @@ func StartAllServices() *ServiceContext {
 			manualScheduleFlag: false,
 			startWebAppFlag:    true,
 			metricsHistorySize: 1440,
-			eventSystemEnabled: false,
 		})
 }
 
@@ -63,16 +61,12 @@ func StartAllServicesWithManualScheduler() *ServiceContext {
 			manualScheduleFlag: true,
 			startWebAppFlag:    false,
 			metricsHistorySize: 0,
-			eventSystemEnabled: false,
 		})
 }
 
 func startAllServicesWithParameters(opts startupOptions) *ServiceContext {
-	if opts.eventSystemEnabled {
-		log.Log(log.Entrypoint).Info("creating and starting event system")
-		events.CreateAndSetEventSystem()
-		events.GetEventSystem().StartService()
-	}
+	log.Log(log.Entrypoint).Info("Starting event system")
+	events.GetEventSystem().StartService()
 
 	sched := scheduler.NewScheduler()
 	proxy := rmproxy.NewRMProxy()

--- a/pkg/events/event_ringbuffer_test.go
+++ b/pkg/events/event_ringbuffer_test.go
@@ -231,7 +231,6 @@ func TestResize(t *testing.T) {
 	ringBuffer = newEventRingBuffer(10)
 	populate(ringBuffer, 10)
 	lastEventIdBeforeResize = ringBuffer.GetLastEventID()
-
 	ringBuffer.Resize(6)
 	assert.Equal(t, uint64(6), ringBuffer.capacity)
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
@@ -244,7 +243,6 @@ func TestResize(t *testing.T) {
 	populate(ringBuffer, 15)
 	assert.Equal(t, true, ringBuffer.head < ringBuffer.capacity)
 	lastEventIdBeforeResize = ringBuffer.GetLastEventID()
-
 	ringBuffer.Resize(8)
 	assert.Equal(t, uint64(8), ringBuffer.capacity)
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
@@ -256,10 +254,8 @@ func TestResize(t *testing.T) {
 	ringBuffer = newEventRingBuffer(10)
 	populate(ringBuffer, 9)
 	assert.Equal(t, false, ringBuffer.full)
-
 	ringBuffer.Resize(2)
 	assert.Equal(t, true, ringBuffer.full)
-
 	ringBuffer.Resize(6)
 	assert.Equal(t, false, ringBuffer.full)
 

--- a/pkg/events/event_system_test.go
+++ b/pkg/events/event_system_test.go
@@ -30,15 +30,6 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
-// the EventSystem should be nil by default, until not set by CreateAndSetEventSystem()
-func TestGetEventSystem(t *testing.T) {
-	eventSystem := GetEventSystem()
-	assert.Assert(t, eventSystem == nil, "the eventSystem should be nil by default")
-	CreateAndSetEventSystem()
-	eventSystem = GetEventSystem()
-	assert.Assert(t, eventSystem != nil, "the eventSystem should not be nil")
-}
-
 // StartService() and Stop() must not cause panic
 func TestSimpleStartAndStop(t *testing.T) {
 	CreateAndSetEventSystem()
@@ -128,9 +119,9 @@ func TestConfigUpdate(t *testing.T) {
 	defer eventSystem.Stop()
 
 	assert.Assert(t, eventSystem.IsEventTrackingEnabled())
-	assert.Assert(t, eventSystem.GetRingBufferCapacity() == configs.DefaultEventRingBufferCapacity)
-	assert.Assert(t, eventSystem.GetRequestCapacity() == configs.DefaultEventRequestCapacity)
-	assert.Assert(t, eventSystem.eventBuffer.capacity == configs.DefaultEventRingBufferCapacity)
+	assert.Equal(t, eventSystem.GetRingBufferCapacity(), uint64(configs.DefaultEventRingBufferCapacity))
+	assert.Equal(t, eventSystem.GetRequestCapacity(), configs.DefaultEventRequestCapacity)
+	assert.Equal(t, eventSystem.eventBuffer.capacity, uint64(configs.DefaultEventRingBufferCapacity))
 	assert.Assert(t, !eventSystem.publisher.stop.Load())
 
 	// update config and wait for refresh
@@ -147,8 +138,8 @@ func TestConfigUpdate(t *testing.T) {
 	}, 10*time.Millisecond, 5*time.Second)
 	assert.NilError(t, err, "timed out waiting for config refresh")
 
-	assert.Assert(t, eventSystem.GetRingBufferCapacity() == newRingBufferCapacity)
-	assert.Assert(t, eventSystem.GetRequestCapacity() == newRequestCapacity)
-	assert.Assert(t, eventSystem.eventBuffer.capacity == newRingBufferCapacity)
+	assert.Equal(t, eventSystem.GetRingBufferCapacity(), newRingBufferCapacity)
+	assert.Equal(t, eventSystem.GetRequestCapacity(), newRequestCapacity)
+	assert.Equal(t, eventSystem.eventBuffer.capacity, newRingBufferCapacity)
 	assert.Assert(t, eventSystem.publisher.stop.Load())
 }

--- a/pkg/scheduler/objects/application_events.go
+++ b/pkg/scheduler/objects/application_events.go
@@ -27,51 +27,46 @@ import (
 )
 
 type applicationEvents struct {
-	enabled     bool
 	eventSystem events.EventSystem
 	app         *Application
 }
 
 func (evt *applicationEvents) sendAppDoesNotFitEvent(request *AllocationAsk) {
-	if !evt.enabled {
+	if !evt.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	message := fmt.Sprintf("Application %s does not fit into %s queue", request.GetApplicationID(), evt.app.queuePath)
 	event := events.CreateRequestEventRecord(request.GetAllocationKey(), request.GetApplicationID(), message, request.GetAllocatedResource())
 	evt.eventSystem.AddEvent(event)
 }
 
 func (evt *applicationEvents) sendPlaceholderLargerEvent(ph *Allocation, request *AllocationAsk) {
-	if !evt.enabled {
+	if !evt.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	message := fmt.Sprintf("Task group '%s' in application '%s': allocation resources '%s' are not matching placeholder '%s' allocation with ID '%s'", ph.GetTaskGroup(), evt.app.ApplicationID, request.GetAllocatedResource().String(), ph.GetAllocatedResource().String(), ph.GetAllocationKey())
 	event := events.CreateRequestEventRecord(ph.GetAllocationKey(), evt.app.ApplicationID, message, request.GetAllocatedResource())
 	evt.eventSystem.AddEvent(event)
 }
 
 func (evt *applicationEvents) sendNewAllocationEvent(alloc *Allocation) {
-	if !evt.enabled {
+	if !evt.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateAppEventRecord(evt.app.ApplicationID, common.Empty, alloc.GetUUID(), si.EventRecord_ADD, si.EventRecord_APP_ALLOC, alloc.GetAllocatedResource())
 	evt.eventSystem.AddEvent(event)
 }
 
 func (evt *applicationEvents) sendNewAskEvent(request *AllocationAsk) {
-	if !evt.enabled {
+	if !evt.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateAppEventRecord(evt.app.ApplicationID, common.Empty, request.GetAllocationKey(), si.EventRecord_ADD, si.EventRecord_APP_REQUEST, request.GetAllocatedResource())
 	evt.eventSystem.AddEvent(event)
 }
 
 func (evt *applicationEvents) sendRemoveAllocationEvent(alloc *Allocation, terminationType si.TerminationType) {
-	if !evt.enabled {
+	if !evt.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
 
@@ -94,16 +89,15 @@ func (evt *applicationEvents) sendRemoveAllocationEvent(alloc *Allocation, termi
 }
 
 func (evt *applicationEvents) sendRemoveAskEvent(request *AllocationAsk, detail si.EventRecord_ChangeDetail) {
-	if !evt.enabled {
+	if !evt.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateAppEventRecord(evt.app.ApplicationID, "", request.GetAllocationKey(), si.EventRecord_REMOVE, detail, request.GetAllocatedResource())
 	evt.eventSystem.AddEvent(event)
 }
 
 func (evt *applicationEvents) sendNewApplicationEvent() {
-	if !evt.enabled {
+	if !evt.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
 	event := events.CreateAppEventRecord(evt.app.ApplicationID, "", "", si.EventRecord_ADD, si.EventRecord_DETAILS_NONE, evt.app.allocatedResource)
@@ -111,7 +105,7 @@ func (evt *applicationEvents) sendNewApplicationEvent() {
 }
 
 func (evt *applicationEvents) sendRemoveApplicationEvent() {
-	if !evt.enabled {
+	if !evt.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
 	event := events.CreateAppEventRecord(evt.app.ApplicationID, "", "", si.EventRecord_REMOVE, si.EventRecord_DETAILS_NONE, evt.app.allocatedResource)
@@ -119,7 +113,7 @@ func (evt *applicationEvents) sendRemoveApplicationEvent() {
 }
 
 func (evt *applicationEvents) sendRejectApplicationEvent(eventInfo string) {
-	if !evt.enabled {
+	if !evt.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
 	event := events.CreateAppEventRecord(evt.app.ApplicationID, eventInfo, "", si.EventRecord_REMOVE, si.EventRecord_APP_REJECT, evt.app.allocatedResource)
@@ -127,7 +121,7 @@ func (evt *applicationEvents) sendRejectApplicationEvent(eventInfo string) {
 }
 
 func (evt *applicationEvents) sendStateChangeEvent(changeDetail si.EventRecord_ChangeDetail) {
-	if !evt.enabled || !evt.app.sendStateChangeEvents {
+	if !evt.eventSystem.IsEventTrackingEnabled() || !evt.app.sendStateChangeEvents {
 		return
 	}
 	event := events.CreateAppEventRecord(evt.app.ApplicationID, "", "", si.EventRecord_SET, changeDetail, evt.app.allocatedResource)
@@ -137,7 +131,6 @@ func (evt *applicationEvents) sendStateChangeEvent(changeDetail si.EventRecord_C
 func newApplicationEvents(app *Application, evt events.EventSystem) *applicationEvents {
 	return &applicationEvents{
 		eventSystem: evt,
-		enabled:     evt != nil,
 		app:         app,
 	}
 }

--- a/pkg/scheduler/objects/application_events_test.go
+++ b/pkg/scheduler/objects/application_events_test.go
@@ -52,18 +52,8 @@ func TestSendAppDoesNotFitEvent(t *testing.T) {
 	app := &Application{
 		queuePath: "root.test",
 	}
-
-	// not enabled
-	evt := newApplicationEvents(app, nil)
-	assert.Assert(t, evt.eventSystem == nil, "event system should be nil")
-	assert.Assert(t, !evt.enabled, "event system should be disabled")
-	evt.sendAppDoesNotFitEvent(&AllocationAsk{})
-
-	// enabled
 	mock := newEventSystemMock()
-	evt = newApplicationEvents(app, mock)
-	assert.Assert(t, evt.eventSystem != nil, "event system should not be nil")
-	assert.Assert(t, evt.enabled, "event system should be enabled")
+	evt := newApplicationEvents(app, mock)
 	evt.sendAppDoesNotFitEvent(&AllocationAsk{
 		applicationID: appID0,
 		allocationKey: aKey,
@@ -75,18 +65,8 @@ func TestSendPlaceholderLargerEvent(t *testing.T) {
 	app := &Application{
 		queuePath: "root.test",
 	}
-
-	// not enabled
-	evt := newApplicationEvents(app, nil)
-	assert.Assert(t, evt.eventSystem == nil, "event system should be nil")
-	assert.Assert(t, !evt.enabled, "event system should be disabled")
-	evt.sendPlaceholderLargerEvent(&Allocation{}, &AllocationAsk{})
-
-	// enabled
 	mock := newEventSystemMock()
-	evt = newApplicationEvents(app, mock)
-	assert.Assert(t, evt.eventSystem != nil, "event system should not be nil")
-	assert.Assert(t, evt.enabled, "event system should be enabled")
+	evt := newApplicationEvents(app, mock)
 	evt.sendPlaceholderLargerEvent(&Allocation{
 		allocationKey: aKey,
 	}, &AllocationAsk{
@@ -101,18 +81,9 @@ func TestSendNewAllocationEvent(t *testing.T) {
 		ApplicationID: appID0,
 		queuePath:     "root.test",
 	}
-
-	// not enabled
-	evt := newApplicationEvents(app, nil)
-	assert.Assert(t, evt.eventSystem == nil, "event system should be nil")
-	assert.Assert(t, !evt.enabled, "event system should be disabled")
-	evt.sendNewAllocationEvent(&Allocation{})
-
-	// enabled
 	mock := newEventSystemMock()
-	evt = newApplicationEvents(app, mock)
+	evt := newApplicationEvents(app, mock)
 	assert.Assert(t, evt.eventSystem != nil, "event system should not be nil")
-	assert.Assert(t, evt.enabled, "event system should be enabled")
 	evt.sendNewAllocationEvent(&Allocation{
 		applicationID: appID0,
 		allocationKey: aKey,
@@ -132,18 +103,9 @@ func TestSendNewAskEvent(t *testing.T) {
 		ApplicationID: appID0,
 		queuePath:     "root.test",
 	}
-
-	// not enabled
-	evt := newApplicationEvents(app, nil)
-	assert.Assert(t, evt.eventSystem == nil, "event system should be nil")
-	assert.Assert(t, !evt.enabled, "event system should be disabled")
-	evt.sendNewAskEvent(&AllocationAsk{})
-
-	// enabled
 	mock := newEventSystemMock()
-	evt = newApplicationEvents(app, mock)
+	evt := newApplicationEvents(app, mock)
 	assert.Assert(t, evt.eventSystem != nil, "event system should not be nil")
-	assert.Assert(t, evt.enabled, "event system should be enabled")
 	evt.sendNewAskEvent(&AllocationAsk{
 		applicationID: appID0,
 		allocationKey: aKey,
@@ -162,7 +124,6 @@ func TestSendRemoveAllocationEvent(t *testing.T) {
 		ApplicationID: appID0,
 		queuePath:     "root.test",
 	}
-
 	testCases := []struct {
 		name                 string
 		eventSystemMock      *EventSystemMock
@@ -175,12 +136,6 @@ func TestSendRemoveAllocationEvent(t *testing.T) {
 		expectedObjectID     string
 		expectedReferenceID  string
 	}{
-		{
-			name:            "disabled event system",
-			eventSystemMock: nil,
-			terminationType: si.TerminationType_UNKNOWN_TERMINATION_TYPE,
-			allocation:      &Allocation{},
-		},
 		{
 			name:                 "remove allocation cause of node removal",
 			eventSystemMock:      newEventSystemMock(),
@@ -247,12 +202,10 @@ func TestSendRemoveAllocationEvent(t *testing.T) {
 			if testCase.eventSystemMock == nil {
 				evt := newApplicationEvents(app, nil)
 				assert.Assert(t, evt.eventSystem == nil, "event system should be nil")
-				assert.Assert(t, !evt.enabled, "event system should be disabled")
 				evt.sendRemoveAllocationEvent(testCase.allocation, testCase.terminationType)
 			} else {
 				evt := newApplicationEvents(app, testCase.eventSystemMock)
 				assert.Assert(t, evt.eventSystem != nil, "event system should not be nil")
-				assert.Assert(t, evt.enabled, "event system should be enabled")
 				evt.sendRemoveAllocationEvent(testCase.allocation, testCase.terminationType)
 				assert.Equal(t, testCase.expectedEventCnt, len(testCase.eventSystemMock.events), "event was not generated")
 				assert.Equal(t, testCase.expectedType, testCase.eventSystemMock.events[0].Type, "event type is not expected")
@@ -274,17 +227,8 @@ func TestSendRemoveAskEvent(t *testing.T) {
 	ask := &AllocationAsk{
 		applicationID: appID0,
 		allocationKey: aKey}
-
-	// not enabled
-	evt := newApplicationEvents(app, nil)
-	assert.Assert(t, evt.eventSystem == nil, "event system should be nil")
-	assert.Assert(t, !evt.enabled, "event system should be disabled")
-	evt.sendRemoveAskEvent(ask, si.EventRecord_REQUEST_CANCEL)
-
-	// enabled
 	mockEvents := newEventSystemMock()
 	appEvents := newApplicationEvents(app, mockEvents)
-
 	appEvents.sendRemoveAskEvent(ask, si.EventRecord_REQUEST_CANCEL)
 	event := mockEvents.events[0]
 	assert.Equal(t, si.EventRecord_APP, event.Type)
@@ -310,16 +254,8 @@ func TestSendNewApplicationEvent(t *testing.T) {
 		ApplicationID: appID0,
 		queuePath:     "root.test",
 	}
-	// not enabled
-	evt := newApplicationEvents(app, nil)
-	assert.Assert(t, evt.eventSystem == nil, "event system should be nil")
-	assert.Assert(t, !evt.enabled, "event system should be disabled")
-	evt.sendNewApplicationEvent()
-
-	// enabled
 	mockEvents := newEventSystemMock()
 	appEvents := newApplicationEvents(app, mockEvents)
-
 	appEvents.sendNewApplicationEvent()
 	event := mockEvents.events[0]
 	assert.Equal(t, si.EventRecord_APP, event.Type)
@@ -335,16 +271,8 @@ func TestSendRemoveApplicationEvent(t *testing.T) {
 		ApplicationID: appID0,
 		queuePath:     "root.test",
 	}
-	// not enabled
-	evt := newApplicationEvents(app, nil)
-	assert.Assert(t, evt.eventSystem == nil, "event system should be nil")
-	assert.Assert(t, !evt.enabled, "event system should be disabled")
-	evt.sendRemoveApplicationEvent()
-
-	// enabled
 	mockEvents := newEventSystemMock()
 	appEvents := newApplicationEvents(app, mockEvents)
-
 	appEvents.sendRemoveApplicationEvent()
 	event := mockEvents.events[0]
 	assert.Equal(t, si.EventRecord_APP, event.Type)
@@ -360,16 +288,8 @@ func TestSendRejectApplicationEvent(t *testing.T) {
 		ApplicationID: appID0,
 		queuePath:     "root.test",
 	}
-	// not enabled
-	evt := newApplicationEvents(app, nil)
-	assert.Assert(t, evt.eventSystem == nil, "event system should be nil")
-	assert.Assert(t, !evt.enabled, "event system should be disabled")
-	evt.sendRejectApplicationEvent("ResourceReservationTimeout")
-
-	// enabled
 	mockEvents := newEventSystemMock()
 	appEvents := newApplicationEvents(app, mockEvents)
-
 	appEvents.sendRejectApplicationEvent("ResourceReservationTimeout")
 	event := mockEvents.events[0]
 	assert.Equal(t, si.EventRecord_APP, event.Type)
@@ -386,16 +306,8 @@ func TestSendStateChangeEvent(t *testing.T) {
 		queuePath:             "root.test",
 		sendStateChangeEvents: true,
 	}
-	// not enabled
-	evt := newApplicationEvents(app, nil)
-	assert.Assert(t, evt.eventSystem == nil, "event system should be nil")
-	assert.Assert(t, !evt.enabled, "event system should be disabled")
-	evt.sendStateChangeEvent(si.EventRecord_APP_RUNNING)
-
-	// enabled
 	mockEvents := newEventSystemMock()
 	appEvents := newApplicationEvents(app, mockEvents)
-
 	appEvents.sendStateChangeEvent(si.EventRecord_APP_RUNNING)
 	event := mockEvents.events[0]
 	assert.Equal(t, si.EventRecord_APP, event.Type)

--- a/pkg/scheduler/objects/application_events_test.go
+++ b/pkg/scheduler/objects/application_events_test.go
@@ -52,9 +52,14 @@ func TestSendAppDoesNotFitEvent(t *testing.T) {
 	app := &Application{
 		queuePath: "root.test",
 	}
-	mock := newEventSystemMock()
-	evt := newApplicationEvents(app, mock)
-	evt.sendAppDoesNotFitEvent(&AllocationAsk{
+	mock := newEventSystemMockDisabled()
+	appEvents := newApplicationEvents(app, mock)
+	appEvents.sendAppDoesNotFitEvent(&AllocationAsk{})
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	appEvents = newApplicationEvents(app, mock)
+	appEvents.sendAppDoesNotFitEvent(&AllocationAsk{
 		applicationID: appID0,
 		allocationKey: aKey,
 	})
@@ -65,9 +70,14 @@ func TestSendPlaceholderLargerEvent(t *testing.T) {
 	app := &Application{
 		queuePath: "root.test",
 	}
-	mock := newEventSystemMock()
-	evt := newApplicationEvents(app, mock)
-	evt.sendPlaceholderLargerEvent(&Allocation{
+	mock := newEventSystemMockDisabled()
+	appEvents := newApplicationEvents(app, mock)
+	appEvents.sendPlaceholderLargerEvent(&Allocation{}, &AllocationAsk{})
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	appEvents = newApplicationEvents(app, mock)
+	appEvents.sendPlaceholderLargerEvent(&Allocation{
 		allocationKey: aKey,
 	}, &AllocationAsk{
 		applicationID: appID0,
@@ -81,10 +91,15 @@ func TestSendNewAllocationEvent(t *testing.T) {
 		ApplicationID: appID0,
 		queuePath:     "root.test",
 	}
-	mock := newEventSystemMock()
-	evt := newApplicationEvents(app, mock)
-	assert.Assert(t, evt.eventSystem != nil, "event system should not be nil")
-	evt.sendNewAllocationEvent(&Allocation{
+	mock := newEventSystemMockDisabled()
+	appEvents := newApplicationEvents(app, mock)
+	appEvents.sendNewAllocationEvent(&Allocation{})
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	appEvents = newApplicationEvents(app, mock)
+	assert.Assert(t, appEvents.eventSystem != nil, "event system should not be nil")
+	appEvents.sendNewAllocationEvent(&Allocation{
 		applicationID: appID0,
 		allocationKey: aKey,
 		uuid:          aUUID,
@@ -103,10 +118,15 @@ func TestSendNewAskEvent(t *testing.T) {
 		ApplicationID: appID0,
 		queuePath:     "root.test",
 	}
-	mock := newEventSystemMock()
-	evt := newApplicationEvents(app, mock)
-	assert.Assert(t, evt.eventSystem != nil, "event system should not be nil")
-	evt.sendNewAskEvent(&AllocationAsk{
+	mock := newEventSystemMockDisabled()
+	appEvents := newApplicationEvents(app, mock)
+	appEvents.sendNewAskEvent(&AllocationAsk{})
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	appEvents = newApplicationEvents(app, mock)
+	assert.Assert(t, appEvents.eventSystem != nil, "event system should not be nil")
+	appEvents.sendNewAskEvent(&AllocationAsk{
 		applicationID: appID0,
 		allocationKey: aKey,
 	})
@@ -124,6 +144,11 @@ func TestSendRemoveAllocationEvent(t *testing.T) {
 		ApplicationID: appID0,
 		queuePath:     "root.test",
 	}
+	mock := newEventSystemMockDisabled()
+	appEvents := newApplicationEvents(app, mock)
+	appEvents.sendRemoveAllocationEvent(&Allocation{}, si.TerminationType_STOPPED_BY_RM)
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
 	testCases := []struct {
 		name                 string
 		eventSystemMock      *EventSystemMock
@@ -200,13 +225,13 @@ func TestSendRemoveAllocationEvent(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			if testCase.eventSystemMock == nil {
-				evt := newApplicationEvents(app, nil)
-				assert.Assert(t, evt.eventSystem == nil, "event system should be nil")
-				evt.sendRemoveAllocationEvent(testCase.allocation, testCase.terminationType)
+				appEvents := newApplicationEvents(app, nil)
+				assert.Assert(t, appEvents.eventSystem == nil, "event system should be nil")
+				appEvents.sendRemoveAllocationEvent(testCase.allocation, testCase.terminationType)
 			} else {
-				evt := newApplicationEvents(app, testCase.eventSystemMock)
-				assert.Assert(t, evt.eventSystem != nil, "event system should not be nil")
-				evt.sendRemoveAllocationEvent(testCase.allocation, testCase.terminationType)
+				appEvents := newApplicationEvents(app, testCase.eventSystemMock)
+				assert.Assert(t, appEvents.eventSystem != nil, "event system should not be nil")
+				appEvents.sendRemoveAllocationEvent(testCase.allocation, testCase.terminationType)
 				assert.Equal(t, testCase.expectedEventCnt, len(testCase.eventSystemMock.events), "event was not generated")
 				assert.Equal(t, testCase.expectedType, testCase.eventSystemMock.events[0].Type, "event type is not expected")
 				assert.Equal(t, testCase.expectedChangeType, testCase.eventSystemMock.events[0].EventChangeType, "event change type is not expected")
@@ -224,13 +249,18 @@ func TestSendRemoveAskEvent(t *testing.T) {
 		ApplicationID: appID0,
 		queuePath:     "root.test",
 	}
+	mock := newEventSystemMockDisabled()
+	appEvents := newApplicationEvents(app, mock)
+	appEvents.sendRemoveAskEvent(&AllocationAsk{}, si.EventRecord_REQUEST_CANCEL)
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
 	ask := &AllocationAsk{
 		applicationID: appID0,
 		allocationKey: aKey}
-	mockEvents := newEventSystemMock()
-	appEvents := newApplicationEvents(app, mockEvents)
+	mock = newEventSystemMock()
+	appEvents = newApplicationEvents(app, mock)
 	appEvents.sendRemoveAskEvent(ask, si.EventRecord_REQUEST_CANCEL)
-	event := mockEvents.events[0]
+	event := mock.events[0]
 	assert.Equal(t, si.EventRecord_APP, event.Type)
 	assert.Equal(t, si.EventRecord_REMOVE, event.EventChangeType)
 	assert.Equal(t, si.EventRecord_REQUEST_CANCEL, event.EventChangeDetail)
@@ -238,9 +268,9 @@ func TestSendRemoveAskEvent(t *testing.T) {
 	assert.Equal(t, "alloc-1", event.ReferenceID)
 	assert.Equal(t, "", event.Message)
 
-	mockEvents.Reset()
+	mock.Reset()
 	appEvents.sendRemoveAskEvent(ask, si.EventRecord_REQUEST_TIMEOUT)
-	event = mockEvents.events[0]
+	event = mock.events[0]
 	assert.Equal(t, si.EventRecord_APP, event.Type)
 	assert.Equal(t, si.EventRecord_REMOVE, event.EventChangeType)
 	assert.Equal(t, si.EventRecord_REQUEST_TIMEOUT, event.EventChangeDetail)
@@ -254,8 +284,13 @@ func TestSendNewApplicationEvent(t *testing.T) {
 		ApplicationID: appID0,
 		queuePath:     "root.test",
 	}
+	mock := newEventSystemMockDisabled()
+	appEvents := newApplicationEvents(app, mock)
+	appEvents.sendNewApplicationEvent()
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
 	mockEvents := newEventSystemMock()
-	appEvents := newApplicationEvents(app, mockEvents)
+	appEvents = newApplicationEvents(app, mockEvents)
 	appEvents.sendNewApplicationEvent()
 	event := mockEvents.events[0]
 	assert.Equal(t, si.EventRecord_APP, event.Type)
@@ -271,10 +306,15 @@ func TestSendRemoveApplicationEvent(t *testing.T) {
 		ApplicationID: appID0,
 		queuePath:     "root.test",
 	}
-	mockEvents := newEventSystemMock()
-	appEvents := newApplicationEvents(app, mockEvents)
+	mock := newEventSystemMockDisabled()
+	appEvents := newApplicationEvents(app, mock)
 	appEvents.sendRemoveApplicationEvent()
-	event := mockEvents.events[0]
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	appEvents = newApplicationEvents(app, mock)
+	appEvents.sendRemoveApplicationEvent()
+	event := mock.events[0]
 	assert.Equal(t, si.EventRecord_APP, event.Type)
 	assert.Equal(t, si.EventRecord_REMOVE, event.EventChangeType)
 	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
@@ -288,10 +328,15 @@ func TestSendRejectApplicationEvent(t *testing.T) {
 		ApplicationID: appID0,
 		queuePath:     "root.test",
 	}
-	mockEvents := newEventSystemMock()
-	appEvents := newApplicationEvents(app, mockEvents)
+	mock := newEventSystemMockDisabled()
+	appEvents := newApplicationEvents(app, mock)
 	appEvents.sendRejectApplicationEvent("ResourceReservationTimeout")
-	event := mockEvents.events[0]
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	appEvents = newApplicationEvents(app, mock)
+	appEvents.sendRejectApplicationEvent("ResourceReservationTimeout")
+	event := mock.events[0]
 	assert.Equal(t, si.EventRecord_APP, event.Type)
 	assert.Equal(t, si.EventRecord_REMOVE, event.EventChangeType)
 	assert.Equal(t, si.EventRecord_APP_REJECT, event.EventChangeDetail)
@@ -306,10 +351,15 @@ func TestSendStateChangeEvent(t *testing.T) {
 		queuePath:             "root.test",
 		sendStateChangeEvents: true,
 	}
-	mockEvents := newEventSystemMock()
-	appEvents := newApplicationEvents(app, mockEvents)
+	mock := newEventSystemMockDisabled()
+	appEvents := newApplicationEvents(app, mock)
 	appEvents.sendStateChangeEvent(si.EventRecord_APP_RUNNING)
-	event := mockEvents.events[0]
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	appEvents = newApplicationEvents(app, mock)
+	appEvents.sendStateChangeEvent(si.EventRecord_APP_RUNNING)
+	event := mock.events[0]
 	assert.Equal(t, si.EventRecord_APP, event.Type)
 	assert.Equal(t, si.EventRecord_SET, event.EventChangeType)
 	assert.Equal(t, si.EventRecord_APP_RUNNING, event.EventChangeDetail)

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -267,32 +267,6 @@ func TestAppAllocReservation(t *testing.T) {
 	if app.HasReserved() || node1.IsReserved() || node2.IsReserved() || reservedAsks != 2 {
 		t.Errorf("ask removal did not clean up all reservations, reserved released = %d", reservedAsks)
 	}
-
-	// wait for events to be processed
-	noEvents := 0
-	err = common.WaitFor(10*time.Millisecond, time.Second, func() bool {
-		fmt.Printf("checking event length: %d\n", eventSystem.Store.CountStoredEvents())
-		noEvents = eventSystem.Store.CountStoredEvents()
-		return noEvents == 3
-	})
-	assert.NilError(t, err, "expected 3 events, got %d", noEvents)
-	records := eventSystem.Store.CollectEvents()
-	if records == nil {
-		t.Fatal("collecting eventChannel should return something")
-	}
-	assert.Equal(t, 3, len(records))
-	allocAskRecord := records[1]
-	assert.Equal(t, si.EventRecord_APP, allocAskRecord.Type, "incorrect event type, expect app")
-	assert.Equal(t, ask.applicationID, allocAskRecord.ObjectID, "incorrect object ID, expected application ID")
-	assert.Equal(t, ask.allocationKey, allocAskRecord.ReferenceID, "incorrect reference ID, expected alloc ask ID")
-	assert.Equal(t, si.EventRecord_ADD, allocAskRecord.EventChangeType, "incorrect change type, expected add")
-	assert.Equal(t, si.EventRecord_APP_REQUEST, allocAskRecord.EventChangeDetail, "incorrect change detail, expected new alloc ask")
-	allocAskCancelRecord := records[2]
-	assert.Equal(t, si.EventRecord_APP, allocAskCancelRecord.Type, "incorrect event type, expect app")
-	assert.Equal(t, ask.applicationID, allocAskCancelRecord.ObjectID, "incorrect object ID, expected application ID")
-	assert.Equal(t, ask.allocationKey, allocAskCancelRecord.ReferenceID, "incorrect reference ID, expected alloc ask ID")
-	assert.Equal(t, si.EventRecord_REMOVE, allocAskCancelRecord.EventChangeType, "incorrect change type, expected remove")
-	assert.Equal(t, si.EventRecord_REQUEST_CANCEL, allocAskCancelRecord.EventChangeDetail, "incorrect change detail, expected new alloc ask")
 }
 
 // test update allocation repeat

--- a/pkg/scheduler/objects/common_test.go
+++ b/pkg/scheduler/objects/common_test.go
@@ -24,7 +24,8 @@ import (
 )
 
 type EventSystemMock struct {
-	events []*si.EventRecord
+	events  []*si.EventRecord
+	enabled bool
 }
 
 func (m *EventSystemMock) AddEvent(event *si.EventRecord) {
@@ -44,11 +45,14 @@ func (m *EventSystemMock) GetEventsFromID(uint64, uint64) ([]*si.EventRecord, ui
 }
 
 func (m *EventSystemMock) IsEventTrackingEnabled() bool {
-	return true
+	return m.enabled
 }
 
 func newEventSystemMock() *EventSystemMock {
-	return &EventSystemMock{events: make([]*si.EventRecord, 0)}
+	return &EventSystemMock{events: make([]*si.EventRecord, 0), enabled: true}
+}
+func newEventSystemMockDisabled() *EventSystemMock {
+	return &EventSystemMock{events: make([]*si.EventRecord, 0), enabled: false}
 }
 
 func getTestResource() *resources.Resource {

--- a/pkg/scheduler/objects/common_test.go
+++ b/pkg/scheduler/objects/common_test.go
@@ -43,6 +43,10 @@ func (m *EventSystemMock) GetEventsFromID(uint64, uint64) ([]*si.EventRecord, ui
 	return nil, 0, 0
 }
 
+func (m *EventSystemMock) IsEventTrackingEnabled() bool {
+	return true
+}
+
 func newEventSystemMock() *EventSystemMock {
 	return &EventSystemMock{events: make([]*si.EventRecord, 0)}
 }

--- a/pkg/scheduler/objects/node_events.go
+++ b/pkg/scheduler/objects/node_events.go
@@ -26,56 +26,50 @@ import (
 )
 
 type nodeEvents struct {
-	enabled     bool
 	eventSystem events.EventSystem
 	node        *Node
 }
 
 func (n *nodeEvents) sendNodeAddedEvent() {
-	if !n.enabled {
+	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, common.Empty, si.EventRecord_ADD,
 		si.EventRecord_DETAILS_NONE, n.node.GetCapacity())
 	n.eventSystem.AddEvent(event)
 }
 
 func (n *nodeEvents) sendNodeRemovedEvent() {
-	if !n.enabled {
+	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, common.Empty, si.EventRecord_REMOVE,
 		si.EventRecord_NODE_DECOMISSION, nil)
 	n.eventSystem.AddEvent(event)
 }
 
 func (n *nodeEvents) sendAllocationAddedEvent(allocID string, res *resources.Resource) {
-	if !n.enabled {
+	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, allocID, si.EventRecord_ADD,
 		si.EventRecord_NODE_ALLOC, res)
 	n.eventSystem.AddEvent(event)
 }
 
 func (n *nodeEvents) sendAllocationRemovedEvent(allocID string, res *resources.Resource) {
-	if !n.enabled {
+	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, allocID, si.EventRecord_REMOVE,
 		si.EventRecord_NODE_ALLOC, res)
 	n.eventSystem.AddEvent(event)
 }
 
 func (n *nodeEvents) sendNodeReadyChangedEvent(ready bool) {
-	if !n.enabled {
+	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	reason := ""
 	if ready {
 		reason = "ready: true"
@@ -89,57 +83,51 @@ func (n *nodeEvents) sendNodeReadyChangedEvent(ready bool) {
 }
 
 func (n *nodeEvents) sendNodeSchedulableChangedEvent(ready bool) {
-	if !n.enabled {
+	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	var reason string
 	if ready {
 		reason = "schedulable: true"
 	} else {
 		reason = "schedulable: false"
 	}
-
 	event := events.CreateNodeEventRecord(n.node.NodeID, reason, common.Empty, si.EventRecord_SET,
 		si.EventRecord_NODE_SCHEDULABLE, nil)
 	n.eventSystem.AddEvent(event)
 }
 
 func (n *nodeEvents) sendNodeCapacityChangedEvent() {
-	if !n.enabled {
+	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, common.Empty, si.EventRecord_SET,
 		si.EventRecord_NODE_CAPACITY, n.node.totalResource)
 	n.eventSystem.AddEvent(event)
 }
 
 func (n *nodeEvents) sendNodeOccupiedResourceChangedEvent() {
-	if !n.enabled {
+	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, common.Empty, si.EventRecord_SET,
 		si.EventRecord_NODE_OCCUPIED, n.node.occupiedResource)
 	n.eventSystem.AddEvent(event)
 }
 
 func (n *nodeEvents) sendReservedEvent(res *resources.Resource, askID string) {
-	if !n.enabled {
+	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, askID, si.EventRecord_ADD,
 		si.EventRecord_NODE_RESERVATION, res)
 	n.eventSystem.AddEvent(event)
 }
 
 func (n *nodeEvents) sendUnreservedEvent(res *resources.Resource, askID string) {
-	if !n.enabled {
+	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, askID, si.EventRecord_REMOVE,
 		si.EventRecord_NODE_RESERVATION, res)
 	n.eventSystem.AddEvent(event)
@@ -148,7 +136,6 @@ func (n *nodeEvents) sendUnreservedEvent(res *resources.Resource, askID string) 
 func newNodeEvents(node *Node, evt events.EventSystem) *nodeEvents {
 	return &nodeEvents{
 		eventSystem: evt,
-		enabled:     evt != nil,
 		node:        node,
 	}
 }

--- a/pkg/scheduler/objects/node_events_test.go
+++ b/pkg/scheduler/objects/node_events_test.go
@@ -28,26 +28,17 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
-func TestNewNodeEvents(t *testing.T) {
-	node := &Node{
-		NodeID: nodeID1,
-	}
-
-	// not enabled
-	ne := newNodeEvents(node, nil)
-	assert.Assert(t, ne.eventSystem == nil, "event system should be nil")
-
-	// enabled
-	ne = newNodeEvents(node, newEventSystemMock())
-	assert.Assert(t, ne.eventSystem != nil, "event system should not be nil")
-}
-
 func TestSendNodeAddedEvent(t *testing.T) {
 	node := &Node{
 		NodeID: nodeID1,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	ne := newNodeEvents(node, mock)
+	ne.sendNodeAddedEvent()
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	ne = newNodeEvents(node, mock)
 	ne.sendNodeAddedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -63,8 +54,13 @@ func TestSendNodeRemovedEvent(t *testing.T) {
 	node := &Node{
 		NodeID: nodeID1,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	ne := newNodeEvents(node, mock)
+	ne.sendNodeRemovedEvent()
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	ne = newNodeEvents(node, mock)
 	ne.sendNodeRemovedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -81,8 +77,14 @@ func TestSendAllocationAddedEvent(t *testing.T) {
 		NodeID: nodeID1,
 	}
 	resource := getTestResource()
-	mock := newEventSystemMock()
+
+	mock := newEventSystemMockDisabled()
 	ne := newNodeEvents(node, mock)
+	ne.sendAllocationAddedEvent("alloc-0", resource)
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	ne = newNodeEvents(node, mock)
 	ne.sendAllocationAddedEvent("alloc-0", resource)
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -101,8 +103,14 @@ func TestSendAllocationRemovedEvent(t *testing.T) {
 		NodeID: nodeID1,
 	}
 	resource := getTestResource()
-	mock := newEventSystemMock()
+
+	mock := newEventSystemMockDisabled()
 	ne := newNodeEvents(node, mock)
+	ne.sendAllocationRemovedEvent("alloc-0", resource)
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	ne = newNodeEvents(node, mock)
 	ne.sendAllocationRemovedEvent("alloc-0", resource)
 	event := mock.events[0]
 	assert.Equal(t, nodeID1, event.ObjectID)
@@ -119,8 +127,13 @@ func TestSendNodeReadyChangedEvent(t *testing.T) {
 	node := &Node{
 		NodeID: nodeID1,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	ne := newNodeEvents(node, mock)
+	ne.sendNodeReadyChangedEvent(true)
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	ne = newNodeEvents(node, mock)
 	ne.sendNodeReadyChangedEvent(true)
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	assert.Equal(t, "ready: true", mock.events[0].Message)
@@ -139,8 +152,13 @@ func TestSendOccupiedResourceChangedEvent(t *testing.T) {
 		NodeID:           nodeID1,
 		occupiedResource: resource,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	ne := newNodeEvents(node, mock)
+	ne.sendNodeOccupiedResourceChangedEvent()
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	ne = newNodeEvents(node, mock)
 	ne.sendNodeOccupiedResourceChangedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -160,8 +178,13 @@ func TestSendCapacityChangedEvent(t *testing.T) {
 		NodeID:        nodeID1,
 		totalResource: resource,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	ne := newNodeEvents(node, mock)
+	ne.sendNodeCapacityChangedEvent()
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	ne = newNodeEvents(node, mock)
 	ne.sendNodeCapacityChangedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -180,8 +203,13 @@ func TestNodeSchedulableChangedEvent(t *testing.T) {
 		NodeID:      nodeID1,
 		schedulable: true,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	ne := newNodeEvents(node, mock)
+	ne.sendNodeSchedulableChangedEvent(false)
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	ne = newNodeEvents(node, mock)
 	ne.sendNodeSchedulableChangedEvent(false)
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -210,8 +238,13 @@ func TestNodeReservationEvent(t *testing.T) {
 		NodeID:      nodeID1,
 		schedulable: true,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	ne := newNodeEvents(node, mock)
+	ne.sendReservedEvent(resource, "alloc-0")
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	ne = newNodeEvents(node, mock)
 	ne.sendReservedEvent(resource, "alloc-0")
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -231,8 +264,13 @@ func TestNodeUnreservationEvent(t *testing.T) {
 		NodeID:      nodeID1,
 		schedulable: true,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	ne := newNodeEvents(node, mock)
+	ne.sendUnreservedEvent(resource, "alloc-0")
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	ne = newNodeEvents(node, mock)
 	ne.sendUnreservedEvent(resource, "alloc-0")
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]

--- a/pkg/scheduler/objects/node_events_test.go
+++ b/pkg/scheduler/objects/node_events_test.go
@@ -36,26 +36,18 @@ func TestNewNodeEvents(t *testing.T) {
 	// not enabled
 	ne := newNodeEvents(node, nil)
 	assert.Assert(t, ne.eventSystem == nil, "event system should be nil")
-	assert.Assert(t, !ne.enabled, "event system should be disabled")
 
 	// enabled
 	ne = newNodeEvents(node, newEventSystemMock())
 	assert.Assert(t, ne.eventSystem != nil, "event system should not be nil")
-	assert.Assert(t, ne.enabled, "event system should be enabled")
 }
 
 func TestSendNodeAddedEvent(t *testing.T) {
 	node := &Node{
 		NodeID: nodeID1,
 	}
-
-	// not enabled
-	ne := newNodeEvents(node, nil)
-	ne.sendNodeAddedEvent()
-
-	// enabled
 	mock := newEventSystemMock()
-	ne = newNodeEvents(node, mock)
+	ne := newNodeEvents(node, mock)
 	ne.sendNodeAddedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -71,14 +63,8 @@ func TestSendNodeRemovedEvent(t *testing.T) {
 	node := &Node{
 		NodeID: nodeID1,
 	}
-
-	// not enabled
-	ne := newNodeEvents(node, nil)
-	ne.sendNodeRemovedEvent()
-
-	// enabled
 	mock := newEventSystemMock()
-	ne = newNodeEvents(node, mock)
+	ne := newNodeEvents(node, mock)
 	ne.sendNodeRemovedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -95,14 +81,8 @@ func TestSendAllocationAddedEvent(t *testing.T) {
 		NodeID: nodeID1,
 	}
 	resource := getTestResource()
-
-	// not enabled
-	ne := newNodeEvents(node, nil)
-	ne.sendAllocationAddedEvent("alloc-0", resource)
-
-	// enabled
 	mock := newEventSystemMock()
-	ne = newNodeEvents(node, mock)
+	ne := newNodeEvents(node, mock)
 	ne.sendAllocationAddedEvent("alloc-0", resource)
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -121,14 +101,8 @@ func TestSendAllocationRemovedEvent(t *testing.T) {
 		NodeID: nodeID1,
 	}
 	resource := getTestResource()
-
-	// not enabled
-	ne := newNodeEvents(node, nil)
-	ne.sendAllocationRemovedEvent("alloc-0", resource)
-
-	// enabled
 	mock := newEventSystemMock()
-	ne = newNodeEvents(node, mock)
+	ne := newNodeEvents(node, mock)
 	ne.sendAllocationRemovedEvent("alloc-0", resource)
 	event := mock.events[0]
 	assert.Equal(t, nodeID1, event.ObjectID)
@@ -145,14 +119,8 @@ func TestSendNodeReadyChangedEvent(t *testing.T) {
 	node := &Node{
 		NodeID: nodeID1,
 	}
-
-	// not enabled
-	ne := newNodeEvents(node, nil)
-	ne.sendNodeReadyChangedEvent(true)
-
-	// enabled
 	mock := newEventSystemMock()
-	ne = newNodeEvents(node, mock)
+	ne := newNodeEvents(node, mock)
 	ne.sendNodeReadyChangedEvent(true)
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	assert.Equal(t, "ready: true", mock.events[0].Message)
@@ -171,14 +139,8 @@ func TestSendOccupiedResourceChangedEvent(t *testing.T) {
 		NodeID:           nodeID1,
 		occupiedResource: resource,
 	}
-
-	// not enabled
-	ne := newNodeEvents(node, nil)
-	ne.sendNodeOccupiedResourceChangedEvent()
-
-	// enabled
 	mock := newEventSystemMock()
-	ne = newNodeEvents(node, mock)
+	ne := newNodeEvents(node, mock)
 	ne.sendNodeOccupiedResourceChangedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -198,14 +160,8 @@ func TestSendCapacityChangedEvent(t *testing.T) {
 		NodeID:        nodeID1,
 		totalResource: resource,
 	}
-
-	// not enabled
-	ne := newNodeEvents(node, nil)
-	ne.sendNodeCapacityChangedEvent()
-
-	// enabled
 	mock := newEventSystemMock()
-	ne = newNodeEvents(node, mock)
+	ne := newNodeEvents(node, mock)
 	ne.sendNodeCapacityChangedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -224,14 +180,8 @@ func TestNodeSchedulableChangedEvent(t *testing.T) {
 		NodeID:      nodeID1,
 		schedulable: true,
 	}
-
-	// not enabled
-	ne := newNodeEvents(node, nil)
-	ne.sendNodeSchedulableChangedEvent(false)
-
-	// enabled
 	mock := newEventSystemMock()
-	ne = newNodeEvents(node, mock)
+	ne := newNodeEvents(node, mock)
 	ne.sendNodeSchedulableChangedEvent(false)
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -260,14 +210,8 @@ func TestNodeReservationEvent(t *testing.T) {
 		NodeID:      nodeID1,
 		schedulable: true,
 	}
-
-	// not enabled
-	ne := newNodeEvents(node, nil)
-	ne.sendNodeSchedulableChangedEvent(false)
-
-	// enabled
 	mock := newEventSystemMock()
-	ne = newNodeEvents(node, mock)
+	ne := newNodeEvents(node, mock)
 	ne.sendReservedEvent(resource, "alloc-0")
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -287,14 +231,8 @@ func TestNodeUnreservationEvent(t *testing.T) {
 		NodeID:      nodeID1,
 		schedulable: true,
 	}
-
-	// not enabled
-	ne := newNodeEvents(node, nil)
-	ne.sendNodeSchedulableChangedEvent(false)
-
-	// enabled
 	mock := newEventSystemMock()
-	ne = newNodeEvents(node, mock)
+	ne := newNodeEvents(node, mock)
 	ne.sendUnreservedEvent(resource, "alloc-0")
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]

--- a/pkg/scheduler/objects/queue_events.go
+++ b/pkg/scheduler/objects/queue_events.go
@@ -25,16 +25,14 @@ import (
 )
 
 type queueEvents struct {
-	enabled     bool
 	eventSystem events.EventSystem
 	queue       *Queue
 }
 
 func (q *queueEvents) sendNewQueueEvent() {
-	if !q.enabled {
+	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	detail := si.EventRecord_QUEUE_DYNAMIC
 	if q.queue.IsManaged() {
 		detail = si.EventRecord_DETAILS_NONE
@@ -45,70 +43,62 @@ func (q *queueEvents) sendNewQueueEvent() {
 }
 
 func (q *queueEvents) sendNewApplicationEvent(appID string) {
-	if !q.enabled {
+	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, appID, si.EventRecord_ADD,
 		si.EventRecord_QUEUE_APP, nil)
 	q.eventSystem.AddEvent(event)
 }
 
 func (q *queueEvents) sendRemoveQueueEvent() {
-	if !q.enabled {
+	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	detail := si.EventRecord_QUEUE_DYNAMIC
 	if q.queue.IsManaged() {
 		detail = si.EventRecord_DETAILS_NONE
 	}
-
 	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, common.Empty, si.EventRecord_REMOVE,
 		detail, nil)
 	q.eventSystem.AddEvent(event)
 }
 
 func (q *queueEvents) sendRemoveApplicationEvent(appID string) {
-	if !q.enabled {
+	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, appID, si.EventRecord_REMOVE,
 		si.EventRecord_QUEUE_APP, nil)
 	q.eventSystem.AddEvent(event)
 }
 
 func (q *queueEvents) sendMaxResourceChangedEvent() {
-	if !q.enabled {
+	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, common.Empty, si.EventRecord_SET,
 		si.EventRecord_QUEUE_MAX, q.queue.maxResource)
 	q.eventSystem.AddEvent(event)
 }
 
 func (q *queueEvents) sendGuaranteedResourceChangedEvent() {
-	if !q.enabled {
+	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, common.Empty, si.EventRecord_SET,
 		si.EventRecord_QUEUE_GUARANTEED, q.queue.guaranteedResource)
 	q.eventSystem.AddEvent(event)
 }
 
 func (q *queueEvents) sendTypeChangedEvent() {
-	if !q.enabled {
+	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-
 	message := "leaf queue: false"
 	if q.queue.isLeaf {
 		message = "leaf queue: true"
 	}
-
 	event := events.CreateQueueEventRecord(q.queue.QueuePath, message, common.Empty, si.EventRecord_SET,
 		si.EventRecord_QUEUE_TYPE, nil)
 	q.eventSystem.AddEvent(event)
@@ -117,7 +107,6 @@ func (q *queueEvents) sendTypeChangedEvent() {
 func newQueueEvents(queue *Queue, evt events.EventSystem) *queueEvents {
 	return &queueEvents{
 		eventSystem: evt,
-		enabled:     evt != nil,
 		queue:       queue,
 	}
 }

--- a/pkg/scheduler/objects/queue_events_test.go
+++ b/pkg/scheduler/objects/queue_events_test.go
@@ -32,35 +32,13 @@ const (
 	testQueuePath = "root.test"
 )
 
-func TestNewQueueEvents(t *testing.T) {
-	queue := &Queue{
-		QueuePath: testQueuePath,
-	}
-
-	// not enabled
-	nq := newQueueEvents(queue, nil)
-	assert.Assert(t, nq.eventSystem == nil, "event system should be nil")
-	assert.Assert(t, !nq.enabled, "event system should be disabled")
-
-	// enabled
-	nq = newQueueEvents(queue, newEventSystemMock())
-	assert.Assert(t, nq.eventSystem != nil, "event system should not be nil")
-	assert.Assert(t, nq.enabled, "event system should be enabled")
-}
-
 func TestSendNewQueueEvent(t *testing.T) {
 	queue := &Queue{
 		QueuePath: testQueuePath,
 		isManaged: true,
 	}
-
-	// not enabled
-	nq := newQueueEvents(queue, nil)
-	nq.sendNewQueueEvent()
-
-	// enabled
 	mock := newEventSystemMock()
-	nq = newQueueEvents(queue, mock)
+	nq := newQueueEvents(queue, mock)
 	nq.sendNewQueueEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -86,14 +64,8 @@ func TestSendRemoveQueueEvent(t *testing.T) {
 		QueuePath: testQueuePath,
 		isManaged: true,
 	}
-
-	// not enabled
-	nq := newQueueEvents(queue, nil)
-	nq.sendRemoveQueueEvent()
-
-	// enabled
 	mock := newEventSystemMock()
-	nq = newQueueEvents(queue, mock)
+	nq := newQueueEvents(queue, mock)
 	nq.sendRemoveQueueEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -118,14 +90,8 @@ func TestNewApplicationEvent(t *testing.T) {
 	queue := &Queue{
 		QueuePath: testQueuePath,
 	}
-
-	// not enabled
-	nq := newQueueEvents(queue, nil)
-	nq.sendNewApplicationEvent(appID0)
-
-	// enabled
 	mock := newEventSystemMock()
-	nq = newQueueEvents(queue, mock)
+	nq := newQueueEvents(queue, mock)
 	nq.sendNewApplicationEvent(appID0)
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -142,14 +108,8 @@ func TestRemoveApplicationEvent(t *testing.T) {
 	queue := &Queue{
 		QueuePath: testQueuePath,
 	}
-
-	// not enabled
-	nq := newQueueEvents(queue, nil)
-	nq.sendRemoveApplicationEvent(appID0)
-
-	// enabled
 	mock := newEventSystemMock()
-	nq = newQueueEvents(queue, mock)
+	nq := newQueueEvents(queue, mock)
 	nq.sendRemoveApplicationEvent(appID0)
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -166,14 +126,8 @@ func TestTypeChangedEvent(t *testing.T) {
 	queue := &Queue{
 		QueuePath: testQueuePath,
 	}
-
-	// not enabled
-	nq := newQueueEvents(queue, nil)
-	nq.sendTypeChangedEvent()
-
-	// enabled
 	mock := newEventSystemMock()
-	nq = newQueueEvents(queue, mock)
+	nq := newQueueEvents(queue, mock)
 	nq.sendTypeChangedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -192,14 +146,8 @@ func TestSendMaxResourceChangedEvent(t *testing.T) {
 		QueuePath:   testQueuePath,
 		maxResource: max,
 	}
-
-	// not enabled
-	nq := newQueueEvents(queue, nil)
-	nq.sendMaxResourceChangedEvent()
-
-	// enabled
 	mock := newEventSystemMock()
-	nq = newQueueEvents(queue, mock)
+	nq := newQueueEvents(queue, mock)
 	nq.sendMaxResourceChangedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -220,14 +168,8 @@ func TestSendGuaranteedResourceChangedEvent(t *testing.T) {
 		QueuePath:          testQueuePath,
 		guaranteedResource: guaranteed,
 	}
-
-	// not enabled
-	nq := newQueueEvents(queue, nil)
-	nq.sendGuaranteedResourceChangedEvent()
-
-	// enabled
 	mock := newEventSystemMock()
-	nq = newQueueEvents(queue, mock)
+	nq := newQueueEvents(queue, mock)
 	nq.sendGuaranteedResourceChangedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]

--- a/pkg/scheduler/objects/queue_events_test.go
+++ b/pkg/scheduler/objects/queue_events_test.go
@@ -37,8 +37,13 @@ func TestSendNewQueueEvent(t *testing.T) {
 		QueuePath: testQueuePath,
 		isManaged: true,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	nq := newQueueEvents(queue, mock)
+	nq.sendNewQueueEvent()
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
 	nq.sendNewQueueEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -64,8 +69,13 @@ func TestSendRemoveQueueEvent(t *testing.T) {
 		QueuePath: testQueuePath,
 		isManaged: true,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	nq := newQueueEvents(queue, mock)
+	nq.sendRemoveQueueEvent()
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
 	nq.sendRemoveQueueEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -90,8 +100,13 @@ func TestNewApplicationEvent(t *testing.T) {
 	queue := &Queue{
 		QueuePath: testQueuePath,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	nq := newQueueEvents(queue, mock)
+	nq.sendNewApplicationEvent(appID0)
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
 	nq.sendNewApplicationEvent(appID0)
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -108,8 +123,13 @@ func TestRemoveApplicationEvent(t *testing.T) {
 	queue := &Queue{
 		QueuePath: testQueuePath,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	nq := newQueueEvents(queue, mock)
+	nq.sendRemoveApplicationEvent(appID0)
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
 	nq.sendRemoveApplicationEvent(appID0)
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -126,8 +146,13 @@ func TestTypeChangedEvent(t *testing.T) {
 	queue := &Queue{
 		QueuePath: testQueuePath,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	nq := newQueueEvents(queue, mock)
+	nq.sendTypeChangedEvent()
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
 	nq.sendTypeChangedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -146,8 +171,13 @@ func TestSendMaxResourceChangedEvent(t *testing.T) {
 		QueuePath:   testQueuePath,
 		maxResource: max,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	nq := newQueueEvents(queue, mock)
+	nq.sendMaxResourceChangedEvent()
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
 	nq.sendMaxResourceChangedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]
@@ -168,8 +198,13 @@ func TestSendGuaranteedResourceChangedEvent(t *testing.T) {
 		QueuePath:          testQueuePath,
 		guaranteedResource: guaranteed,
 	}
-	mock := newEventSystemMock()
+	mock := newEventSystemMockDisabled()
 	nq := newQueueEvents(queue, mock)
+	nq.sendGuaranteedResourceChangedEvent()
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	nq = newQueueEvents(queue, mock)
 	nq.sendGuaranteedResourceChangedEvent()
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 	event := mock.events[0]

--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/yunikorn-core/pkg/common/configs"
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/common/security"
+	"github.com/apache/yunikorn-core/pkg/events"
 	"github.com/apache/yunikorn-core/pkg/rmproxy"
 	"github.com/apache/yunikorn-core/pkg/scheduler/ugm"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
@@ -174,7 +175,7 @@ func newNodeInternal(nodeID string, total, occupied *resources.Resource) *Node {
 		schedulable:       true,
 		reservations:      make(map[string]*reservation),
 	}
-	sn.nodeEvents = newNodeEvents(sn, nil)
+	sn.nodeEvents = newNodeEvents(sn, events.GetEventSystem())
 	return sn
 }
 


### PR DESCRIPTION
### What is this PR for?
We must consider the current configuration when sending out events. Right now, a boolean is initialzed only once and config reloads do not take effect.

The event system is always initialized when running the entry point, so `events.GetEventSystem()` never returns nil.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1899

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
