### PR TITLE
[YUNIKORN-2014] fix /ws/v1/config yaml response

### DIFF
--- a/pkg/webservice/dao/config_info.go
+++ b/pkg/webservice/dao/config_info.go
@@ -26,6 +26,6 @@ type ValidateConfResponse struct {
 }
 
 type ConfigDAOInfo struct {
-	*configs.SchedulerConfig
-	Extra map[string]string `yaml:",omitempty" json:",omitempty"`
+	*configs.SchedulerConfig `yaml:",inline"`
+	Extra                    map[string]string `yaml:",omitempty" json:",omitempty"`
 }


### PR DESCRIPTION
### What is this PR for?

After https://github.com/apache/yunikorn-core/pull/652, the yaml response has `schedulerconfig` field name. Add `yaml:",inline"` to make the response as same as before.


### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2014
