### PR TITLE
[YUNIKORN-1928] Exceed queue quota requests should be skipped when cl…

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -21,7 +21,6 @@ package objects
 import (
 	"context"
 	"fmt"
-	"github.com/apache/yunikorn-core/pkg/plugins"
 	"math"
 	"strings"
 	"sync"
@@ -38,6 +37,7 @@ import (
 	"github.com/apache/yunikorn-core/pkg/handler"
 	"github.com/apache/yunikorn-core/pkg/log"
 	"github.com/apache/yunikorn-core/pkg/metrics"
+	"github.com/apache/yunikorn-core/pkg/plugins"
 	"github.com/apache/yunikorn-core/pkg/rmproxy/rmevent"
 	"github.com/apache/yunikorn-core/pkg/scheduler/ugm"
 	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"


### PR DESCRIPTION
…uster auto scaling.

### What is this PR for?
In shim side we have skip autoscaling logic both for yunikorn mode and plugin mode, we need to make that exceed queue quota requests should be skipped when cluster auto scaling.


```
switch request.State {
case si.UpdateContainerSchedulingStateRequest_SKIPPED:
    // auto-scaler scans pods whose pod condition is PodScheduled=false && reason=Unschedulable
    // if the pod is skipped because the queue quota has been exceed, we do not trigger the auto-scaling
    task.SetTaskSchedulingState(interfaces.TaskSchedSkipped)
    if ctx.updatePodCondition(task,
       &v1.PodCondition{
          Type:    v1.PodScheduled,
          Status:  v1.ConditionFalse,
          Reason:  "SchedulingSkipped",
          Message: request.Reason,
       }) {
       events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
          v1.EventTypeNormal, "PodUnschedulable", "PodUnschedulable",
          "Task %s is skipped from scheduling because the queue quota has been exceed", task.alias)
    }
```
It will be over auto scaling.



### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN/
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
