### PR TITLE
[YUNIKORN-1967] Update the help message in the application_total metric

### DIFF
--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -86,7 +86,7 @@ func InitSchedulerMetrics() *SchedulerMetrics {
 			Namespace: Namespace,
 			Subsystem: SchedulerSubsystem,
 			Name:      "application_total",
-			Help:      "Total number of applications. State of the application includes `running` and `completed`.",
+			Help:      "Total number of applications. State of the application includes `running`, `completed` and `failed`.",
 		}, []string{"state"})
 
 	s.node = prometheus.NewGaugeVec(


### PR DESCRIPTION
### What is this PR for?
The help message of the application_total metric  lack of `failed` state.
https://github.com/apache/yunikorn-core/blob/master/pkg/metrics/scheduler.go#L89
application_total metric record applications under failed state
https://github.com/apache/yunikorn-core/blob/master/pkg/scheduler/objects/application_state.go#L233

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1967

### How should this be tested?
this pr improve help message in prometheus GaugeOpts, no need to add test

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
