### PR TITLE
[YUNIKORN-2073] add rate limiter to event system

### DIFF
--- a/pkg/scheduler/objects/application_events_test.go
+++ b/pkg/scheduler/objects/application_events_test.go
@@ -20,6 +20,7 @@ package objects
 
 import (
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 
@@ -63,6 +64,27 @@ func TestSendAppDoesNotFitEvent(t *testing.T) {
 		applicationID: appID0,
 		allocationKey: aKey,
 	})
+	assert.Equal(t, 1, len(mock.events), "event was not generated")
+}
+
+func TestSendAppDoesNotFitEventWithRateLimiter(t *testing.T) {
+	app := &Application{
+		queuePath: "root.test",
+	}
+	mock := newEventSystemMock()
+	appEvents := newApplicationEvents(app, mock)
+	startTime := time.Now()
+	for {
+		elapsed := time.Since(startTime)
+		if elapsed > 500*time.Millisecond {
+			break
+		}
+		appEvents.sendAppDoesNotFitEvent(&AllocationAsk{
+			applicationID: appID0,
+			allocationKey: aKey,
+		})
+		time.Sleep(10 * time.Millisecond)
+	}
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 }
 


### PR DESCRIPTION
### What is this PR for?

The `sendAppDoesNotFitEvent()` causes a spew in the event system. We need to limit the number of those events with some throttle.

The event will be send every time it does not fit in the queue headroom. That could occur really often if it is a high priority request on an application that does not fit but other requests get scheduled (eager scheduling).

### What type of PR is it?
* [X] - Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2073

### How should this be tested?

Covered by unit tests.
