### PR TITLE
[YUNIKORN-1991] Fix wrong log key in Application

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -678,7 +678,7 @@ func (sa *Application) AddAllocationAsk(ask *AllocationAsk) error {
 
 	log.Log(log.SchedApplication).Info("ask added successfully to application",
 		zap.String("appID", sa.ApplicationID),
-		zap.String("appID", sa.user.User),
+		zap.String("user", sa.user.User),
 		zap.String("ask", ask.GetAllocationKey()),
 		zap.Bool("placeholder", ask.IsPlaceholder()),
 		zap.Stringer("pendingDelta", delta))


### PR DESCRIPTION
### What is this PR for?
we show task user info log in AddAllocationAsk method of Application as
zap.String("appID",sa.user.User)
it should be zap.String("user",sa.user.User)

### What type of PR is it?

 - [x] - Improvement


### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1991
### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
