### PR TITLE
[YUNIKORN-2052] Logging Enhancement for Preemption

### DIFF
--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -557,7 +557,6 @@ func (p *Preemptor) TryPreemption() (*Allocation, bool) {
 				zap.String("victimNodeID", victim.GetNodeID()),
 				zap.String("victimQueue", victimQueue.Name),
 			)
-
 		} else {
 			log.Log(log.SchedPreemption).Warn("BUG: Queue not found for preemption victim",
 				zap.String("queue", p.queue.Name),

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -553,9 +553,10 @@ func (p *Preemptor) TryPreemption() (*Allocation, bool) {
 				zap.String("askQueue", p.queue.Name),
 				zap.String("victimApplicationID", victim.GetApplicationID()),
 				zap.String("victimAllocationKey", victim.GetAllocationKey()),
+				zap.Stringer("victimAllocatedResource", victim.GetAllocatedResource()),
+				zap.String("victimNodeID", victim.GetNodeID()),
 				zap.String("victimQueue", victimQueue.Name),
-				zap.String("nodeID", victim.GetNodeID()),
-				zap.Stringer("resources", victim.GetAllocatedResource()))
+			)
 
 		} else {
 			log.Log(log.SchedPreemption).Warn("BUG: Queue not found for preemption victim",

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -548,16 +548,18 @@ func (p *Preemptor) TryPreemption() (*Allocation, bool) {
 			victimQueue.IncPreemptingResource(victim.GetAllocatedResource())
 			victim.MarkPreempted()
 			log.Log(log.SchedPreemption).Info("Preempting task",
-				zap.String("victimApplicationID", victim.GetApplicationID()),
-				zap.String("victimAllocationKey", victim.GetAllocationKey()),
-				zap.String("nodeID", victim.GetNodeID()),
-				zap.Stringer("resources", victim.GetAllocatedResource()),
 				zap.String("askApplicationID", p.ask.applicationID),
 				zap.String("askAllocationKey", p.ask.allocationKey),
-				zap.String("askQueue", p.ask.String()),
-				zap.String("victimQueue", victimQueue.Name))
+				zap.String("askQueue", p.queue.Name),
+				zap.String("victimApplicationID", victim.GetApplicationID()),
+				zap.String("victimAllocationKey", victim.GetAllocationKey()),
+				zap.String("victimQueue", victimQueue.Name),
+				zap.String("nodeID", victim.GetNodeID()),
+				zap.Stringer("resources", victim.GetAllocatedResource()))
+
 		} else {
 			log.Log(log.SchedPreemption).Warn("BUG: Queue not found for preemption victim",
+				zap.String("queue", p.queue.Name),
 				zap.String("victimApplicationID", victim.GetApplicationID()),
 				zap.String("victimAllocationKey", victim.GetAllocationKey()))
 		}

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -548,14 +548,18 @@ func (p *Preemptor) TryPreemption() (*Allocation, bool) {
 			victimQueue.IncPreemptingResource(victim.GetAllocatedResource())
 			victim.MarkPreempted()
 			log.Log(log.SchedPreemption).Info("Preempting task",
-				zap.String("applicationID", victim.GetApplicationID()),
-				zap.String("allocationKey", victim.GetAllocationKey()),
+				zap.String("victimApplicationID", victim.GetApplicationID()),
+				zap.String("victimAllocationKey", victim.GetAllocationKey()),
 				zap.String("nodeID", victim.GetNodeID()),
-				zap.Stringer("resources", victim.GetAllocatedResource()))
+				zap.Stringer("resources", victim.GetAllocatedResource()),
+				zap.String("askApplicationID", p.ask.applicationID),
+				zap.String("askAllocationKey", p.ask.allocationKey),
+				zap.String("askQueue", p.ask.String()),
+				zap.String("victimQueue", victimQueue.Name))
 		} else {
 			log.Log(log.SchedPreemption).Warn("BUG: Queue not found for preemption victim",
-				zap.String("applicationID", victim.GetApplicationID()),
-				zap.String("allocationKey", victim.GetAllocationKey()))
+				zap.String("victimApplicationID", victim.GetApplicationID()),
+				zap.String("victimAllocationKey", victim.GetAllocationKey()))
 		}
 	}
 


### PR DESCRIPTION
Logging Enhancement for Preemption Logs

Newly Added fields in the Preemption Logs

- applicationID of ask => "askApplicationID"
- allocationKey of ask => "askAllocationKey"
- queue of ask => "askQueue"
- queue of victim => "victimQueue"

Also, rename a few of the existing output items:

- "applicationID" => "victimApplicationID"
- "allocationKey" => "victimAllocationKey"
-  "nodeID" -> victimNodeID
-  "resources" -> victimAllocatedResource

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring



### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2052
