### PR TITLE
[YUNIKORN-970] Add queue metrics with queue names as labels

### DIFF
--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -28,11 +28,13 @@ import (
 
 // QueueMetrics to declare queue metrics
 type QueueMetrics struct {
-	appMetricsLabel          *prometheus.GaugeVec
-	appMetricsSubsystem      *prometheus.GaugeVec
-	containerMetrics *prometheus.CounterVec
-	ResourceMetricsLabel     *prometheus.GaugeVec
-	ResourceMetricsSubsystem *prometheus.GaugeVec
+	appMetricsLabel *prometheus.GaugeVec
+	// Deprecated - To be removed in 1.7.0. Replaced with queue label Metrics
+	appMetricsSubsystem  *prometheus.GaugeVec
+	containerMetrics     *prometheus.CounterVec
+	resourceMetricsLabel *prometheus.GaugeVec
+	// Deprecated - To be removed in 1.7.0. Replaced with queue label Metrics
+	resourceMetricsSubsystem *prometheus.GaugeVec
 }
 
 // InitQueueMetrics to initialize queue metrics
@@ -65,7 +67,7 @@ func InitQueueMetrics(name string) CoreQueueMetrics {
 			Help:      "Queue container metrics. State of the attempt includes `allocated`, `released`.",
 		}, []string{"state"})
 
-	q.ResourceMetricsLabel = prometheus.NewGaugeVec(
+	q.resourceMetricsLabel = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace:   Namespace,
 			Name:        "queue_resource",
@@ -73,7 +75,7 @@ func InitQueueMetrics(name string) CoreQueueMetrics {
 			Help:        "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`.",
 		}, []string{"state", "resource"})
 
-	q.ResourceMetricsSubsystem = prometheus.NewGaugeVec(
+	q.resourceMetricsSubsystem = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Subsystem: replaceStr,
@@ -85,8 +87,8 @@ func InitQueueMetrics(name string) CoreQueueMetrics {
 		q.appMetricsLabel,
 		q.appMetricsSubsystem,
 		q.containerMetrics,
-		q.ResourceMetricsLabel,
-		q.ResourceMetricsSubsystem,
+		q.resourceMetricsLabel,
+		q.resourceMetricsSubsystem,
 	}
 
 	// Register the metrics
@@ -105,24 +107,31 @@ func InitQueueMetrics(name string) CoreQueueMetrics {
 func (m *QueueMetrics) Reset() {
 	m.appMetricsLabel.Reset()
 	m.appMetricsSubsystem.Reset()
-	m.ResourceMetricsLabel.Reset()
-	m.ResourceMetricsSubsystem.Reset()
+	m.resourceMetricsLabel.Reset()
+	m.resourceMetricsSubsystem.Reset()
+}
+
+func (m *QueueMetrics) IncQueueApplications(state string) {
+	m.appMetricsLabel.With(prometheus.Labels{"state": state}).Inc()
+	m.appMetricsSubsystem.With(prometheus.Labels{"state": state}).Inc()
+}
+
+func (m *QueueMetrics) DecQueueApplications(state string) {
+	m.appMetricsLabel.With(prometheus.Labels{"state": state}).Dec()
+	m.appMetricsSubsystem.With(prometheus.Labels{"state": state}).Dec()
 }
 
 func (m *QueueMetrics) IncQueueApplicationsRunning() {
-	m.appMetricsLabel.With(prometheus.Labels{"state": "running"}).Inc()
-	m.appMetricsSubsystem.With(prometheus.Labels{"state": "running"}).Inc()
+	m.IncQueueApplications("running")
 }
 
 func (m *QueueMetrics) DecQueueApplicationsRunning() {
-	m.appMetricsLabel.With(prometheus.Labels{"state": "running"}).Dec()
-	m.appMetricsSubsystem.With(prometheus.Labels{"state": "running"}).Dec()
-
+	m.DecQueueApplications("running")
 }
 
 func (m *QueueMetrics) GetQueueApplicationsRunning() (int, error) {
 	metricDto := &dto.Metric{}
-	err := m.appMetrics.With(prometheus.Labels{"state": "running"}).Write(metricDto)
+	err := m.appMetricsLabel.With(prometheus.Labels{"state": "running"}).Write(metricDto)
 	if err == nil {
 		return int(*metricDto.Gauge.Value), nil
 	}
@@ -130,13 +139,12 @@ func (m *QueueMetrics) GetQueueApplicationsRunning() (int, error) {
 }
 
 func (m *QueueMetrics) IncQueueApplicationsAccepted() {
-	m.appMetricsLabel.With(prometheus.Labels{"state": "accepted"}).Inc()
-	m.appMetricsSubsystem.With(prometheus.Labels{"state": "accepted"}).Inc()
+	m.IncQueueApplications("accepted")
 }
 
 func (m *QueueMetrics) GetQueueApplicationsAccepted() (int, error) {
 	metricDto := &dto.Metric{}
-	err := m.appMetrics.With(prometheus.Labels{"state": "accepted"}).Write(metricDto)
+	err := m.appMetricsLabel.With(prometheus.Labels{"state": "accepted"}).Write(metricDto)
 	if err == nil {
 		return int(*metricDto.Gauge.Value), nil
 	}
@@ -144,13 +152,12 @@ func (m *QueueMetrics) GetQueueApplicationsAccepted() (int, error) {
 }
 
 func (m *QueueMetrics) IncQueueApplicationsRejected() {
-	m.appMetricsLabel.With(prometheus.Labels{"state": "rejected"}).Inc()
-	m.appMetricsSubsystem.With(prometheus.Labels{"state": "rejected"}).Inc()
+	m.IncQueueApplications("rejected")
 }
 
 func (m *QueueMetrics) GetQueueApplicationsRejected() (int, error) {
 	metricDto := &dto.Metric{}
-	err := m.appMetrics.With(prometheus.Labels{"state": "rejected"}).Write(metricDto)
+	err := m.appMetricsLabel.With(prometheus.Labels{"state": "rejected"}).Write(metricDto)
 	if err == nil {
 		return int(*metricDto.Gauge.Value), nil
 	}
@@ -158,13 +165,12 @@ func (m *QueueMetrics) GetQueueApplicationsRejected() (int, error) {
 }
 
 func (m *QueueMetrics) IncQueueApplicationsFailed() {
-	m.appMetricsLabel.With(prometheus.Labels{"state": "failed"}).Inc()
-	m.appMetricsSubsystem.With(prometheus.Labels{"state": "failed"}).Inc()
+	m.IncQueueApplications("failed")
 }
 
 func (m *QueueMetrics) GetQueueApplicationsFailed() (int, error) {
 	metricDto := &dto.Metric{}
-	err := m.appMetrics.With(prometheus.Labels{"state": "failed"}).Write(metricDto)
+	err := m.appMetricsLabel.With(prometheus.Labels{"state": "failed"}).Write(metricDto)
 	if err == nil {
 		return int(*metricDto.Gauge.Value), nil
 	}
@@ -172,13 +178,12 @@ func (m *QueueMetrics) GetQueueApplicationsFailed() (int, error) {
 }
 
 func (m *QueueMetrics) IncQueueApplicationsCompleted() {
-	m.appMetricsLabel.With(prometheus.Labels{"state": "completed"}).Inc()
-	m.appMetricsSubsystem.With(prometheus.Labels{"state": "completed"}).Inc()
+	m.IncQueueApplications("completed")
 }
 
 func (m *QueueMetrics) GetQueueApplicationsCompleted() (int, error) {
 	metricDto := &dto.Metric{}
-	err := m.appMetrics.With(prometheus.Labels{"state": "completed"}).Write(metricDto)
+	err := m.appMetricsLabel.With(prometheus.Labels{"state": "completed"}).Write(metricDto)
 	if err == nil {
 		return int(*metricDto.Gauge.Value), nil
 	}
@@ -197,42 +202,44 @@ func (m *QueueMetrics) AddReleasedContainers(value int) {
 	m.containerMetrics.With(prometheus.Labels{"state": "released"}).Add(float64(value))
 }
 
+func (m *QueueMetrics) AddQueueResource(state string, resourceName string, value float64) {
+	m.resourceMetricsLabel.With(prometheus.Labels{"state": state, "resource": resourceName}).Add(value)
+	m.resourceMetricsSubsystem.With(prometheus.Labels{"state": state, "resource": resourceName}).Add(value)
+}
+
+func (m *QueueMetrics) SetQueueResource(state string, resourceName string, value float64) {
+	m.resourceMetricsLabel.With(prometheus.Labels{"state": state, "resource": resourceName}).Set(value)
+	m.resourceMetricsSubsystem.With(prometheus.Labels{"state": state, "resource": resourceName}).Set(value)
+}
+
 func (m *QueueMetrics) SetQueueGuaranteedResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "guaranteed", "resource": resourceName}).Set(value)
-	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "guaranteed", "resource": resourceName}).Set(value)
+	m.SetQueueResource("guaranteed", resourceName, value)
 }
 
 func (m *QueueMetrics) SetQueueMaxResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "max", "resource": resourceName}).Set(value)
-	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "max", "resource": resourceName}).Set(value)
+	m.SetQueueResource("max", resourceName, value)
 }
 
 func (m *QueueMetrics) SetQueueAllocatedResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "allocated", "resource": resourceName}).Set(value)
-	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "allocated", "resource": resourceName}).Set(value)
+	m.SetQueueResource("allocated", resourceName, value)
 }
 
 func (m *QueueMetrics) AddQueueAllocatedResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "allocated", "resource": resourceName}).Add(value)
-	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "allocated", "resource": resourceName}).Add(value)
+	m.AddQueueResource("allocated", resourceName, value)
 }
 
 func (m *QueueMetrics) SetQueuePendingResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "pending", "resource": resourceName}).Set(value)
-	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "pending", "resource": resourceName}).Set(value)
+	m.SetQueueResource("pending", resourceName, value)
 }
 
 func (m *QueueMetrics) AddQueuePendingResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "pending", "resource": resourceName}).Add(value)
-	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "pending", "resource": resourceName}).Add(value)
+	m.AddQueueResource("pending", resourceName, value)
 }
 
 func (m *QueueMetrics) SetQueuePreemptingResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "preempting", "resource": resourceName}).Set(value)
-	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "preempting", "resource": resourceName}).Set(value)
+	m.SetQueueResource("preempting", resourceName, value)
 }
 
 func (m *QueueMetrics) AddQueuePreemptingResourceMetrics(resourceName string, value float64) {
-	m.ResourceMetricsLabel.With(prometheus.Labels{"state": "preempting", "resource": resourceName}).Add(value)
-	m.ResourceMetricsSubsystem.With(prometheus.Labels{"state": "preempting", "resource": resourceName}).Add(value)
+	m.AddQueueResource("preempting", resourceName, value)
 }

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -104,6 +104,26 @@ func InitQueueMetrics(name string) CoreQueueMetrics {
 	return q
 }
 
+func (m *QueueMetrics) incQueueApplications(state string) {
+	m.appMetricsLabel.With(prometheus.Labels{"state": state}).Inc()
+	m.appMetricsSubsystem.With(prometheus.Labels{"state": state}).Inc()
+}
+
+func (m *QueueMetrics) decQueueApplications(state string) {
+	m.appMetricsLabel.With(prometheus.Labels{"state": state}).Dec()
+	m.appMetricsSubsystem.With(prometheus.Labels{"state": state}).Dec()
+}
+
+func (m *QueueMetrics) addQueueResource(state string, resourceName string, value float64) {
+	m.resourceMetricsLabel.With(prometheus.Labels{"state": state, "resource": resourceName}).Add(value)
+	m.resourceMetricsSubsystem.With(prometheus.Labels{"state": state, "resource": resourceName}).Add(value)
+}
+
+func (m *QueueMetrics) setQueueResource(state string, resourceName string, value float64) {
+	m.resourceMetricsLabel.With(prometheus.Labels{"state": state, "resource": resourceName}).Set(value)
+	m.resourceMetricsSubsystem.With(prometheus.Labels{"state": state, "resource": resourceName}).Set(value)
+}
+
 func (m *QueueMetrics) Reset() {
 	m.appMetricsLabel.Reset()
 	m.appMetricsSubsystem.Reset()
@@ -111,22 +131,12 @@ func (m *QueueMetrics) Reset() {
 	m.resourceMetricsSubsystem.Reset()
 }
 
-func (m *QueueMetrics) IncQueueApplications(state string) {
-	m.appMetricsLabel.With(prometheus.Labels{"state": state}).Inc()
-	m.appMetricsSubsystem.With(prometheus.Labels{"state": state}).Inc()
-}
-
-func (m *QueueMetrics) DecQueueApplications(state string) {
-	m.appMetricsLabel.With(prometheus.Labels{"state": state}).Dec()
-	m.appMetricsSubsystem.With(prometheus.Labels{"state": state}).Dec()
-}
-
 func (m *QueueMetrics) IncQueueApplicationsRunning() {
-	m.IncQueueApplications("running")
+	m.incQueueApplications("running")
 }
 
 func (m *QueueMetrics) DecQueueApplicationsRunning() {
-	m.DecQueueApplications("running")
+	m.decQueueApplications("running")
 }
 
 func (m *QueueMetrics) GetQueueApplicationsRunning() (int, error) {
@@ -139,7 +149,7 @@ func (m *QueueMetrics) GetQueueApplicationsRunning() (int, error) {
 }
 
 func (m *QueueMetrics) IncQueueApplicationsAccepted() {
-	m.IncQueueApplications("accepted")
+	m.incQueueApplications("accepted")
 }
 
 func (m *QueueMetrics) GetQueueApplicationsAccepted() (int, error) {
@@ -152,7 +162,7 @@ func (m *QueueMetrics) GetQueueApplicationsAccepted() (int, error) {
 }
 
 func (m *QueueMetrics) IncQueueApplicationsRejected() {
-	m.IncQueueApplications("rejected")
+	m.incQueueApplications("rejected")
 }
 
 func (m *QueueMetrics) GetQueueApplicationsRejected() (int, error) {
@@ -165,7 +175,7 @@ func (m *QueueMetrics) GetQueueApplicationsRejected() (int, error) {
 }
 
 func (m *QueueMetrics) IncQueueApplicationsFailed() {
-	m.IncQueueApplications("failed")
+	m.incQueueApplications("failed")
 }
 
 func (m *QueueMetrics) GetQueueApplicationsFailed() (int, error) {
@@ -178,7 +188,7 @@ func (m *QueueMetrics) GetQueueApplicationsFailed() (int, error) {
 }
 
 func (m *QueueMetrics) IncQueueApplicationsCompleted() {
-	m.IncQueueApplications("completed")
+	m.incQueueApplications("completed")
 }
 
 func (m *QueueMetrics) GetQueueApplicationsCompleted() (int, error) {
@@ -202,44 +212,34 @@ func (m *QueueMetrics) AddReleasedContainers(value int) {
 	m.containerMetrics.With(prometheus.Labels{"state": "released"}).Add(float64(value))
 }
 
-func (m *QueueMetrics) AddQueueResource(state string, resourceName string, value float64) {
-	m.resourceMetricsLabel.With(prometheus.Labels{"state": state, "resource": resourceName}).Add(value)
-	m.resourceMetricsSubsystem.With(prometheus.Labels{"state": state, "resource": resourceName}).Add(value)
-}
-
-func (m *QueueMetrics) SetQueueResource(state string, resourceName string, value float64) {
-	m.resourceMetricsLabel.With(prometheus.Labels{"state": state, "resource": resourceName}).Set(value)
-	m.resourceMetricsSubsystem.With(prometheus.Labels{"state": state, "resource": resourceName}).Set(value)
-}
-
 func (m *QueueMetrics) SetQueueGuaranteedResourceMetrics(resourceName string, value float64) {
-	m.SetQueueResource("guaranteed", resourceName, value)
+	m.setQueueResource("guaranteed", resourceName, value)
 }
 
 func (m *QueueMetrics) SetQueueMaxResourceMetrics(resourceName string, value float64) {
-	m.SetQueueResource("max", resourceName, value)
+	m.setQueueResource("max", resourceName, value)
 }
 
 func (m *QueueMetrics) SetQueueAllocatedResourceMetrics(resourceName string, value float64) {
-	m.SetQueueResource("allocated", resourceName, value)
+	m.setQueueResource("allocated", resourceName, value)
 }
 
 func (m *QueueMetrics) AddQueueAllocatedResourceMetrics(resourceName string, value float64) {
-	m.AddQueueResource("allocated", resourceName, value)
+	m.addQueueResource("allocated", resourceName, value)
 }
 
 func (m *QueueMetrics) SetQueuePendingResourceMetrics(resourceName string, value float64) {
-	m.SetQueueResource("pending", resourceName, value)
+	m.setQueueResource("pending", resourceName, value)
 }
 
 func (m *QueueMetrics) AddQueuePendingResourceMetrics(resourceName string, value float64) {
-	m.AddQueueResource("pending", resourceName, value)
+	m.addQueueResource("pending", resourceName, value)
 }
 
 func (m *QueueMetrics) SetQueuePreemptingResourceMetrics(resourceName string, value float64) {
-	m.SetQueueResource("preempting", resourceName, value)
+	m.setQueueResource("preempting", resourceName, value)
 }
 
 func (m *QueueMetrics) AddQueuePreemptingResourceMetrics(resourceName string, value float64) {
-	m.AddQueueResource("preempting", resourceName, value)
+	m.addQueueResource("preempting", resourceName, value)
 }

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -43,10 +43,10 @@ func InitQueueMetrics(name string) CoreQueueMetrics {
 
 	q.appMetricsLabel = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Name:      "queue_app",
+			Namespace:   Namespace,
+			Name:        "queue_app",
 			ConstLabels: prometheus.Labels{"queue": name},
-			Help:      "Queue application metrics. State of the application includes `running`.",
+			Help:        "Queue application metrics. State of the application includes `running`.",
 		}, []string{"state"})
 
 	q.appMetricsSubsystem = prometheus.NewGaugeVec(
@@ -67,10 +67,10 @@ func InitQueueMetrics(name string) CoreQueueMetrics {
 
 	q.ResourceMetricsLabel = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Name:      "queue_resource",
+			Namespace:   Namespace,
+			Name:        "queue_resource",
 			ConstLabels: prometheus.Labels{"queue": name},
-			Help:      "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`.",
+			Help:        "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`.",
 		}, []string{"state", "resource"})
 
 	q.ResourceMetricsSubsystem = prometheus.NewGaugeVec(

--- a/pkg/metrics/queue_test.go
+++ b/pkg/metrics/queue_test.go
@@ -269,7 +269,6 @@ func unregisterQueueMetrics(t *testing.T) {
 	prometheus.Unregister(qm.appMetricsLabel)
 	prometheus.Unregister(qm.appMetricsSubsystem)
 	prometheus.Unregister(qm.containerMetrics)
-	prometheus.Unregister(qm.ResourceMetricsLabel)
-	prometheus.Unregister(qm.ResourceMetricsSubsystem)
-
+	prometheus.Unregister(qm.resourceMetricsLabel)
+	prometheus.Unregister(qm.resourceMetricsSubsystem)
 }


### PR DESCRIPTION
### What is this PR for?
Add duplicate Prometheus queue metrics with queue name in label instead of in the subsystem (which results in a metric emitted per queue). This allows us to ingest metrics with a uniform name per metric and use label to differentiate between queues. Eventually we will remove the subsystem metrics and only have metrics with queue labels

1. `1.5.0` introduce metrics with `<queue name>` label
2. `1.6.0` deprecate metrics with `<queue name>` subsystem
3. `1.7.0` remove metrics with `<queue name>` subsystem

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-970

### How should this be tested?
Unit Test:
```
will@mac ~/code/yunikorn-core (YUNIKORN-970) $ make test
running unit tests
"go" clean -testcache
"go" test ./... -race -tags deadlock -coverprofile=build/coverage.txt -covermode=atomic
?       github.com/apache/yunikorn-core/cmd/queueconfigchecker  [no test files]
?       github.com/apache/yunikorn-core/cmd/schedulerclient     [no test files]
?       github.com/apache/yunikorn-core/cmd/simplescheduler     [no test files]
?       github.com/apache/yunikorn-core/pkg/entrypoint  [no test files]
?       github.com/apache/yunikorn-core/pkg/examples    [no test files]
?       github.com/apache/yunikorn-core/pkg/handler     [no test files]
ok      github.com/apache/yunikorn-core/pkg/common      1.322s  coverage: 67.5% of statements
?       github.com/apache/yunikorn-core/pkg/rmproxy     [no test files]
?       github.com/apache/yunikorn-core/pkg/rmproxy/rmevent     [no test files]
ok      github.com/apache/yunikorn-core/pkg/common/configs      1.458s  coverage: 94.5% of statements
ok      github.com/apache/yunikorn-core/pkg/common/resources    1.527s  coverage: 93.2% of statements
ok      github.com/apache/yunikorn-core/pkg/common/security     1.644s  coverage: 86.5% of statements
ok      github.com/apache/yunikorn-core/pkg/events      1.712s  coverage: 99.5% of statements
?       github.com/apache/yunikorn-core/pkg/scheduler/placement/types   [no test files]
?       github.com/apache/yunikorn-core/pkg/webservice/dao      [no test files]
ok      github.com/apache/yunikorn-core/pkg/log 8.984s  coverage: 86.7% of statements
ok      github.com/apache/yunikorn-core/pkg/metrics     4.760s  coverage: 57.4% of statements
ok      github.com/apache/yunikorn-core/pkg/metrics/history     1.775s  coverage: 100.0% of statements
ok      github.com/apache/yunikorn-core/pkg/plugins     1.762s  coverage: 60.0% of statements
ok      github.com/apache/yunikorn-core/pkg/scheduler   4.568s  coverage: 65.8% of statements
ok      github.com/apache/yunikorn-core/pkg/scheduler/objects   15.058s coverage: 83.6% of statements
ok      github.com/apache/yunikorn-core/pkg/scheduler/objects/template  1.341s  coverage: 80.6% of statements
ok      github.com/apache/yunikorn-core/pkg/scheduler/placement 1.257s  coverage: 90.6% of statements
ok      github.com/apache/yunikorn-core/pkg/scheduler/policies  1.298s  coverage: 100.0% of statements
ok      github.com/apache/yunikorn-core/pkg/scheduler/tests     41.290s coverage: 71.4% of statements
ok      github.com/apache/yunikorn-core/pkg/scheduler/ugm       1.321s  coverage: 93.1% of statements
ok      github.com/apache/yunikorn-core/pkg/trace       1.402s  coverage: 94.4% of statements
ok      github.com/apache/yunikorn-core/pkg/webservice  1.291s  coverage: 81.0% of statements
```

Queue metrics with with queue in label example:
```
will@mac ~/code/yunikorn-core (YUNIKORN-970) $ curl localhost:9080/ws/v1/metrics 2>/dev/null | grep queue-small
yunikorn_queue_app{queue="root.queue-small",state="accepted"} 1
yunikorn_queue_app{queue="root.queue-small",state="completed"} 1
yunikorn_queue_app{queue="root.queue-small",state="released"} 6
yunikorn_queue_app{queue="root.queue-small",state="running"} 0
yunikorn_queue_resource{queue="root.queue-small",resource="memory",state="allocated"} 0
yunikorn_queue_resource{queue="root.queue-small",resource="memory",state="pending"} 0
yunikorn_queue_resource{queue="root.queue-small",resource="pods",state="allocated"} 0
yunikorn_queue_resource{queue="root.queue-small",resource="pods",state="pending"} 0
yunikorn_queue_resource{queue="root.queue-small",resource="vcore",state="allocated"} 0
yunikorn_queue_resource{queue="root.queue-small",resource="vcore",state="pending"} 0
```

Queue metrics with queue in subsystem example:
```
will@mac ~/code/yunikorn-core (YUNIKORN-970) $ curl localhost:9080/ws/v1/metrics 2>/dev/null | grep queue_small
# HELP yunikorn_root_queue_small_queue_app Queue application metrics. State of the application includes `running`.
# TYPE yunikorn_root_queue_small_queue_app gauge
yunikorn_root_queue_small_queue_app{state="accepted"} 1
yunikorn_root_queue_small_queue_app{state="completed"} 1
yunikorn_root_queue_small_queue_app{state="released"} 6
yunikorn_root_queue_small_queue_app{state="running"} 0
# HELP yunikorn_root_queue_small_queue_resource Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`.
# TYPE yunikorn_root_queue_small_queue_resource gauge
yunikorn_root_queue_small_queue_resource{resource="memory",state="allocated"} 0
yunikorn_root_queue_small_queue_resource{resource="memory",state="pending"} 0
yunikorn_root_queue_small_queue_resource{resource="pods",state="allocated"} 0
yunikorn_root_queue_small_queue_resource{resource="pods",state="pending"} 0
yunikorn_root_queue_small_queue_resource{resource="vcore",state="allocated"} 0
yunikorn_root_queue_small_queue_resource{resource="vcore",state="pending"} 0
```


### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
