### PR TITLE
[YUNIKORN-1951] Ensure that queues with no guaranteed resources do not trigger preemption

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -907,6 +907,11 @@ func (r *Resource) HasNegativeValue() bool {
 	return false
 }
 
+// IsEmpty returns true if the resource is nil or has no component resources specified.
+func (r *Resource) IsEmpty() bool {
+	return r == nil || len(r.Resources) == 0
+}
+
 // Returns a new resource with the largest value for each quantity in the resources
 // If either resource passed in is nil a zero resource is returned
 func ComponentWiseMax(left, right *Resource) *Resource {

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -1683,3 +1683,21 @@ func TestHasNegativeValue(t *testing.T) {
 		})
 	}
 }
+
+func TestIsEmpty(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          *Resource
+		expectedResult bool
+	}{
+		{"Nil resource", nil, true},
+		{"Empty resource", NewResource(), true},
+		{"Positive value", NewResourceFromMap(map[string]Quantity{common.Memory: 100}), false},
+		{"Negative value", NewResourceFromMap(map[string]Quantity{common.Memory: -100}), false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedResult, tc.input.IsEmpty())
+		})
+	}
+}

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -1722,6 +1722,7 @@ func (sq *Queue) createPreemptionSnapshot(cache map[string]*QueuePreemptionSnaps
 	snapshot = &QueuePreemptionSnapshot{
 		Parent:             parentSnapshot,
 		QueuePath:          sq.QueuePath,
+		Leaf:               sq.isLeaf,
 		AllocatedResource:  sq.allocatedResource.Clone(),
 		PreemptingResource: sq.preemptingResource.Clone(),
 		MaxResource:        sq.maxResource.Clone(),


### PR DESCRIPTION
### What is this PR for?
When a queue has no guaranteed resources, yunikorn always sees that queue as being within guaranteed limits. For unspecified resources, this is correct, but in the case where no guarantees are given at all, this should not be the case.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1951

### How should this be tested?
New unit tests added to cover this case.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
