### PR TITLE
[YUNIKORN-970]  Add queue metrics with queue names as tags (#1)

### DIFF
--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -27,8 +27,10 @@ import (
 
 // QueueMetrics to declare queue metrics
 type QueueMetrics struct {
-	appMetrics      *prometheus.GaugeVec
-	ResourceMetrics *prometheus.GaugeVec
+	appMetricsLabel          *prometheus.GaugeVec
+	appMetricsSubsystem      *prometheus.GaugeVec
+	ResourceMetricsLabel     *prometheus.GaugeVec
+	ResourceMetricsSubsystem *prometheus.GaugeVec
 }
 
 // InitQueueMetrics to initialize queue metrics
@@ -37,7 +39,15 @@ func InitQueueMetrics(name string) CoreQueueMetrics {
 
 	replaceStr := formatMetricName(name)
 
-	q.appMetrics = prometheus.NewGaugeVec(
+	q.appMetricsLabel = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "queue_app",
+			ConstLabels: prometheus.Labels{"queue": name},
+			Help:      "Queue application metrics. State of the application includes `running`.",
+		}, []string{"state"})
+
+	q.appMetricsSubsystem = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Subsystem: replaceStr,
@@ -45,7 +55,15 @@ func InitQueueMetrics(name string) CoreQueueMetrics {
 			Help:      "Queue application metrics. State of the application includes `running`.",
 		}, []string{"state"})
 
-	q.ResourceMetrics = prometheus.NewGaugeVec(
+	q.ResourceMetricsLabel = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "queue_resource",
+			ConstLabels: prometheus.Labels{"queue": name},
+			Help:      "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`.",
+		}, []string{"state", "resource"})
+
+	q.ResourceMetricsSubsystem = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Subsystem: replaceStr,
@@ -54,8 +72,10 @@ func InitQueueMetrics(name string) CoreQueueMetrics {
 		}, []string{"state", "resource"})
 
 	var queueMetricsList = []prometheus.Collector{
-		q.appMetrics,
-		q.ResourceMetrics,
+		q.appMetricsLabel,
+		q.appMetricsSubsystem,
+		q.ResourceMetricsLabel,
+		q.ResourceMetricsSubsystem,
 	}
 
 	// Register the metrics
@@ -72,70 +92,89 @@ func InitQueueMetrics(name string) CoreQueueMetrics {
 }
 
 func (m *QueueMetrics) Reset() {
-	m.appMetrics.Reset()
-	m.ResourceMetrics.Reset()
+	m.appMetricsLabel.Reset()
+	m.appMetricsSubsystem.Reset()
+	m.ResourceMetricsLabel.Reset()
+	m.ResourceMetricsSubsystem.Reset()
 }
 
 func (m *QueueMetrics) IncQueueApplicationsRunning() {
-	m.appMetrics.With(prometheus.Labels{"state": "running"}).Inc()
+	m.appMetricsLabel.With(prometheus.Labels{"state": "running"}).Inc()
+	m.appMetricsSubsystem.With(prometheus.Labels{"state": "running"}).Inc()
 }
 
 func (m *QueueMetrics) DecQueueApplicationsRunning() {
-	m.appMetrics.With(prometheus.Labels{"state": "running"}).Dec()
+	m.appMetricsLabel.With(prometheus.Labels{"state": "running"}).Dec()
+	m.appMetricsSubsystem.With(prometheus.Labels{"state": "running"}).Dec()
+
 }
 
 func (m *QueueMetrics) IncQueueApplicationsAccepted() {
-	m.appMetrics.With(prometheus.Labels{"state": "accepted"}).Inc()
+	m.appMetricsLabel.With(prometheus.Labels{"state": "accepted"}).Inc()
+	m.appMetricsSubsystem.With(prometheus.Labels{"state": "accepted"}).Inc()
 }
 
 func (m *QueueMetrics) IncQueueApplicationsRejected() {
-	m.appMetrics.With(prometheus.Labels{"state": "rejected"}).Inc()
+	m.appMetricsLabel.With(prometheus.Labels{"state": "rejected"}).Inc()
+	m.appMetricsSubsystem.With(prometheus.Labels{"state": "rejected"}).Inc()
 }
 
 func (m *QueueMetrics) IncQueueApplicationsFailed() {
-	m.appMetrics.With(prometheus.Labels{"state": "failed"}).Inc()
+	m.appMetricsLabel.With(prometheus.Labels{"state": "failed"}).Inc()
+	m.appMetricsSubsystem.With(prometheus.Labels{"state": "failed"}).Inc()
 }
 
 func (m *QueueMetrics) IncQueueApplicationsCompleted() {
-	m.appMetrics.With(prometheus.Labels{"state": "completed"}).Inc()
+	m.appMetricsLabel.With(prometheus.Labels{"state": "completed"}).Inc()
+	m.appMetricsSubsystem.With(prometheus.Labels{"state": "completed"}).Inc()
 }
 
 func (m *QueueMetrics) IncAllocatedContainer() {
-	m.appMetrics.With(prometheus.Labels{"state": "allocated"}).Inc()
+	m.appMetricsLabel.With(prometheus.Labels{"state": "allocated"}).Inc()
+	m.appMetricsSubsystem.With(prometheus.Labels{"state": "allocated"}).Inc()
 }
 
 func (m *QueueMetrics) IncReleasedContainer() {
-	m.appMetrics.With(prometheus.Labels{"state": "released"}).Inc()
+	m.appMetricsLabel.With(prometheus.Labels{"state": "released"}).Inc()
+	m.appMetricsSubsystem.With(prometheus.Labels{"state": "released"}).Inc()
 }
 
 func (m *QueueMetrics) SetQueueGuaranteedResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetrics.With(prometheus.Labels{"state": "guaranteed", "resource": resourceName}).Set(value)
+	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "guaranteed", "resource": resourceName}).Set(value)
+	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "guaranteed", "resource": resourceName}).Set(value)
 }
 
 func (m *QueueMetrics) SetQueueMaxResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetrics.With(prometheus.Labels{"state": "max", "resource": resourceName}).Set(value)
+	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "max", "resource": resourceName}).Set(value)
+	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "max", "resource": resourceName}).Set(value)
 }
 
 func (m *QueueMetrics) SetQueueAllocatedResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetrics.With(prometheus.Labels{"state": "allocated", "resource": resourceName}).Set(value)
+	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "allocated", "resource": resourceName}).Set(value)
+	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "allocated", "resource": resourceName}).Set(value)
 }
 
 func (m *QueueMetrics) AddQueueAllocatedResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetrics.With(prometheus.Labels{"state": "allocated", "resource": resourceName}).Add(value)
+	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "allocated", "resource": resourceName}).Add(value)
+	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "allocated", "resource": resourceName}).Add(value)
 }
 
 func (m *QueueMetrics) SetQueuePendingResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetrics.With(prometheus.Labels{"state": "pending", "resource": resourceName}).Set(value)
+	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "pending", "resource": resourceName}).Set(value)
+	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "pending", "resource": resourceName}).Set(value)
 }
 
 func (m *QueueMetrics) AddQueuePendingResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetrics.With(prometheus.Labels{"state": "pending", "resource": resourceName}).Add(value)
+	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "pending", "resource": resourceName}).Add(value)
+	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "pending", "resource": resourceName}).Add(value)
 }
 
 func (m *QueueMetrics) SetQueuePreemptingResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetrics.With(prometheus.Labels{"state": "preempting", "resource": resourceName}).Set(value)
+	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "preempting", "resource": resourceName}).Set(value)
+	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "preempting", "resource": resourceName}).Set(value)
 }
 
 func (m *QueueMetrics) AddQueuePreemptingResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetrics.With(prometheus.Labels{"state": "preempting", "resource": resourceName}).Add(value)
+	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "preempting", "resource": resourceName}).Add(value)
+	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "preempting", "resource": resourceName}).Add(value)
 }

--- a/pkg/metrics/queue_test.go
+++ b/pkg/metrics/queue_test.go
@@ -131,16 +131,52 @@ func getQueueMetrics() CoreQueueMetrics {
 }
 
 func verifyAppMetrics(t *testing.T, expectedState string) {
+	verifyAppMetricsLabel(t, expectedState)
+	verifyAppMetricsSubsystem(t, expectedState)
+}
+
+func verifyAppMetricsLabel(t *testing.T, expectedState string) {
+	checkFn := func(labels []*dto.LabelPair) {
+		assert.Equal(t, 2, len(labels))
+		assert.Equal(t, "queue", *labels[0].Name)
+		assert.Equal(t, "root.test", *labels[0].Value)
+		assert.Equal(t, "state", *labels[1].Name)
+		assert.Equal(t, expectedState, *labels[1].Value)
+	}
+
+	verifyMetricsLabel(t, checkFn)
+}
+
+func verifyAppMetricsSubsystem(t *testing.T, expectedState string) {
 	checkFn := func(labels []*dto.LabelPair) {
 		assert.Equal(t, 1, len(labels))
 		assert.Equal(t, "state", *labels[0].Name)
 		assert.Equal(t, expectedState, *labels[0].Value)
 	}
 
-	verifyMetrics(t, checkFn)
+	verifyMetricsSubsytem(t, checkFn)
 }
 
 func verifyResourceMetrics(t *testing.T, expectedState, expectedResource string) {
+	verifyResourceMetricsLabel(t, expectedState, expectedResource)
+	verifyResourceMetricsSubsystem(t, expectedState, expectedResource)
+}
+
+func verifyResourceMetricsLabel(t *testing.T, expectedState, expectedResource string) {
+	checkFn := func(labels []*dto.LabelPair) {
+		assert.Equal(t, 3, len(labels))
+		assert.Equal(t, "queue", *labels[0].Name)
+		assert.Equal(t, "root.test", *labels[0].Value)
+		assert.Equal(t, "resource", *labels[1].Name)
+		assert.Equal(t, expectedResource, *labels[1].Value)
+		assert.Equal(t, "state", *labels[2].Name)
+		assert.Equal(t, expectedState, *labels[2].Value)
+	}
+
+	verifyMetricsLabel(t, checkFn)
+}
+
+func verifyResourceMetricsSubsystem(t *testing.T, expectedState, expectedResource string) {
 	checkFn := func(labels []*dto.LabelPair) {
 		assert.Equal(t, 2, len(labels))
 		assert.Equal(t, "resource", *labels[0].Name)
@@ -149,10 +185,31 @@ func verifyResourceMetrics(t *testing.T, expectedState, expectedResource string)
 		assert.Equal(t, expectedState, *labels[1].Value)
 	}
 
-	verifyMetrics(t, checkFn)
+	verifyMetricsSubsytem(t, checkFn)
 }
 
-func verifyMetrics(t *testing.T, checkLabel func(label []*dto.LabelPair)) {
+func verifyMetricsLabel(t *testing.T, checkLabel func(label []*dto.LabelPair)) {
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	assert.NilError(t, err)
+
+	var checked bool
+	for _, metric := range mfs {
+		if strings.Contains(metric.GetName(), "yunikorn_queue") {
+			assert.Equal(t, 1, len(metric.Metric))
+			assert.Equal(t, dto.MetricType_GAUGE, metric.GetType())
+			m := metric.Metric[0]
+			checkLabel(m.Label)
+			assert.Assert(t, m.Gauge != nil)
+			assert.Equal(t, float64(1), *m.Gauge.Value)
+			checked = true
+			break
+		}
+	}
+
+	assert.Assert(t, checked, "Failed to find metric")
+}
+
+func verifyMetricsSubsytem(t *testing.T, checkLabel func(label []*dto.LabelPair)) {
 	mfs, err := prometheus.DefaultGatherer.Gather()
 	assert.NilError(t, err)
 
@@ -178,6 +235,9 @@ func unregisterQueueMetrics(t *testing.T) {
 		t.Fatalf("Type assertion failed, metrics is not QueueMetrics")
 	}
 
-	prometheus.Unregister(qm.appMetrics)
-	prometheus.Unregister(qm.ResourceMetrics)
+	prometheus.Unregister(qm.appMetricsLabel)
+	prometheus.Unregister(qm.appMetricsSubsystem)
+	prometheus.Unregister(qm.ResourceMetricsLabel)
+	prometheus.Unregister(qm.ResourceMetricsSubsystem)
+
 }


### PR DESCRIPTION
Add duplicate Prometheus queue metrics with queue name in label instead of in the subsystem (which will result in per-queue metric). Eventually we will remove the subsystem metrics and only have metrics with queue labels

* [ ] - Bug Fix
* [X] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

Unit Tests:
```
yongjunzhang-57YJGH6:yunikorn-core yongjunzhang$ make test
running unit tests
"go" clean -testcache
"go" test ./... -race -tags deadlock -coverprofile=build/coverage.txt -covermode=atomic
?   	github.com/apache/yunikorn-core/cmd/schedulerclient	[no test files]
?   	github.com/apache/yunikorn-core/cmd/simplescheduler	[no test files]
ok  	github.com/apache/yunikorn-core/pkg/common	0.472s	coverage: 67.5% of statements
ok  	github.com/apache/yunikorn-core/pkg/common/configs	0.425s	coverage: 94.5% of statements
ok  	github.com/apache/yunikorn-core/pkg/common/resources	0.760s	coverage: 93.2% of statements
ok  	github.com/apache/yunikorn-core/pkg/common/security	0.564s	coverage: 86.5% of statements
?   	github.com/apache/yunikorn-core/pkg/entrypoint	[no test files]
?   	github.com/apache/yunikorn-core/pkg/examples	[no test files]
?   	github.com/apache/yunikorn-core/pkg/handler	[no test files]
?   	github.com/apache/yunikorn-core/pkg/rmproxy	[no test files]
?   	github.com/apache/yunikorn-core/pkg/rmproxy/rmevent	[no test files]
ok  	github.com/apache/yunikorn-core/pkg/events	0.421s	coverage: 99.5% of statements
?   	github.com/apache/yunikorn-core/pkg/scheduler/placement/types	[no test files]
?   	github.com/apache/yunikorn-core/pkg/webservice/dao	[no test files]
ok  	github.com/apache/yunikorn-core/pkg/log	13.346s	coverage: 86.7% of statements
ok  	github.com/apache/yunikorn-core/pkg/metrics	3.775s	coverage: 57.4% of statements
ok  	github.com/apache/yunikorn-core/pkg/metrics/history	0.832s	coverage: 100.0% of statements
ok  	github.com/apache/yunikorn-core/pkg/plugins	1.075s	coverage: 60.0% of statements
ok  	github.com/apache/yunikorn-core/pkg/scheduler	3.747s	coverage: 65.8% of statements
ok  	github.com/apache/yunikorn-core/pkg/scheduler/objects	14.201s	coverage: 83.7% of statements
ok  	github.com/apache/yunikorn-core/pkg/scheduler/objects/template	0.582s	coverage: 80.6% of statements
ok  	github.com/apache/yunikorn-core/pkg/scheduler/placement	0.829s	coverage: 90.6% of statements
ok  	github.com/apache/yunikorn-core/pkg/scheduler/policies	0.915s	coverage: 100.0% of statements
ok  	github.com/apache/yunikorn-core/pkg/scheduler/tests	41.159s	coverage: 71.4% of statements
ok  	github.com/apache/yunikorn-core/pkg/scheduler/ugm	1.519s	coverage: 93.1% of statements
ok  	github.com/apache/yunikorn-core/pkg/trace	1.679s	coverage: 94.4% of statements
ok  	github.com/apache/yunikorn-core/pkg/webservice	0.607s	coverage: 81.0% of statements
"go" vet github.com/apache/yunikorn-core/pkg...



<!-- https://github.com/pinternal/yunikorn-core/pull/1 -->

### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - http://yunikorn.apache.org/community/how_to_contribute   


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-970

### How should this be tested?

### Screenshots (if appropriate)
 HELP yunikorn_queue_resource Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`.
yunikorn_queue_resource{queue="root",resource="attachable-volumes-aws-ebs",state="max"} 64
yunikorn_queue_resource{queue="root",resource="ephemeral-storage",state="max"} 1.848047531e+11
yunikorn_queue_resource{queue="root",resource="hugepages-1Gi",state="max"} 0
yunikorn_queue_resource{queue="root",resource="hugepages-2Mi",state="max"} 0
yunikorn_queue_resource{queue="root",resource="hugepages-32Mi",state="max"} 0
yunikorn_queue_resource{queue="root",resource="hugepages-64Ki",state="max"} 0
yunikorn_queue_resource{queue="root",resource="memory",state="max"} 1.051849142272e+12
yunikorn_queue_resource{queue="root",resource="pods",state="max"} 192
yunikorn_queue_resource{queue="root",resource="vcore",state="max"} 127540
yunikorn_root_queue_resource{resource="attachable-volumes-aws-ebs",state="max"} 64
yunikorn_root_queue_resource{resource="ephemeral-storage",state="max"} 1.848047531e+11
yunikorn_root_queue_resource{resource="hugepages-1Gi",state="max"} 0
yunikorn_root_queue_resource{resource="hugepages-2Mi",state="max"} 0
yunikorn_root_queue_resource{resource="hugepages-32Mi",state="max"} 0
yunikorn_root_queue_resource{resource="hugepages-64Ki",state="max"} 0
yunikorn_root_queue_resource{resource="memory",state="max"} 1.051849142272e+12
yunikorn_root_queue_resource{resource="pods",state="max"} 192
yunikorn_root_queue_resource{resource="vcore",state="max"} 127540
```
### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
