### PR TITLE
[YUNIKORN-2263] Initialize node attributes if it's nil

### DIFF
--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -113,6 +113,11 @@ func (sn *Node) String() string {
 func (sn *Node) initializeAttribute(newAttributes map[string]string) {
 	sn.attributes = newAttributes
 
+	// Avoid passing empty nodeAttributes in initializeAttribute
+	if len(sn.attributes) == 0 {
+		sn.attributes = map[string]string{}
+	}
+
 	sn.Hostname = sn.attributes[common.HostName]
 	sn.Rackname = sn.attributes[common.RackName]
 	sn.Partition = sn.attributes[common.NodePartition]


### PR DESCRIPTION
### What is this PR for?

This is a short addendum to [YUNIKORN-1124](https://issues.apache.org/jira/browse/YUNIKORN-1124): init `sn.attributes` if it's nil.


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
[YUNIKORN-2263](https://issues.apache.org/jira/browse/YUNIKORN-2263)

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
