### PR TITLE
[YUNIKORN-1915] Rename CreateAndSetEventSystem() and reduce code duplication

### DIFF
--- a/pkg/events/event_system.go
+++ b/pkg/events/event_system.go
@@ -68,16 +68,7 @@ func (ec *EventSystemImpl) GetEventsFromID(id, count uint64) ([]*si.EventRecord,
 
 func GetEventSystem() EventSystem {
 	once.Do(func() {
-		store := newEventStore()
-		ev = &EventSystemImpl{
-			Store:         store,
-			channel:       make(chan *si.EventRecord, defaultEventChannelSize),
-			stop:          make(chan bool),
-			stopped:       false,
-			publisher:     CreateShimPublisher(store),
-			eventBuffer:   newEventRingBuffer(defaultRingBufferSize),
-			eventSystemId: fmt.Sprintf("event-system-%d", time.Now().Unix()),
-		}
+		Init()
 	})
 	return ev
 }
@@ -100,7 +91,8 @@ func (ec *EventSystemImpl) GetRingBufferCapacity() uint64 {
 	return ec.ringBufferCapacity
 }
 
-func CreateAndSetEventSystem() {
+// VisibleForTesting
+func Init() {
 	store := newEventStore()
 	ev = &EventSystemImpl{
 		Store:         store,

--- a/pkg/events/event_system_test.go
+++ b/pkg/events/event_system_test.go
@@ -32,7 +32,7 @@ import (
 
 // StartService() and Stop() must not cause panic
 func TestSimpleStartAndStop(t *testing.T) {
-	CreateAndSetEventSystem()
+	Init()
 	eventSystem := GetEventSystem()
 	// adding event to stopped eventSystem does not cause panic
 	eventSystem.AddEvent(nil)
@@ -48,7 +48,7 @@ func TestSimpleStartAndStop(t *testing.T) {
 // if an EventRecord is added to the EventSystem, the same record
 // should be retrieved from the EventStore
 func TestSingleEventStoredCorrectly(t *testing.T) {
-	CreateAndSetEventSystem()
+	Init()
 	eventSystem := GetEventSystem().(*EventSystemImpl) //nolint:errcheck
 	// don't run publisher, because it can collect the event while we're waiting
 	eventSystem.StartServiceWithPublisher(false)
@@ -81,7 +81,7 @@ func TestSingleEventStoredCorrectly(t *testing.T) {
 }
 
 func TestGetEvents(t *testing.T) {
-	CreateAndSetEventSystem()
+	Init()
 	eventSystem := GetEventSystem().(*EventSystemImpl) //nolint:errcheck
 	eventSystem.StartServiceWithPublisher(false)
 	defer eventSystem.Stop()
@@ -113,7 +113,7 @@ func TestConfigUpdate(t *testing.T) {
 	configs.SetConfigMap(map[string]string{})
 	defer configs.SetConfigMap(map[string]string{})
 
-	CreateAndSetEventSystem()
+	Init()
 	eventSystem := GetEventSystem().(*EventSystemImpl) //nolint:errcheck
 	eventSystem.StartService()
 	defer eventSystem.Stop()

--- a/pkg/scheduler/objects/application_state_test.go
+++ b/pkg/scheduler/objects/application_state_test.go
@@ -240,7 +240,7 @@ func TestFailedStateTransition(t *testing.T) {
 }
 
 func TestAppStateTransitionEvents(t *testing.T) {
-	events.CreateAndSetEventSystem()
+	events.Init()
 	eventSystem := events.GetEventSystem().(*events.EventSystemImpl) //nolint:errcheck
 	eventSystem.StartServiceWithPublisher(false)
 	// Accept only from new

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -202,7 +202,7 @@ func TestAppReservation(t *testing.T) {
 func TestAppAllocReservation(t *testing.T) {
 	app := newApplication(appID1, "default", "root.unknown")
 	// Create event system after new application to avoid new application event.
-	events.CreateAndSetEventSystem()
+	events.Init()
 	eventSystem := events.GetEventSystem().(*events.EventSystemImpl) //nolint:errcheck
 	eventSystem.StartServiceWithPublisher(false)
 	app.disableStateChangeEvents()
@@ -320,7 +320,7 @@ func TestUpdateRepeat(t *testing.T) {
 func TestAddAllocAsk(t *testing.T) {
 	app := newApplication(appID1, "default", "root.unknown")
 	// Create event system after new application to avoid new application event.
-	events.CreateAndSetEventSystem()
+	events.Init()
 	eventSystem := events.GetEventSystem().(*events.EventSystemImpl) //nolint:errcheck
 	eventSystem.StartServiceWithPublisher(false)
 	app.disableStateChangeEvents()
@@ -1997,7 +1997,7 @@ func TestMaxAskPriority(t *testing.T) {
 func TestAskEvents(t *testing.T) {
 	app := newApplication(appID1, "default", "root.default")
 	// Create event system after new application to avoid new app event.
-	events.CreateAndSetEventSystem()
+	events.Init()
 	eventSystem := events.GetEventSystem().(*events.EventSystemImpl) //nolint:errcheck
 	eventSystem.StartServiceWithPublisher(false)
 	app.disableStateChangeEvents()
@@ -2063,7 +2063,7 @@ func TestAskEvents(t *testing.T) {
 func TestAllocationEvents(t *testing.T) { //nolint:funlen
 	app := newApplication(appID1, "default", "root.default")
 	// Create event system after new application to avoid new app event.
-	events.CreateAndSetEventSystem()
+	events.Init()
 	eventSystem := events.GetEventSystem().(*events.EventSystemImpl) //nolint:errcheck
 	eventSystem.StartServiceWithPublisher(false)
 	app.disableStateChangeEvents()
@@ -2182,7 +2182,7 @@ func TestPlaceholderLargerEvent(t *testing.T) {
 
 	app := newApplication(appID1, "default", "root.default")
 	// Create event system after new application to avoid new application event.
-	events.CreateAndSetEventSystem()
+	events.Init()
 	eventSystem := events.GetEventSystem().(*events.EventSystemImpl) //nolint:errcheck
 	eventSystem.StartServiceWithPublisher(false)
 	app.disableStateChangeEvents()
@@ -2229,7 +2229,7 @@ func TestAppDoesNotFitEvent(t *testing.T) {
 	ask := newAllocationAsk("alloc-0", "app-1", res)
 	app := newApplication(appID1, "default", "root.default")
 	// Create event system after new application to avoid new application event.
-	events.CreateAndSetEventSystem()
+	events.Init()
 	eventSystem := events.GetEventSystem().(*events.EventSystemImpl) //nolint:errcheck
 	eventSystem.StartServiceWithPublisher(false)
 	app.disableStateChangeEvents()

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -2582,7 +2582,7 @@ func TestQueue_setAllocatingAccepted(t *testing.T) {
 }
 
 func TestQueueEvents(t *testing.T) {
-	events.CreateAndSetEventSystem()
+	events.Init()
 	eventSystem := events.GetEventSystem().(*events.EventSystemImpl) //nolint:errcheck
 	eventSystem.StartServiceWithPublisher(false)
 	queue, err := createRootQueue(nil)

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -3396,7 +3396,7 @@ func TestTryAllocateMaxRunning(t *testing.T) {
 }
 
 func TestNewQueueEvents(t *testing.T) {
-	events.CreateAndSetEventSystem()
+	events.Init()
 	eventSystem := events.GetEventSystem().(*events.EventSystemImpl) //nolint:errcheck
 	eventSystem.StartServiceWithPublisher(false)
 

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1352,7 +1352,7 @@ func TestGetEvents(t *testing.T) {
 }
 
 func addEvents(t *testing.T) (appEvent, nodeEvent, queueEvent *si.EventRecord) {
-	events.CreateAndSetEventSystem()
+	events.Init()
 	ev := events.GetEventSystem().(*events.EventSystemImpl) //nolint:errcheck
 	ev.StartServiceWithPublisher(false)
 	protoRes := resources.NewResourceFromMap(map[string]resources.Quantity{


### PR DESCRIPTION
### What is this PR for?
Currently, the event system can be intialized twice by the same code, GetEventSystem() and CreateAndSetEventSystem().
Remove the duplication and rename CreateAndSetEventSystem() to Init() to reflect its true purpose.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1915

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
