### PR TITLE
[YUNIKORN-1948] Introduce a command to validate the content of a give…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ pseudo:
 
 # Build the example binaries for dev and test
 .PHONY: commands
-commands: build/simplescheduler build/schedulerclient
+commands: build/simplescheduler build/schedulerclient build/queueconfigchecker
 
 build/simplescheduler: go.mod go.sum cmd
 	@echo "building example scheduler"
@@ -188,6 +188,11 @@ build/schedulerclient:
 	@echo "building example client"
 	@mkdir -p build
 	"$(GO)" build $(RACE) -a -ldflags '-extldflags "-static"' -o build/schedulerclient ./cmd/schedulerclient
+
+build/queueconfigchecker:
+	@echo "building queueconfigchecker"
+	@mkdir -p build
+	"$(GO)" build $(RACE) -a -ldflags '-extldflags "-static"' -o build/queueconfigchecker ./cmd/queueconfigchecker
 
 # Build binaries for dev and test
 .PHONY: build

--- a/cmd/queueconfigchecker/queueconfigchecker.go
+++ b/cmd/queueconfigchecker/queueconfigchecker.go
@@ -34,14 +34,14 @@ func main() {
 		os.Exit(1)
 	}
 	queueFile := os.Args[1]
-	iv, err := os.ReadFile(queueFile)
+	conf, err := os.ReadFile(queueFile)
 	if err != nil {
-		log.Println(err)
+		log.Printf("Could not read file: %v", err)
 		os.Exit(2)
 	}
-	_, err1 := configs.LoadSchedulerConfigFromByteArray(iv)
-	if err1 != nil {
-		log.Println(err1)
+	_, err = configs.LoadSchedulerConfigFromByteArray(conf)
+	if err != nil {
+		log.Printf("Config validation failed: %v", err)
 		os.Exit(3)
 	}
 }

--- a/cmd/queueconfigchecker/queueconfigchecker.go
+++ b/cmd/queueconfigchecker/queueconfigchecker.go
@@ -1,0 +1,44 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/apache/yunikorn-core/pkg/common/configs"
+)
+
+/*
+	A utility command to load queue configuration file and check its validity
+ */
+func main() {
+	if len(os.Args) != 2 {
+		log.Println("Error: queue config file is not provided")
+		log.Println("Usage: " + os.Args[0] + " <queue-config-file>")
+		os.Exit(1)
+	}
+	queueFile := os.Args[1]
+	iv, err := os.ReadFile(queueFile)
+	if err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+	configs.LoadSchedulerConfigFromByteArray(iv)
+}

--- a/cmd/queueconfigchecker/queueconfigchecker.go
+++ b/cmd/queueconfigchecker/queueconfigchecker.go
@@ -26,11 +26,10 @@ import (
 )
 
 /*
-	A utility command to load queue configuration file and check its validity
- */
+A utility command to load queue configuration file and check its validity
+*/
 func main() {
 	if len(os.Args) != 2 {
-		log.Println("Error: queue config file is not provided")
 		log.Println("Usage: " + os.Args[0] + " <queue-config-file>")
 		os.Exit(1)
 	}
@@ -38,7 +37,11 @@ func main() {
 	iv, err := os.ReadFile(queueFile)
 	if err != nil {
 		log.Println(err)
-		os.Exit(1)
+		os.Exit(2)
 	}
-	configs.LoadSchedulerConfigFromByteArray(iv)
+	_, err1 := configs.LoadSchedulerConfigFromByteArray(iv)
+	if err1 != nil {
+		log.Println(err1)
+		os.Exit(3)
+	}
 }

--- a/pkg/common/configs/config.go
+++ b/pkg/common/configs/config.go
@@ -149,7 +149,6 @@ type NodeSortingPolicy struct {
 	ResourceWeights map[string]float64 `yaml:",omitempty" json:",omitempty"`
 }
 
-// Visible by tests
 func LoadSchedulerConfigFromByteArray(content []byte) (*SchedulerConfig, error) {
 	conf, err := ParseAndValidateConfig(content)
 	if err != nil {


### PR DESCRIPTION

### What is this PR for?
When preparing the queue configuration file, manually, or use a program, a format error can happen. It can be costly to load the file to production and revert.

This Jira introduces a dedicated command to load the input queue config file (queues.yaml etc), and run the same code that production uses to validate the file, and report errors if there are any.

### What type of PR is it?
* [ ] - Bug Fix
* [X ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1948

### How should this be tested?
Tested locally with queues.yaml file by modifying the content to make it invalid

$ build/queueconfigchecker queues.yaml
2023-08-31T11:25:44.115-0700	ERROR	core.config	configs/config.go:181	queue configuration validation failed	{"error": "guaranteed resource of parent map[memory:3384828493824 vcore:4006191] is smaller than sum of guaranteed resources map[memory:33848285986816 vcore:4006191] of the children for queue xyz"}
github.com/apache/yunikorn-core/pkg/common/configs.ParseAndValidateConfig
	/Users/yongjunzhang/code/yunikorn/yunikorn-core/pkg/common/configs/config.go:181
github.com/apache/yunikorn-core/pkg/common/configs.LoadSchedulerConfigFromByteArray
	/Users/yongjunzhang/code/yunikorn/yunikorn-core/pkg/common/configs/config.go:154
main.main
	/Users/yongjunzhang/code/yunikorn/yunikorn-core/cmd/queueconfigchecker/queueconfigchecker.go:43
runtime.main
	/usr/local/go/src/runtime/proc.go:250

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
