### PR TITLE
[YUNIKORN-1919] decrease runningApps when app changes from starting to completing

### DIFF
--- a/pkg/scheduler/objects/application_state.go
+++ b/pkg/scheduler/objects/application_state.go
@@ -162,6 +162,11 @@ func NewAppState() *fsm.FSM {
 			},
 			fmt.Sprintf("enter_%s", Completing.String()): func(_ context.Context, event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
+				if event.Src == Starting.String() {
+					app.queue.decRunningApps()
+					metrics.GetQueueMetrics(app.queuePath).DecQueueApplicationsRunning()
+					metrics.GetSchedulerMetrics().DecTotalApplicationsRunning()
+				}
 				app.setStateTimer(completingTimeout, app.stateMachine.Current(), CompleteApplication)
 				app.appEvents.sendStateChangeEvent(si.EventRecord_APP_COMPLETING)
 			},


### PR DESCRIPTION
### What is this PR for?

We didn't decrease `runningApps` if the single-allocation app changes from starting to completing.


### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-1919

### How should this be tested?

Add a unit test for it.