### PR TITLE
[YUNIKORN-1987] Identity config fields not set explicitly

### DIFF
--- a/pkg/common/configs/config.go
+++ b/pkg/common/configs/config.go
@@ -188,6 +188,18 @@ func (i *DefaultValues) CheckAndSetDefault(v interface{}, name string) interface
 	}
 }
 
+// IsDefault checks whether the provided fieldName exists in the list of default fields.
+// It performs a case-insensitive comparison of the fieldName parameter
+// against the names in the defaultFields slice.
+//
+// This function is designed for use with field types that are either strings or uint64.
+// Other types are not supported and could lead to wrong result.
+//
+// Parameters:
+// - fieldName (string): The name of the field to check.
+//
+// Returns:
+// - bool: True if the fieldName exists in the defaultFields, false otherwise.
 func (i *DefaultValues) IsDefault(fieldName string) bool {
 	searchedName := strings.ToLower(fieldName)
 	for _, f := range i.defaultFields {


### PR DESCRIPTION
### What is this PR for?
Identuty config fields not set explicitly. 

I have added a struct called `DefaultValues` to keep track of the fields that the user has not entered. 
The function `CheckAndSetDefault` is used to determine if the value inside this field matches the predefined default value. 
If it does, the field name will be added to `DefaultValues.defaultFields`, and the value of this field will be overwritten with the corresponding default value of its data type. 

In the default settings, `uint64` is set to the maximum value of `uint64`, and `string` is set to `"defaultStringValue"`. 
I did not handle operations for map, slice, etc. because if the user does not provide any input, it will be nil.

To enable the above functionality, an `UnmarshalYAML` method has been implemented for each object that includes the `DefaultValues` struct. 


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-1987

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - Not sure if setting uint64 default value to the maximum is appropriate.