### PR TITLE
[YUNIKORN-1989] Update the help message in the queue_app metric

### DIFF
--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -42,7 +42,7 @@ func InitQueueMetrics(name string) CoreQueueMetrics {
 			Namespace: Namespace,
 			Subsystem: replaceStr,
 			Name:      "queue_app",
-			Help:      "Queue application metrics. State of the application includes `running`.",
+			Help:      "Queue application metrics. State of the application includes `running`, `accepted`, `rejected`, `failed`, `completed`, `allocated`, `released`.",
 		}, []string{"state"})
 
 	q.ResourceMetrics = prometheus.NewGaugeVec(


### PR DESCRIPTION
### What is this PR for?
The help message of the queue_app (i.e. appMetrics) metric lack of `accepted`, `rejected`, `failed`, `completed`, `allocated`, `released` state.

queue_app metric record applications in

[https://github.com/apache/yunikorn-core/blob/master/pkg/metrics/queue.go#L79-L109](https://github.com/apache/yunikorn-core/blob/9dd3df7dadb29a19de0d5f5971137df8fa674ea5/pkg/metrics/queue.go#L79-L109)

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1989

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
