### PR TITLE
[YUNIKORN-2025] Mismatched running container count if preemption was triggered

### DIFF
--- a/pkg/rmproxy/rmproxy.go
+++ b/pkg/rmproxy/rmproxy.go
@@ -146,11 +146,7 @@ func (rmp *RMProxy) processRMReleaseAllocationEvent(event *rmevent.RMReleaseAllo
 			Released: event.ReleasedAllocations,
 		}
 		rmp.triggerUpdateAllocation(event.RmID, response)
-		// If preemption is triggered, we should prevent an increase in the count of released containers until shim detects it.
-		// When shim detects the release of a preempted allocation, the TerminationType will be set to STOPPED_BY_RM.
-		if event.ReleasedAllocations[0].TerminationType != si.TerminationType_PREEMPTED_BY_SCHEDULER {
-			metrics.GetSchedulerMetrics().AddReleasedContainers(len(event.ReleasedAllocations))
-		}
+		metrics.GetSchedulerMetrics().AddReleasedContainers(len(event.ReleasedAllocations))
 	}
 
 	// Done, notify channel

--- a/pkg/rmproxy/rmproxy.go
+++ b/pkg/rmproxy/rmproxy.go
@@ -146,7 +146,11 @@ func (rmp *RMProxy) processRMReleaseAllocationEvent(event *rmevent.RMReleaseAllo
 			Released: event.ReleasedAllocations,
 		}
 		rmp.triggerUpdateAllocation(event.RmID, response)
-		metrics.GetSchedulerMetrics().AddReleasedContainers(len(event.ReleasedAllocations))
+		// If preemption is triggered, we should prevent an increase in the count of released containers until shim detects it.
+		// When shim detects the release of a preempted allocation, the TerminationType will be set to STOPPED_BY_RM.
+		if event.ReleasedAllocations[0].TerminationType != si.TerminationType_PREEMPTED_BY_SCHEDULER {
+			metrics.GetSchedulerMetrics().AddReleasedContainers(len(event.ReleasedAllocations))
+		}
 	}
 
 	// Done, notify channel

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1370,9 +1370,9 @@ func (pc *PartitionContext) removeAllocation(release *si.AllocationRelease) ([]*
 	pc.updateAllocationCount(-len(released))
 	metrics.GetQueueMetrics(queue.GetQueuePath()).AddReleasedContainers(len(released))
 
-	// if the termination type is timeout, we don't notify the shim, because it's
-	// originated from that side
-	if release.TerminationType == si.TerminationType_TIMEOUT {
+	// if the termination type is TIMEOUT/PREEMPTED_BY_SCHEDULER, we don't notify the shim,
+	// because it's originated from that side
+	if release.TerminationType == si.TerminationType_TIMEOUT || release.TerminationType == si.TerminationType_PREEMPTED_BY_SCHEDULER {
 		released = nil
 	}
 	return released, confirmed

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -563,7 +563,7 @@ func TestPlaceholderDataWithPlaceholderPreemption(t *testing.T) {
 		TerminationType: si.TerminationType_PREEMPTED_BY_SCHEDULER,
 	}
 	releases, _ := partition.removeAllocation(release)
-	assert.Equal(t, 1, len(releases), "unexpected number of allocations released")
+	assert.Equal(t, 0, len(releases), "not expecting any released allocations")
 	assertPlaceholderData(t, gangApp, 7, 1)
 }
 
@@ -2120,7 +2120,7 @@ func setupPreemptionForRequiredNode(t *testing.T) (*PartitionContext, *objects.A
 		TerminationType: si.TerminationType_PREEMPTED_BY_SCHEDULER,
 	}
 	releases, _ := partition.removeAllocation(release)
-	assert.Equal(t, 1, len(releases), "unexpected number of allocations released")
+	assert.Equal(t, 0, len(releases), "not expecting any released allocations")
 	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 0}), getExpectedQueuesLimitsForPreemptionWithRequiredNode())
 	return partition, app
 }


### PR DESCRIPTION
### What is this PR for?
Metric of releasedContainers will decrease twice if preemption was triggered.  
If a allocation was preempted, 2 RMReleaseAllocationEvent will be created as below:
1. Core → Shim (TerminationType: **PREEMPTED_BY_SCHEDULER**) 
2. Core → Shim (TerminationType: **STOPPED_BY_RM**) 
   (A callback of RM Shim → Core, but it shouldn't happend)

This PR handle PREEMPTED_BY_SCHEDULER just like TIMEOUT.
Check the PREEMPTED_BY_SCHEDULER termination type to prevent the second decrease of release containers.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2025

### How should this be tested?
1. Trigger e2e test 'Verify_basic_preemption'. (You will see -1 running conainer in YuniKorn UI.)
2. Redeploy YuniKorn with this fix
3. Trigger e2e test 'Verify_basic_preemption'. (You will see 0 running conainer in YuniKorn UI.)

### Screenshots (if appropriate)
<img width="1449" alt="Nagative Running Container Count - UI Screenshot" src="https://github.com/apache/yunikorn-core/assets/26764036/2dd91049-e262-4d00-9332-329df73d79b4">


### Questions:
NA
