### PR TITLE
[YUNIKORN-1930] Add message to node added/removed event

### DIFF
--- a/pkg/scheduler/objects/node_events.go
+++ b/pkg/scheduler/objects/node_events.go
@@ -34,7 +34,7 @@ func (n *nodeEvents) sendNodeAddedEvent() {
 	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, common.Empty, si.EventRecord_ADD,
+	event := events.CreateNodeEventRecord(n.node.NodeID, "Node added to the scheduler", common.Empty, si.EventRecord_ADD,
 		si.EventRecord_DETAILS_NONE, n.node.GetCapacity())
 	n.eventSystem.AddEvent(event)
 }
@@ -43,7 +43,7 @@ func (n *nodeEvents) sendNodeRemovedEvent() {
 	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, common.Empty, si.EventRecord_REMOVE,
+	event := events.CreateNodeEventRecord(n.node.NodeID, "Node removed from the scheduler", common.Empty, si.EventRecord_REMOVE,
 		si.EventRecord_NODE_DECOMISSION, nil)
 	n.eventSystem.AddEvent(event)
 }

--- a/pkg/scheduler/objects/node_events_test.go
+++ b/pkg/scheduler/objects/node_events_test.go
@@ -44,7 +44,7 @@ func TestSendNodeAddedEvent(t *testing.T) {
 	event := mock.events[0]
 	assert.Equal(t, nodeID1, event.ObjectID)
 	assert.Equal(t, common.Empty, event.ReferenceID)
-	assert.Equal(t, common.Empty, event.Message)
+	assert.Equal(t, "Node added to the scheduler", event.Message)
 	assert.Equal(t, si.EventRecord_ADD, event.EventChangeType)
 	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
 	assert.Equal(t, 0, len(event.Resource.Resources))
@@ -66,7 +66,7 @@ func TestSendNodeRemovedEvent(t *testing.T) {
 	event := mock.events[0]
 	assert.Equal(t, nodeID1, event.ObjectID)
 	assert.Equal(t, common.Empty, event.ReferenceID)
-	assert.Equal(t, common.Empty, event.Message)
+	assert.Equal(t, "Node removed from the scheduler", event.Message)
 	assert.Equal(t, si.EventRecord_REMOVE, event.EventChangeType)
 	assert.Equal(t, si.EventRecord_NODE_DECOMISSION, event.EventChangeDetail)
 	assert.Equal(t, 0, len(event.Resource.Resources))


### PR DESCRIPTION
### What is this PR for?
Messages that are sent to the shim should have a Message field set properly. This will be visible when the events for a given object (pod/node) are listed.
The node added/removed event will be sent out as an event to K8s, so we add an informative message.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1930

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
