### PR TITLE
[YUNIKORN-1982] Enable manual triggering for GitHub CI 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch: {}
 
 jobs:
   build:


### PR DESCRIPTION
### What is this PR for?
Allow running manually from the github ui.
Everyone can manually run the CI on their fork.

github docs

https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
[YUNIKORN-1982](https://issues.apache.org/jira/browse/YUNIKORN-1982)

### Screenshots (if appropriate)
Similar to the Apache/Spark benchmark GitHub action, anyone who forks the [yunikorn-core](https://github.com/apache/yunikorn-core) repository can execute tests on their own fork. This offers several benefits:

1. Increased confidence in pull requests.
2. Enhanced code quality through improved performance and stability.



<img width="1433" alt="截圖 2023-10-20 下午6 39 13" src="https://github.com/apache/yunikorn-core/assets/143783826/1795bd8c-600f-4e66-ae32-10d4792ebbbe">

