### PR TITLE
[YUNIKORN-1942] Null Batch API Response when we reset ring buffer size

### DIFF
--- a/pkg/events/event_ringbuffer.go
+++ b/pkg/events/event_ringbuffer.go
@@ -35,20 +35,21 @@ type eventRange struct {
 
 // eventRingBuffer A specialized circular buffer to store event objects.
 //
-// Unlike to regular circular buffers, existing entries are never directly removed and new entries can be added if the buffer is full.
+// Unlike regular circular buffers, existing entries are never directly removed
+// and new entries can be added if the buffer is full.
 // In this case, the oldest entry is overwritten and can be collected by the GC.
-// Each event has an ID, however, this mapping is not stored directly. If needed, we calculate the id
-// of the event based on slice positions.
+// Each event has an ID; however, this mapping is not stored directly.
+// If needed, we calculate the id of the event based on slice positions.
 //
-// Retrieving the records can be achieved with GetEventsFromID and GetRecentEntries.
+// Retrieving the records can be achieved with GetEventsFromID.
 type eventRingBuffer struct {
-	events   []*si.EventRecord
-	capacity uint64 // capacity of the buffer
-	head     uint64 // position of the next element (no tail since we don't remove elements)
-	full     bool   // indicates whether the buffer if full - once it is, it stays full unless the buffer is resized
-	id       uint64 // unique id of an event record
-	lowestId uint64 // lowest id of an event record available in the buffer at any given time
-	idAtZero uint64 // id at index 0, used to calculate position based on id
+	events       []*si.EventRecord
+	capacity     uint64 // capacity of the buffer
+	head         uint64 // position of the next element (no tail since we don't remove elements)
+	full         bool   // indicates whether the buffer if full - once it is, it stays full unless the buffer is resized
+	id           uint64 // unique id of an event record
+	lowestId     uint64 // lowest id of an event record available in the buffer at any given time
+	resizeOffset uint64 // used to aid the calculation of id->pos after resize (see id2pos)
 
 	sync.RWMutex
 }
@@ -58,10 +59,6 @@ type eventRingBuffer struct {
 func (e *eventRingBuffer) Add(event *si.EventRecord) {
 	e.Lock()
 	defer e.Unlock()
-
-	if e.head == 0 {
-		e.idAtZero = e.lowestId
-	}
 
 	e.events[e.head] = event
 	if !e.full {
@@ -73,7 +70,7 @@ func (e *eventRingBuffer) Add(event *si.EventRecord) {
 	e.id++
 }
 
-// GetEventsFromID returns "count" number of event records from id if possible. The id can be determined from
+// GetEventsFromID returns "count" number of event records from "id" if possible. The id can be determined from
 // the first call of the method - if it returns nothing because the id is not in the buffer, the lowest valid
 // identifier is returned which can be used to get the first batch.
 // If the caller does not want to pose limit on the number of events returned, "count" must be set to a high
@@ -164,13 +161,18 @@ func (e *eventRingBuffer) getEntriesFromRanges(r1, r2 *eventRange) []*si.EventRe
 }
 
 // id2pos translates the unique event ID to an index in the event slice.
+// If the event is present, the position will be returned and the found flag will be true.
+// If the event ID is not present, the position returned is 0 and the flag is false.
 func (e *eventRingBuffer) id2pos(id uint64) (uint64, bool) {
 	// id out of range?
 	if id < e.lowestId || id >= e.id {
 		return 0, false
 	}
 
-	return (id - e.idAtZero) % e.capacity, true
+	// resizeOffset tells how many elements were "shifted out" after resizing the buffer
+	// eg a buffer with 10 elements is full, then gets resized to 6
+	// the first element at index 0 is no longer 0 or the multiples of 10, but 4, 16, 22, etc.
+	return (id - e.resizeOffset) % e.capacity, true
 }
 
 // getLowestID returns the current lowest available id in the buffer.
@@ -193,7 +195,7 @@ func (e *eventRingBuffer) updateLowestId(beginSize, endSize uint64) {
 	}
 
 	// bufferSize is shrinking
-	// if number of events is < newSize no change
+	// if the number of events is < newSize, then no change
 	if (e.id - e.getLowestID()) <= endSize {
 		return
 	}
@@ -248,6 +250,6 @@ func (e *eventRingBuffer) Resize(newSize uint64) {
 	e.capacity = newSize
 	e.events = newEvents
 	e.head = numEventsToCopy % newSize
-	e.idAtZero = e.lowestId
+	e.resizeOffset = e.lowestId
 	e.full = numEventsToCopy == e.capacity
 }

--- a/pkg/events/event_ringbuffer_test.go
+++ b/pkg/events/event_ringbuffer_test.go
@@ -192,7 +192,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, uint64(6), ringBuffer.capacity)
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 6, len(ringBuffer.events))
-	assert.Equal(t, uint64(0), ringBuffer.idAtZero)
+	assert.Equal(t, uint64(0), ringBuffer.resizeOffset)
 
 	// Test case 2: Resize to a smaller size
 	lastEventIdBeforeResize = ringBuffer.GetLastEventID()
@@ -200,7 +200,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, uint64(2), ringBuffer.capacity)
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 2, len(ringBuffer.events))
-	assert.Equal(t, uint64(2), ringBuffer.idAtZero)
+	assert.Equal(t, uint64(2), ringBuffer.resizeOffset)
 
 	// Test case 3: Resize to a larger size
 	lastEventIdBeforeResize = ringBuffer.GetLastEventID()
@@ -208,7 +208,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, uint64(20), ringBuffer.capacity)
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 20, len(ringBuffer.events))
-	assert.Equal(t, uint64(2), ringBuffer.idAtZero)
+	assert.Equal(t, uint64(2), ringBuffer.resizeOffset)
 
 	// Test case 4: Resize when head is at the last element
 	ringBuffer = newEventRingBuffer(5)
@@ -218,7 +218,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, uint64(2), ringBuffer.capacity)
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 2, len(ringBuffer.events))
-	assert.Equal(t, uint64(2), ringBuffer.idAtZero)
+	assert.Equal(t, uint64(2), ringBuffer.resizeOffset)
 
 	// Test case 5: Resize to events length when head is at the last element
 	ringBuffer = newEventRingBuffer(5)
@@ -229,7 +229,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, uint64(4), ringBuffer.capacity)
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 4, len(ringBuffer.events))
-	assert.Equal(t, uint64(0), ringBuffer.idAtZero)
+	assert.Equal(t, uint64(0), ringBuffer.resizeOffset)
 	assert.Assert(t, ringBuffer.full)
 
 	// Test case 6: Resize when the buffer is full
@@ -242,7 +242,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, 6, len(ringBuffer.events))
 	assert.Equal(t, uint64(0), ringBuffer.head)
 	assert.Equal(t, true, ringBuffer.full)
-	assert.Equal(t, uint64(4), ringBuffer.idAtZero)
+	assert.Equal(t, uint64(4), ringBuffer.resizeOffset)
 
 	// Test case 7: Resize when the buffer is overflown (head is wrapped and position > 0)
 	ringBuffer = newEventRingBuffer(10)
@@ -254,7 +254,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 8, len(ringBuffer.events))
 	assert.Equal(t, uint64(0), ringBuffer.head)
-	assert.Equal(t, uint64(7), ringBuffer.idAtZero)
+	assert.Equal(t, uint64(7), ringBuffer.resizeOffset)
 	assert.Assert(t, ringBuffer.full)
 
 	// Test case 8: Test event full : Resize to lower size, followed by resize to a large size
@@ -265,7 +265,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, true, ringBuffer.full)
 	ringBuffer.Resize(6)
 	assert.Equal(t, false, ringBuffer.full)
-	assert.Equal(t, uint64(7), ringBuffer.idAtZero)
+	assert.Equal(t, uint64(7), ringBuffer.resizeOffset)
 
 	// Test case 9: Test resize to same size
 	lastEventIdBeforeResize = ringBuffer.GetLastEventID()
@@ -274,7 +274,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 6, len(ringBuffer.events))
 	assert.Equal(t, false, ringBuffer.full)
-	assert.Equal(t, uint64(7), ringBuffer.idAtZero)
+	assert.Equal(t, uint64(7), ringBuffer.resizeOffset)
 }
 
 func populate(buffer *eventRingBuffer, count int) {

--- a/pkg/events/event_ringbuffer_test.go
+++ b/pkg/events/event_ringbuffer_test.go
@@ -192,6 +192,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, uint64(6), ringBuffer.capacity)
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 6, len(ringBuffer.events))
+	assert.Equal(t, uint64(0), ringBuffer.idAtZero)
 
 	// Test case 2: Resize to a smaller size
 	lastEventIdBeforeResize = ringBuffer.GetLastEventID()
@@ -199,6 +200,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, uint64(2), ringBuffer.capacity)
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 2, len(ringBuffer.events))
+	assert.Equal(t, uint64(2), ringBuffer.idAtZero)
 
 	// Test case 3: Resize to a larger size
 	lastEventIdBeforeResize = ringBuffer.GetLastEventID()
@@ -206,6 +208,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, uint64(20), ringBuffer.capacity)
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 20, len(ringBuffer.events))
+	assert.Equal(t, uint64(2), ringBuffer.idAtZero)
 
 	// Test case 4: Resize when head is at the last element
 	ringBuffer = newEventRingBuffer(5)
@@ -215,6 +218,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, uint64(2), ringBuffer.capacity)
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 2, len(ringBuffer.events))
+	assert.Equal(t, uint64(2), ringBuffer.idAtZero)
 
 	// Test case 5: Resize to events length when head is at the last element
 	ringBuffer = newEventRingBuffer(5)
@@ -225,7 +229,8 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, uint64(4), ringBuffer.capacity)
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 4, len(ringBuffer.events))
-	assert.Equal(t, true, ringBuffer.full)
+	assert.Equal(t, uint64(0), ringBuffer.idAtZero)
+	assert.Assert(t, ringBuffer.full)
 
 	// Test case 6: Resize when the buffer is full
 	ringBuffer = newEventRingBuffer(10)
@@ -237,6 +242,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, 6, len(ringBuffer.events))
 	assert.Equal(t, uint64(0), ringBuffer.head)
 	assert.Equal(t, true, ringBuffer.full)
+	assert.Equal(t, uint64(4), ringBuffer.idAtZero)
 
 	// Test case 7: Resize when the buffer is overflown (head is wrapped and position > 0)
 	ringBuffer = newEventRingBuffer(10)
@@ -248,7 +254,8 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 8, len(ringBuffer.events))
 	assert.Equal(t, uint64(0), ringBuffer.head)
-	assert.Equal(t, true, ringBuffer.full)
+	assert.Equal(t, uint64(7), ringBuffer.idAtZero)
+	assert.Assert(t, ringBuffer.full)
 
 	// Test case 8: Test event full : Resize to lower size, followed by resize to a large size
 	ringBuffer = newEventRingBuffer(10)
@@ -258,6 +265,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, true, ringBuffer.full)
 	ringBuffer.Resize(6)
 	assert.Equal(t, false, ringBuffer.full)
+	assert.Equal(t, uint64(7), ringBuffer.idAtZero)
 
 	// Test case 9: Test resize to same size
 	lastEventIdBeforeResize = ringBuffer.GetLastEventID()
@@ -266,7 +274,7 @@ func TestResize(t *testing.T) {
 	assert.Equal(t, lastEventIdBeforeResize, ringBuffer.getLastEventID())
 	assert.Equal(t, 6, len(ringBuffer.events))
 	assert.Equal(t, false, ringBuffer.full)
-
+	assert.Equal(t, uint64(7), ringBuffer.idAtZero)
 }
 
 func populate(buffer *eventRingBuffer, count int) {

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -185,7 +185,7 @@ var webRoutes = routes{
 	route{
 		"Scheduler",
 		"GET",
-		"/ws/v1/events/batch/",
+		"/ws/v1/events/batch",
 		getEvents,
 	},
 	// endpoint to retrieve CPU, Memory profiling data,


### PR DESCRIPTION
### What is this PR for?
`ringBuffer.id2pos()` does not work properly after resizing the buffer. We need to track the ID of position 0 because the id-to-position calculation becomes invalid. By doing so, `id2pos()` also becomes simpler.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1942

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
