### PR TITLE
[YUNIKORN-1848] Report resource used by preempted pods in the app summary

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -47,43 +47,43 @@ func (q Quantity) string() string {
 }
 
 // Util struct to keep track of application resource usage
-type UsedResource struct {
+type TrackedResource struct {
 	// Two level map for aggregated resource usage
 	// With instance type being the top level key, the mapped value is a map:
 	//   resource type (CPU, memory etc) -> the aggregated used time (in seconds) of the resource type
 	//
-	UsedResourceMap map[string]map[string]int64
+	TrackedResourceMap map[string]map[string]int64
 
 	sync.RWMutex
 }
 
-func (ur *UsedResource) Clone() *UsedResource {
+func (ur *TrackedResource) Clone() *TrackedResource {
 	if ur == nil {
 		return nil
 	}
-	ret := NewUsedResource()
+	ret := NewTrackedResource()
 	ur.RLock()
 	defer ur.RUnlock()
-	for k, v := range ur.UsedResourceMap {
+	for k, v := range ur.TrackedResourceMap {
 		dest := make(map[string]int64)
 		for key, element := range v {
 			dest[key] = element
 		}
-		ret.UsedResourceMap[k] = dest
+		ret.TrackedResourceMap[k] = dest
 	}
 	return ret
 }
 
 // Aggregate the resource usage to UsedResourceMap[instType]
 // The time the given resource used is the delta between the resource createTime and currentTime
-func (ur *UsedResource) AggregateUsedResource(instType string,
+func (ur *TrackedResource) AggregateTrackedResource(instType string,
 	resource *Resource, bindTime time.Time) {
 	ur.Lock()
 	defer ur.Unlock()
 
 	releaseTime := time.Now()
 	timeDiff := int64(releaseTime.Sub(bindTime).Seconds())
-	aggregatedResourceTime, ok := ur.UsedResourceMap[instType]
+	aggregatedResourceTime, ok := ur.TrackedResourceMap[instType]
 	if !ok {
 		aggregatedResourceTime = map[string]int64{}
 	}
@@ -95,7 +95,7 @@ func (ur *UsedResource) AggregateUsedResource(instType string,
 		curUsage += int64(element) * timeDiff // resource size times timeDiff
 		aggregatedResourceTime[key] = curUsage
 	}
-	ur.UsedResourceMap[instType] = aggregatedResourceTime
+	ur.TrackedResourceMap[instType] = aggregatedResourceTime
 }
 
 // Never update value of Zero
@@ -157,8 +157,8 @@ func NewResourceFromConf(configMap map[string]string) (*Resource, error) {
 	return res, nil
 }
 
-func NewUsedResource() *UsedResource {
-	return &UsedResource{UsedResourceMap: make(map[string]map[string]int64)}
+func NewTrackedResource() *TrackedResource {
+	return &TrackedResource{TrackedResourceMap: make(map[string]map[string]int64)}
 }
 
 func (r *Resource) String() string {

--- a/pkg/scheduler/objects/application_state.go
+++ b/pkg/scheduler/objects/application_state.go
@@ -199,7 +199,7 @@ func NewAppState() *fsm.FSM {
 				metrics.GetSchedulerMetrics().IncTotalApplicationsRejected()
 				app.setStateTimer(terminatedTimeout, app.stateMachine.Current(), ExpireApplication)
 				app.finishedTime = time.Now()
-				app.CleanupUsedResource()
+				app.CleanupTrackedResource()
 				// No rejected message when use app.HandleApplicationEvent(RejectApplication)
 				if len(event.Args) == 2 {
 					app.rejectedMessage = event.Args[1].(string) //nolint:errcheck

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -1062,7 +1062,7 @@ func TestCompleted(t *testing.T) {
 }
 
 func assertResourceUsage(t *testing.T, appSummary *ApplicationSummary, memorySeconds int64, vcoresSecconds int64) {
-	detailedResource := appSummary.ResourceUsage.UsedResourceMap[instType1]
+	detailedResource := appSummary.ResourceUsage.TrackedResourceMap[instType1]
 	assert.Equal(t, memorySeconds, detailedResource["memory"])
 	assert.Equal(t, vcoresSecconds, detailedResource["vcores"])
 }

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1452,7 +1452,7 @@ func (pc *PartitionContext) moveTerminatedApp(appID string) {
 		zap.String("appID", appID),
 		zap.String("app status", app.CurrentState()))
 	app.LogAppSummary(pc.RmID)
-	app.CleanupUsedResource()
+	app.CleanupTrackedResource()
 	pc.Lock()
 	defer pc.Unlock()
 	delete(pc.applications, appID)


### PR DESCRIPTION

### What is this PR for?
YUNIKORN-1385 reports resource usage of application upon its completion. Given that preemption feature is added, we can also report resource used by pods being preempted, so we can have idea how much resource was used by both run-to-completion pods and pods being preempted.

### What type of PR is it?
* [ ] - Bug Fix
* [x ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1848

### How should this be tested?
Added checking in unit test

### Screenshots (if appropriate)
In partition_test.go TestPreemption(t *testing.T) : 

	appSummary := app1.GetApplicationSummary("default")
	appSummary.DoLogging()
	assertPreemptedResource(t, appSummary, -1, 15000)

	appSummary = app2.GetApplicationSummary("default")
	appSummary.DoLogging()
	assertPreemptedResource(t, appSummary, -1, 0)
### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
