### PR TITLE
[YUNIKORN-2012] group quota is not considered during pod scheduling

### DIFF
--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -45,6 +45,7 @@ func setupUGM() {
 	userManager := ugm.GetUserManager()
 	userManager.ClearUserTrackers()
 	userManager.ClearGroupTrackers()
+	userManager.ClearConfigLimits()
 }
 
 func setupNode(t *testing.T, nodeID string, partition *PartitionContext, nodeRes *resources.Resource) *objects.Node {

--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -118,11 +118,10 @@ func (gt *GroupTracker) UnlinkQT(queuePath string) bool {
 	return gt.queueTracker.UnlinkQT(strings.Split(queuePath, configs.DOT))
 }
 
-// canBeRemoved Does "root" queue has any child queue trackers? Is there any running applications in "root" qt?
 func (gt *GroupTracker) canBeRemoved() bool {
 	gt.RLock()
 	defer gt.RUnlock()
-	return len(gt.queueTracker.childQueueTrackers) == 0 && len(gt.queueTracker.runningApplications) == 0
+	return gt.queueTracker.canBeRemoved()
 }
 
 func (gt *GroupTracker) getName() string {

--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -338,13 +338,7 @@ func (m *Manager) UpdateConfig(config configs.QueueConfig, queuePath string) err
 	}
 	m.userLimits = make(map[string]map[string]bool)
 	m.groupLimits = make(map[string]map[string]bool)
-	if err := m.internalProcessConfig(config, queuePath, earlierUserLimits, earlierGroupLimits); err != nil {
-		return err
-	}
-	// clean up the copies of user and group limits
-	earlierUserLimits = make(map[string]map[string]bool)
-	earlierGroupLimits = make(map[string]map[string]bool)
-	return nil
+	return m.internalProcessConfig(config, queuePath, earlierUserLimits, earlierGroupLimits)
 }
 
 func (m *Manager) internalProcessConfig(cur configs.QueueConfig, queuePath string, earlierUserLimits map[string]map[string]bool, earlierGroupLimits map[string]map[string]bool) error {
@@ -428,7 +422,6 @@ func (m *Manager) internalProcessConfig(cur configs.QueueConfig, queuePath strin
 // clearEarlierSetLimits Clear already configured limits of users and groups for which limits have been configured before but not now
 func (m *Manager) clearEarlierSetLimits(currentUserLimits map[string]bool, currentGroupLimits map[string]bool, earlierUserLimits map[string]map[string]bool,
 	earlierGroupLimits map[string]map[string]bool, queuePath string) error {
-
 	// Clear already configured limits of group for which limits have been configured before but not now
 	for _, gt := range m.groupTrackers {
 		appUsersMap := m.clearEarlierSetGroupLimits(gt, queuePath, currentGroupLimits, earlierGroupLimits)

--- a/pkg/scheduler/ugm/queue_tracker.go
+++ b/pkg/scheduler/ugm/queue_tracker.go
@@ -350,6 +350,9 @@ func (qt *QueueTracker) UnlinkQT(hierarchy []string) bool {
 		if qt.childQueueTrackers[childName] != nil {
 			if qt.childQueueTrackers[childName].UnlinkQT(hierarchy[1:]) {
 				delete(qt.childQueueTrackers, childName)
+				// returning false, so that it comes out when end queue detach itself from its immediate parent.
+				// i.e., once leaf detached from root.parent for root.parent.leaf queue path.
+				// otherwise, detachment continues all the way upto the root, even parent from root. which is not needed.
 				return false
 			}
 		}

--- a/pkg/scheduler/ugm/queue_tracker.go
+++ b/pkg/scheduler/ugm/queue_tracker.go
@@ -250,6 +250,7 @@ func (qt *QueueTracker) headroom(hierarchy []string) *resources.Resource {
 		}
 		childHeadroom = qt.childQueueTrackers[childName].headroom(hierarchy[1:])
 	}
+
 	// arrived at the leaf or on the way out: check against current max if set
 	if !resources.Equals(resources.NewResource(), qt.maxResources) {
 		headroom = qt.maxResources.Clone()
@@ -349,6 +350,7 @@ func (qt *QueueTracker) UnlinkQT(hierarchy []string) bool {
 		if qt.childQueueTrackers[childName] != nil {
 			if qt.childQueueTrackers[childName].UnlinkQT(hierarchy[1:]) {
 				delete(qt.childQueueTrackers, childName)
+				return false
 			}
 		}
 	} else if len(hierarchy) <= 1 {
@@ -389,12 +391,10 @@ func (qt *QueueTracker) decreaseTrackedResourceUsageDownwards(hierarchy []string
 			}
 		}
 	}
-
 	if len(qt.runningApplications) > 0 && qt.resourceUsage != resources.NewResource() {
 		qt.resourceUsage = resources.NewResource()
 		qt.runningApplications = make(map[string]bool)
 	}
-
 	return removedApplications
 }
 
@@ -455,4 +455,30 @@ func (qt *QueueTracker) canRunApp(hierarchy []string, applicationID string, trac
 		}
 	}
 	return true
+}
+
+// canBeRemoved Start from root and reach all levels of queue hierarchy to confirm whether corresponding queue tracker
+// object can be removed from ugm or not. Based on running applications, resource usage, child queue trackers, max running apps, max resources etc
+// it decides the removal. It returns false the moment it sees any unexpected values for any queue in any levels.
+func (qt *QueueTracker) canBeRemoved() bool {
+	for _, childQT := range qt.childQueueTrackers {
+		// quick check to avoid further traversal
+		if childQT.canBeRemovedInternal() {
+			if !childQT.canBeRemoved() {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	// reached leaf queues, no more to traverse
+	return qt.canBeRemovedInternal()
+}
+
+func (qt *QueueTracker) canBeRemovedInternal() bool {
+	if len(qt.runningApplications) == 0 && resources.Equals(resources.NewResource(), qt.resourceUsage) && len(qt.childQueueTrackers) == 0 &&
+		qt.maxRunningApps == 0 && resources.Equals(resources.NewResource(), qt.maxResources) {
+		return true
+	}
+	return false
 }

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -164,11 +164,10 @@ func (ut *UserTracker) UnlinkQT(queuePath string) bool {
 	return ut.queueTracker.UnlinkQT(strings.Split(queuePath, configs.DOT))
 }
 
-// canBeRemoved Does "root" queue has any child queue trackers? Is there any running applications in "root" qt?
 func (ut *UserTracker) canBeRemoved() bool {
 	ut.RLock()
 	defer ut.RUnlock()
-	return len(ut.queueTracker.childQueueTrackers) == 0 && len(ut.queueTracker.runningApplications) == 0
+	return ut.queueTracker.canBeRemoved()
 }
 
 func (ut *UserTracker) canRunApp(queuePath, applicationID string) bool {


### PR DESCRIPTION
### What is this PR for?

Problem: When config has limits set only for group, its quota was not getting honoured. User belonging to the group are allowed to use more resources than the allowed limit.

Besides fixing the issue, this pr also simplifies the "cleaning up old user/group limits resource usage when config changes" codepath by removing the unnecessary clean up processing for the queue path. For example, say group "test" limit is set for queue path a.b.c. A config change had happened for the removal of "test" from a.b.c. So, clean up is required only when a.b.c queue path comes. But, clean up happens even when we are processing a & b from queue configs just because those queues has been tracked for the group "test". So far, as long as the queue has been tracked for a group, then, even that queue enters the clean up loop. This unnecessary processing reset the values already set not only for the a & b, even for c. which is not needed and correct.

Now simplified the whole codepath by comparing the old config with the new config. If new config doesn't have the limit set for group "test", then clean up triggers.


### What type of PR is it?
* [ ] - Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2012

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
