### PR TITLE
[YUNIKORN-1965] Display a unique id on the REST interface when returning events

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -982,7 +982,5 @@ func (cc *ClusterContext) SetLastHealthCheckResult(c *dao.SchedulerHealthDAOInfo
 }
 
 func (cc *ClusterContext) GetUUID() string {
-	cc.RLock()
-	defer cc.RUnlock()
 	return cc.uuid
 }

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -46,6 +46,7 @@ type ClusterContext struct {
 	partitions     map[string]*PartitionContext
 	policyGroup    string
 	rmEventHandler handler.EventHandler
+	uuid           string
 
 	// config values that change scheduling behaviour
 	needPreemption      bool
@@ -77,6 +78,7 @@ func NewClusterContext(rmID, policyGroup string, config []byte) (*ClusterContext
 		policyGroup:         policyGroup,
 		reservationDisabled: common.GetBoolEnvVar(disableReservation, false),
 		startTime:           time.Now(),
+		uuid:                common.GetNewUUID(),
 	}
 	// If reservation is turned off set the reservation delay to the maximum duration defined.
 	// The time package does not export maxDuration so use the equivalent from the math package.
@@ -97,6 +99,7 @@ func newClusterContext() *ClusterContext {
 		partitions:          make(map[string]*PartitionContext),
 		reservationDisabled: common.GetBoolEnvVar(disableReservation, false),
 		startTime:           time.Now(),
+		uuid:                common.GetNewUUID(),
 	}
 	// If reservation is turned off set the reservation delay to the maximum duration defined.
 	// The time package does not export maxDuration so use the equivalent from the math package.
@@ -976,4 +979,10 @@ func (cc *ClusterContext) SetLastHealthCheckResult(c *dao.SchedulerHealthDAOInfo
 	cc.Lock()
 	defer cc.Unlock()
 	cc.lastHealthCheckResult = c
+}
+
+func (cc *ClusterContext) GetUUID() string {
+	cc.RLock()
+	defer cc.RUnlock()
+	return cc.uuid
 }

--- a/pkg/webservice/dao/event_record.go
+++ b/pkg/webservice/dao/event_record.go
@@ -23,6 +23,7 @@ import (
 )
 
 type EventRecordDAO struct {
+	UUID         string
 	LowestID     uint64
 	HighestID    uint64
 	EventRecords []*si.EventRecord

--- a/pkg/webservice/dao/event_record.go
+++ b/pkg/webservice/dao/event_record.go
@@ -23,7 +23,7 @@ import (
 )
 
 type EventRecordDAO struct {
-	UUID         string
+	InstanceUUID string
 	LowestID     uint64
 	HighestID    uint64
 	EventRecords []*si.EventRecord

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -910,6 +910,7 @@ func getEvents(w http.ResponseWriter, r *http.Request) {
 
 	records, lowestID, highestID := eventSystem.GetEventsFromID(start, count)
 	eventDao := dao.EventRecordDAO{
+		UUID:         schedulerContext.GetUUID(),
 		LowestID:     lowestID,
 		HighestID:    highestID,
 		EventRecords: records,

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -910,7 +910,7 @@ func getEvents(w http.ResponseWriter, r *http.Request) {
 
 	records, lowestID, highestID := eventSystem.GetEventsFromID(start, count)
 	eventDao := dao.EventRecordDAO{
-		UUID:         schedulerContext.GetUUID(),
+		InstanceUUID: schedulerContext.GetUUID(),
 		LowestID:     lowestID,
 		HighestID:    highestID,
 		EventRecords: records,

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1333,6 +1333,7 @@ func TestUsersAndGroupsResourceUsage(t *testing.T) {
 }
 
 func TestGetEvents(t *testing.T) {
+	prepareSchedulerContext(t, false)
 	appEvent, nodeEvent, queueEvent := addEvents(t)
 
 	checkAllEvents(t, []*si.EventRecord{appEvent, nodeEvent, queueEvent})
@@ -1420,6 +1421,7 @@ func checkSingleEvent(t *testing.T, event *si.EventRecord, query string) {
 	req, err := http.NewRequest("GET", "/ws/v1/events/batch?"+query, strings.NewReader(""))
 	assert.NilError(t, err)
 	eventDao := getEventRecordDao(t, req)
+	assert.Assert(t, eventDao.UUID != "")
 	assert.Equal(t, 1, len(eventDao.EventRecords))
 	compareEvents(t, event, eventDao.EventRecords[0])
 }

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1421,7 +1421,7 @@ func checkSingleEvent(t *testing.T, event *si.EventRecord, query string) {
 	req, err := http.NewRequest("GET", "/ws/v1/events/batch?"+query, strings.NewReader(""))
 	assert.NilError(t, err)
 	eventDao := getEventRecordDao(t, req)
-	assert.Assert(t, eventDao.UUID != "")
+	assert.Assert(t, eventDao.InstanceUUID != "")
 	assert.Equal(t, 1, len(eventDao.EventRecords))
 	compareEvents(t, event, eventDao.EventRecords[0])
 }


### PR DESCRIPTION
### What is this PR for?
Add an UUID to the REST response inside `EventDAO` so that consumers can detect a Yunikorn restart and all event IDs are unique.
A new UUID is generated for a `ClusterContext`. This is newer re-created - a different UUID means a new Yunikorn instance.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1965

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
