### PR TITLE
[YUNIKORN-1932] Ignore not-started app when reporting app summary

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -2013,6 +2013,9 @@ func (sa *Application) CleanupUsedResource() {
 }
 
 func (sa *Application) LogAppSummary(rmID string) {
+	if sa.startTime.IsZero() {
+		return
+	}
 	appSummary := sa.GetApplicationSummary(rmID)
 	appSummary.DoLogging()
 	appSummary.ResourceUsage = nil


### PR DESCRIPTION
### What is this PR for?
Apps can go from Accepted state directly to Completing state in some situations. In this case, the startTime of the app is not initialized, and the resource usage is 0. Given that the app summary is to report resource usage, this jira is to ignore not-started app when reporting app summary

### What type of PR is it?
* [ ] - Bug Fix
* [ x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1932

### How should this be tested?
To observe that no apps with startTime -62135596800000 are reported in app summary log prefixed with YK_APP_SUMMARY
### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
