### PR TITLE
[YUNIKORN-1918] Remove UpdateSchedulerConfig from core

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -324,26 +324,6 @@ func (cc *ClusterContext) removePartitionsByRMID(event *rmevent.RMPartitionsRemo
 	}
 }
 
-// Locked version of the configuration update called from the webservice
-// NOTE: this call assumes one RM which is registered and uses that RM for the updates
-func (cc *ClusterContext) UpdateSchedulerConfig(conf *configs.SchedulerConfig) error {
-	cc.Lock()
-	defer cc.Unlock()
-	// hack around the missing rmID
-	for _, pi := range cc.partitions {
-		rmID := pi.RmID
-		log.Log(log.SchedContext).Debug("Assuming one RM on config update call from webservice",
-			zap.String("rmID", rmID))
-		if err := cc.updateSchedulerConfig(conf, rmID); err != nil {
-			return err
-		}
-		// update global scheduler configs
-		configs.ConfigContext.Set(cc.policyGroup, conf)
-		return nil
-	}
-	return fmt.Errorf("RM has no active partitions, make sure it is registered")
-}
-
 // Locked version of the configuration update called outside of event system.
 // Updates the current config via the config loader.
 // Used in test only, normal updates use the internal call


### PR DESCRIPTION
### What is this PR for?
In the ClusterContext there is a locked version to update the scheduler config. The locked version was introduced to allow setting the config via the web service. This has been removed in a previous version and now the function UpdateSchedulerConfig() is no longer useful and as dead code should be removed.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1918

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
