### PR TITLE
[YUNIKORN-1920] headroom with parent queue usage

### DIFF
--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -19,9 +19,11 @@
 package ugm
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/apache/yunikorn-core/pkg/common"
+	"github.com/apache/yunikorn-core/pkg/common/configs"
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/webservice/dao"
 )
@@ -81,7 +83,7 @@ func (gt *GroupTracker) setLimits(queuePath string, resource *resources.Resource
 func (gt *GroupTracker) headroom(queuePath string) *resources.Resource {
 	gt.Lock()
 	defer gt.Unlock()
-	return gt.queueTracker.headroom(queuePath)
+	return gt.queueTracker.headroom(strings.Split(queuePath, configs.DOT))
 }
 
 func (gt *GroupTracker) GetGroupResourceUsageDAOInfo() *dao.GroupResourceUsageDAOInfo {

--- a/pkg/scheduler/ugm/queue_tracker.go
+++ b/pkg/scheduler/ugm/queue_tracker.go
@@ -245,34 +245,32 @@ func (qt *QueueTracker) setLimit(queuePath string, maxResource *resources.Resour
 	childQueueTracker.maxResources = maxResource
 }
 
-func (qt *QueueTracker) headroom(queuePath string) *resources.Resource {
+func (qt *QueueTracker) headroom(hierarchy []string) *resources.Resource {
 	log.Log(log.SchedUGM).Debug("Calculating headroom",
-		zap.String("queue path", queuePath))
-	childQueuePath, immediateChildQueueName := getChildQueuePath(queuePath)
-	if childQueuePath != common.Empty {
-		if qt.childQueueTrackers[immediateChildQueueName] != nil {
-			headroom := qt.childQueueTrackers[immediateChildQueueName].headroom(childQueuePath)
-			if headroom != nil {
-				return resources.ComponentWiseMinPermissive(headroom, qt.maxResources)
-			}
-		} else {
-			log.Log(log.SchedUGM).Error("Child queueTracker tracker must be available in child queues map",
-				zap.String("child queueTracker name", immediateChildQueueName))
-			return nil
+		zap.Strings("queue path", hierarchy))
+	// depth first: all the way to the leaf, create if not exists
+	// more than 1 in the slice means we need to recurse down
+	var headroom, childHeadroom *resources.Resource
+	if len(hierarchy) > 1 {
+		childName := hierarchy[1]
+		if qt.childQueueTrackers[childName] == nil {
+			qt.childQueueTrackers[childName] = newQueueTracker(qt.queuePath, childName)
 		}
+		childHeadroom = qt.childQueueTrackers[childName].headroom(hierarchy[1:])
 	}
-
+	// arrived at the leaf or on the way out: check against current max if set
 	if !resources.Equals(resources.NewResource(), qt.maxResources) {
-		headroom := qt.maxResources.Clone()
+		headroom = qt.maxResources.Clone()
 		headroom.SubOnlyExisting(qt.resourceUsage)
 		log.Log(log.SchedUGM).Debug("Calculated headroom",
-			zap.String("queue path", queuePath),
-			zap.String("queue", qt.queueName),
+			zap.String("queue path", qt.queuePath),
 			zap.String("max resource", qt.maxResources.String()),
 			zap.String("headroom", headroom.String()))
-		return headroom
 	}
-	return nil
+	if headroom == nil {
+		return childHeadroom
+	}
+	return resources.ComponentWiseMinPermissive(headroom, childHeadroom)
 }
 
 func (qt *QueueTracker) getResourceUsageDAOInfo(parentQueuePath string) *dao.ResourceUsageDAOInfo {

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -19,11 +19,13 @@
 package ugm
 
 import (
+	"strings"
 	"sync"
 
 	"go.uber.org/zap"
 
 	"github.com/apache/yunikorn-core/pkg/common"
+	"github.com/apache/yunikorn-core/pkg/common/configs"
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/log"
 	"github.com/apache/yunikorn-core/pkg/webservice/dao"
@@ -124,7 +126,7 @@ func (ut *UserTracker) setLimits(queuePath string, resource *resources.Resource,
 func (ut *UserTracker) headroom(queuePath string) *resources.Resource {
 	ut.Lock()
 	defer ut.Unlock()
-	return ut.queueTracker.headroom(queuePath)
+	return ut.queueTracker.headroom(strings.Split(queuePath, configs.DOT))
 }
 
 func (ut *UserTracker) GetUserResourceUsageDAOInfo() *dao.UserResourceUsageDAOInfo {


### PR DESCRIPTION
### What is this PR for?
Headroom needs to take into account the usage in each queue and not assume that the full max resource is available if the queue is not the leaf queue.
Add a queue tracker object for any queue that is not found while traversing the hierarchy. The user/group has an application running in that queue and will add usage at some point.

Add tests to cover usage and max with different resource types set.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-1920

### How should this be tested?
New unit tests added to cover the scenario