### PR TITLE
[YUNIKORN-2045] unify DeepEqual

### DIFF
--- a/pkg/common/configs/config_test.go
+++ b/pkg/common/configs/config_test.go
@@ -1721,7 +1721,7 @@ func TestGetConfigurationString(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.DeepEqual(t, tc.expectedConfig, GetConfigurationString(tc.requestBytes))
+			assert.Equal(t, tc.expectedConfig, GetConfigurationString(tc.requestBytes))
 		})
 	}
 }

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1636,7 +1636,7 @@ func TestGetPartitionQueueDAOInfo(t *testing.T) {
 
 	// test properties
 	root.properties = getProperties()
-	assert.Assert(t, reflect.DeepEqual(root.properties, root.GetPartitionQueueDAOInfo().Properties))
+	assert.DeepEqual(t, root.properties, root.GetPartitionQueueDAOInfo().Properties)
 
 	// test template
 	root.template, err = template.FromConf(&configs.ChildTemplate{
@@ -1647,7 +1647,7 @@ func TestGetPartitionQueueDAOInfo(t *testing.T) {
 		},
 	})
 	assert.NilError(t, err)
-	assert.Assert(t, reflect.DeepEqual(root.template.GetProperties(), root.GetPartitionQueueDAOInfo().TemplateInfo.Properties))
+	assert.DeepEqual(t, root.template.GetProperties(), root.GetPartitionQueueDAOInfo().TemplateInfo.Properties)
 	assert.DeepEqual(t, root.template.GetMaxResource().DAOMap(), root.template.GetMaxResource().DAOMap())
 	assert.DeepEqual(t, root.template.GetGuaranteedResource().DAOMap(), root.template.GetGuaranteedResource().DAOMap())
 
@@ -1712,11 +1712,11 @@ func TestSetResources(t *testing.T) {
 
 	expectedGuaranteedResource, err := resources.NewResourceFromConf(guaranteedResource)
 	assert.NilError(t, err, "failed to parse resource: %v", err)
-	assert.Assert(t, reflect.DeepEqual(queue.guaranteedResource, expectedGuaranteedResource))
+	assert.DeepEqual(t, queue.guaranteedResource, expectedGuaranteedResource)
 
 	expectedMaxResource, err := resources.NewResourceFromConf(maxResource)
 	assert.NilError(t, err, "failed to parse resource: %v", err)
-	assert.Assert(t, reflect.DeepEqual(queue.maxResource, expectedMaxResource))
+	assert.DeepEqual(t, queue.maxResource, expectedMaxResource)
 
 	// case 1: empty resource won't change the resources
 	err = queue.setResources(configs.Resources{
@@ -1724,8 +1724,8 @@ func TestSetResources(t *testing.T) {
 		Max:        make(map[string]string),
 	})
 	assert.NilError(t, err, "failed to set resources: %v", err)
-	assert.Assert(t, reflect.DeepEqual(queue.guaranteedResource, expectedGuaranteedResource))
-	assert.Assert(t, reflect.DeepEqual(queue.maxResource, expectedMaxResource))
+	assert.DeepEqual(t, queue.guaranteedResource, expectedGuaranteedResource)
+	assert.DeepEqual(t, queue.maxResource, expectedMaxResource)
 
 	// case 2: zero resource won't change the resources
 	err = queue.setResources(configs.Resources{
@@ -1733,8 +1733,8 @@ func TestSetResources(t *testing.T) {
 		Max:        getZeroResourceConf(),
 	})
 	assert.NilError(t, err, "failed to set resources: %v", err)
-	assert.Assert(t, reflect.DeepEqual(queue.guaranteedResource, expectedGuaranteedResource))
-	assert.Assert(t, reflect.DeepEqual(queue.maxResource, expectedMaxResource))
+	assert.DeepEqual(t, queue.guaranteedResource, expectedGuaranteedResource)
+	assert.DeepEqual(t, queue.maxResource, expectedMaxResource)
 }
 
 func TestPreemptingResource(t *testing.T) {
@@ -1960,9 +1960,9 @@ func TestSetTemplate(t *testing.T) {
 	assert.NilError(t, err, "failed to parse resource: %v", err)
 
 	checkTemplate := func(queue *Queue) {
-		assert.Assert(t, reflect.DeepEqual(queue.template.GetProperties(), properties))
-		assert.Assert(t, reflect.DeepEqual(queue.template.GetGuaranteedResource(), expectedGuaranteedResource))
-		assert.Assert(t, reflect.DeepEqual(queue.template.GetMaxResource(), expectedMaxResource))
+		assert.DeepEqual(t, queue.template.GetProperties(), properties)
+		assert.DeepEqual(t, queue.template.GetGuaranteedResource(), expectedGuaranteedResource)
+		assert.DeepEqual(t, queue.template.GetMaxResource(), expectedMaxResource)
 	}
 
 	// case 0: normal case
@@ -2003,9 +2003,9 @@ func TestApplyTemplate(t *testing.T) {
 	assert.NilError(t, err, "failed to create basic queue queue: %v", err)
 	leaf.applyTemplate(childTemplate)
 	assert.Assert(t, leaf.template == nil)
-	assert.Assert(t, reflect.DeepEqual(leaf.properties, childTemplate.GetProperties()))
-	assert.Assert(t, reflect.DeepEqual(leaf.guaranteedResource, childTemplate.GetGuaranteedResource()))
-	assert.Assert(t, reflect.DeepEqual(leaf.maxResource, childTemplate.GetMaxResource()))
+	assert.DeepEqual(t, leaf.properties, childTemplate.GetProperties())
+	assert.DeepEqual(t, leaf.guaranteedResource, childTemplate.GetGuaranteedResource())
+	assert.DeepEqual(t, leaf.maxResource, childTemplate.GetMaxResource())
 
 	// case 1: zero resource template generates nil resource
 	leaf2, err := createManagedQueueWithProps(nil, "tmp", false, nil, nil)
@@ -2151,7 +2151,7 @@ func TestNewConfiguredQueue(t *testing.T) {
 	assert.Equal(t, parent.QueuePath, "parent_queue")
 	assert.Equal(t, parent.isManaged, true)
 	assert.Equal(t, parent.maxRunningApps, uint64(32))
-	assert.Assert(t, reflect.DeepEqual(properties, parent.template.GetProperties()))
+	assert.DeepEqual(t, properties, parent.template.GetProperties())
 	assert.Assert(t, resources.Equals(resourceStruct, parent.template.GetMaxResource()))
 	assert.Assert(t, resources.Equals(resourceStruct, parent.template.GetGuaranteedResource()))
 
@@ -2169,7 +2169,7 @@ func TestNewConfiguredQueue(t *testing.T) {
 	assert.NilError(t, err, "failed to create queue: %v", err)
 	assert.Equal(t, childLeaf.QueuePath, "parent_queue.leaf_queue")
 	assert.Assert(t, childLeaf.template == nil)
-	assert.Assert(t, reflect.DeepEqual(childLeaf.properties, parent.template.GetProperties()))
+	assert.DeepEqual(t, childLeaf.properties, parent.template.GetProperties())
 	assert.Assert(t, resources.Equals(childLeaf.maxResource, parent.template.GetMaxResource()))
 	assert.Assert(t, resources.Equals(childLeaf.guaranteedResource, parent.template.GetGuaranteedResource()))
 
@@ -2237,9 +2237,9 @@ func TestNewDynamicQueue(t *testing.T) {
 	childLeaf, err := NewDynamicQueue("leaf", true, parent)
 	assert.NilError(t, err, "failed to create dynamic queue: %v", err)
 	assert.Assert(t, childLeaf.template == nil)
-	assert.Assert(t, reflect.DeepEqual(childLeaf.properties, parent.template.GetProperties()))
-	assert.Assert(t, reflect.DeepEqual(childLeaf.maxResource, parent.template.GetMaxResource()))
-	assert.Assert(t, reflect.DeepEqual(childLeaf.guaranteedResource, parent.template.GetGuaranteedResource()))
+	assert.DeepEqual(t, childLeaf.properties, parent.template.GetProperties())
+	assert.DeepEqual(t, childLeaf.maxResource, parent.template.GetMaxResource())
+	assert.DeepEqual(t, childLeaf.guaranteedResource, parent.template.GetGuaranteedResource())
 	assert.Assert(t, childLeaf.prioritySortEnabled)
 	assert.Equal(t, childLeaf.priorityPolicy, policies.DefaultPriorityPolicy)
 	assert.Equal(t, childLeaf.preemptionPolicy, policies.DefaultPreemptionPolicy)

--- a/pkg/scheduler/objects/template/template_test.go
+++ b/pkg/scheduler/objects/template/template_test.go
@@ -19,7 +19,6 @@
 package template
 
 import (
-	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -51,14 +50,14 @@ func getResource(t *testing.T) *resources.Resource {
 
 func checkMembers(t *testing.T, template *Template, properties map[string]string, maxResource *resources.Resource, guaranteedResource *resources.Resource) {
 	// test inner members
-	assert.Assert(t, reflect.DeepEqual(template.properties, properties))
-	assert.Assert(t, reflect.DeepEqual(template.maxResource, maxResource))
-	assert.Assert(t, reflect.DeepEqual(template.guaranteedResource, guaranteedResource))
+	assert.DeepEqual(t, template.properties, properties)
+	assert.DeepEqual(t, template.maxResource, maxResource)
+	assert.DeepEqual(t, template.guaranteedResource, guaranteedResource)
 
 	// test all getters
-	assert.Assert(t, reflect.DeepEqual(template.GetProperties(), properties))
-	assert.Assert(t, reflect.DeepEqual(template.GetMaxResource(), maxResource))
-	assert.Assert(t, reflect.DeepEqual(template.GetGuaranteedResource(), guaranteedResource))
+	assert.DeepEqual(t, template.GetProperties(), properties)
+	assert.DeepEqual(t, template.GetMaxResource(), maxResource)
+	assert.DeepEqual(t, template.GetGuaranteedResource(), guaranteedResource)
 }
 
 func TestNewTemplate(t *testing.T) {

--- a/pkg/scheduler/policies/nodesorting_policy.go
+++ b/pkg/scheduler/policies/nodesorting_policy.go
@@ -44,4 +44,3 @@ func SortingPolicyFromString(str string) (SortingPolicy, error) {
 		return FairnessPolicy, fmt.Errorf("undefined policy: %s", str)
 	}
 }
-

--- a/pkg/scheduler/policies/nodesorting_policy_test.go
+++ b/pkg/scheduler/policies/nodesorting_policy_test.go
@@ -63,4 +63,3 @@ func TestSortingPolicyToString(t *testing.T) {
 		}
 	}
 }
-

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -509,7 +509,7 @@ func TestGetConfigYAML(t *testing.T) {
 	assert.NilError(t, err, "failed to unmarshal config from response body (updated config)")
 	assert.Equal(t, conf.Partitions[0].NodeSortPolicy.Type, "binpacking", "node sort policy not updated")
 	assert.Assert(t, startConfSum != conf.Checksum, "checksums did not change in output")
-	assert.Assert(t, reflect.DeepEqual(conf.Extra, updatedExtraConf), "extra config did not change")
+	assert.DeepEqual(t, conf.Extra, updatedExtraConf)
 
 	// reset extra config map
 	configs.SetConfigMap(map[string]string{})
@@ -540,7 +540,7 @@ func TestGetConfigJSON(t *testing.T) {
 	assert.NilError(t, err, "failed to unmarshal config from response body (json, updated config)")
 	assert.Assert(t, startConfSum != conf.Checksum, "checksums did not change in json output: %s, %s", startConfSum, conf.Checksum)
 	assert.Equal(t, conf.Partitions[0].NodeSortPolicy.Type, "binpacking", "node sort policy not updated (json)")
-	assert.Assert(t, reflect.DeepEqual(conf.Extra, updatedExtraConf), "extra config did not change")
+	assert.DeepEqual(t, conf.Extra, updatedExtraConf)
 
 	// reset extra config map
 	configs.SetConfigMap(map[string]string{})


### PR DESCRIPTION
### What is this PR for?
In most cases, use assert.DeepEqual uniformly.
For example:
`assert.Assert(t, reflect.DeepEqual(root.properties, root.GetPartitionQueueDAOInfo().Properties))`
change to:
`assert.DeepEqual(t, root.properties, root.GetPartitionQueueDAOInfo().Properties)`

Other modifications:

- in `pkg/common/configs/config_test.go`:
`assert.DeepEqual(t, tc.expectedConfig, GetConfigurationString(tc.requestBytes))`
change to :
`assert.Equal(t, tc.expectedConfig, GetConfigurationString(tc.requestBytes))`

- `pkg/scheduler/policies/nodesorting_policy.go `and `pkg/scheduler/policies/nodesorting_policy_test.go `delete a line

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [x] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-2045

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
