### PR TITLE
[YUNIKORN-1980] Remove deprecated log REST calls

### DIFF
--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -622,20 +622,6 @@ func getApplication(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func setLogLevel(w http.ResponseWriter, r *http.Request) {
-	writeHeaders(w)
-	message := "Setting log levels via the REST API is deprecated. The /ws/v1/loglevel endpoint will be removed in a future release."
-	log.Log(log.Deprecation).Warn(message)
-	buildJSONErrorResponse(w, message, http.StatusGone)
-}
-
-func getLogLevel(w http.ResponseWriter, r *http.Request) {
-	writeHeaders(w)
-	message := "Getting log levels via the REST API is deprecated. The /ws/v1/loglevel endpoint will be removed in a future release."
-	log.Log(log.Deprecation).Warn(message)
-	buildJSONErrorResponse(w, message, http.StatusGone)
-}
-
 func getPartitionInfoDAO(lists map[string]*scheduler.PartitionContext) []*dao.PartitionInfo {
 	var result []*dao.PartitionInfo
 

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -624,15 +624,16 @@ func getApplication(w http.ResponseWriter, r *http.Request) {
 
 func setLogLevel(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
-	log.Log(log.Deprecation).Warn("Setting log levels via the REST API is deprecated. The /ws/v1/loglevel endpoint will be removed in a future release.")
+	message := "Setting log levels via the REST API is deprecated. The /ws/v1/loglevel endpoint will be removed in a future release."
+	log.Log(log.Deprecation).Warn(message)
+	buildJSONErrorResponse(w, message, http.StatusGone)
 }
 
 func getLogLevel(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
-	log.Log(log.Deprecation).Warn("Getting log levels via the REST API is deprecated. The /ws/v1/loglevel endpoint will be removed in a future release.")
-	if _, err := w.Write([]byte("info")); err != nil {
-		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
-	}
+	message := "Getting log levels via the REST API is deprecated. The /ws/v1/loglevel endpoint will be removed in a future release."
+	log.Log(log.Deprecation).Warn(message)
+	buildJSONErrorResponse(w, message, http.StatusGone)
 }
 
 func getPartitionInfoDAO(lists map[string]*scheduler.PartitionContext) []*dao.PartitionInfo {

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1200,44 +1200,6 @@ func TestFullStateDumpPath(t *testing.T) {
 	verifyStateDumpJSON(t, &aggregated)
 }
 
-func TestGetLoggerLevel(t *testing.T) {
-	req, err := http.NewRequest("GET", "/ws/v1/loglevel", strings.NewReader(""))
-	assert.NilError(t, err)
-
-	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(getLogLevel)
-	handler.ServeHTTP(rr, req)
-
-	assert.Equal(t, rr.Code, http.StatusGone)
-	var errObject dao.YAPIError
-	errResponse := json.Unmarshal(rr.Body.Bytes(), &errObject)
-	expected := "Getting log levels via the REST API is deprecated. The /ws/v1/loglevel endpoint will be removed in a future release."
-	assert.NilError(t, errResponse, "cannot unmarshal YAPIError")
-	assert.Equal(t, errObject.Message, expected,
-		fmt.Sprintf("handler returned unexpected body: got %v want %v", rr.Body.String(), expected))
-	assert.Equal(t, errObject.StatusCode, http.StatusGone)
-}
-
-func TestSetLoggerLevel(t *testing.T) {
-	req, err := http.NewRequest("PUT", "/ws/v1/loglevel", strings.NewReader(""))
-	assert.NilError(t, err)
-	req = req.WithContext(context.WithValue(req.Context(), httprouter.ParamsKey, httprouter.Params{
-		httprouter.Param{Key: "level", Value: "error"},
-	}))
-	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(setLogLevel)
-	handler.ServeHTTP(rr, req)
-
-	assert.Equal(t, rr.Code, http.StatusGone)
-	var errObject dao.YAPIError
-	errResponse := json.Unmarshal(rr.Body.Bytes(), &errObject)
-	expected := "Setting log levels via the REST API is deprecated. The /ws/v1/loglevel endpoint will be removed in a future release."
-	assert.NilError(t, errResponse, "cannot unmarshal YAPIError")
-	assert.Equal(t, errObject.Message, expected,
-		fmt.Sprintf("handler returned unexpected body: got %v want %v", rr.Body.String(), expected))
-	assert.Equal(t, errObject.StatusCode, http.StatusGone)
-}
-
 func TestSpecificUserAndGroupResourceUsage(t *testing.T) {
 	prepareUserAndGroupContext(t)
 	// Test user name is missing

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1208,10 +1208,14 @@ func TestGetLoggerLevel(t *testing.T) {
 	handler := http.HandlerFunc(getLogLevel)
 	handler.ServeHTTP(rr, req)
 
-	expected := "info"
-	assert.Equal(t, rr.Body.String(), expected,
+	assert.Equal(t, rr.Code, http.StatusGone)
+	var errObject dao.YAPIError
+	errResponse := json.Unmarshal(rr.Body.Bytes(), &errObject)
+	expected := "Getting log levels via the REST API is deprecated. The /ws/v1/loglevel endpoint will be removed in a future release."
+	assert.NilError(t, errResponse, "cannot unmarshal YAPIError")
+	assert.Equal(t, errObject.Message, expected,
 		fmt.Sprintf("handler returned unexpected body: got %v want %v", rr.Body.String(), expected))
-	assert.Equal(t, rr.Code, http.StatusOK)
+	assert.Equal(t, errObject.StatusCode, http.StatusGone)
 }
 
 func TestSetLoggerLevel(t *testing.T) {
@@ -1223,7 +1227,15 @@ func TestSetLoggerLevel(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(setLogLevel)
 	handler.ServeHTTP(rr, req)
-	assert.Equal(t, rr.Code, http.StatusOK)
+
+	assert.Equal(t, rr.Code, http.StatusGone)
+	var errObject dao.YAPIError
+	errResponse := json.Unmarshal(rr.Body.Bytes(), &errObject)
+	expected := "Setting log levels via the REST API is deprecated. The /ws/v1/loglevel endpoint will be removed in a future release."
+	assert.NilError(t, errResponse, "cannot unmarshal YAPIError")
+	assert.Equal(t, errObject.Message, expected,
+		fmt.Sprintf("handler returned unexpected body: got %v want %v", rr.Body.String(), expected))
+	assert.Equal(t, errObject.StatusCode, http.StatusGone)
 }
 
 func TestSpecificUserAndGroupResourceUsage(t *testing.T) {

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -100,18 +100,6 @@ var webRoutes = routes{
 	},
 	route{
 		"Scheduler",
-		"PUT",
-		"/ws/v1/loglevel/:level",
-		setLogLevel,
-	},
-	route{
-		"Scheduler",
-		"GET",
-		"/ws/v1/loglevel",
-		getLogLevel,
-	},
-	route{
-		"Scheduler",
 		"GET",
 		"/ws/v1/partition/:partition/nodes",
 		getPartitionNodes,


### PR DESCRIPTION
### What is this PR for?
~~return 410 in deprecated REST APIs `PUT /ws/v1/loglevel/{level}` and `GET /ws/v1/loglevel`~~
remove deprecated REST APIs `PUT /ws/v1/loglevel/{level}` and `GET /ws/v1/loglevel`

### What type of PR is it?
* [x] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1980

### How should this be tested?
~~Covered by unit tests.~~