### PR TITLE
[YUNIKORN-2107] Allow preemption to be disabled globally

### DIFF
--- a/pkg/common/configs/config.go
+++ b/pkg/common/configs/config.go
@@ -50,14 +50,14 @@ type PartitionConfig struct {
 	Queues            []QueueConfig
 	PlacementRules    []PlacementRule           `yaml:",omitempty" json:",omitempty"`
 	Limits            []Limit                   `yaml:",omitempty" json:",omitempty"`
-	Preemption        PartitionPreemptionConfig `yaml:",omitempty" json:",omitempty"` // deprecated
+	Preemption        PartitionPreemptionConfig `yaml:",omitempty" json:",omitempty"`
 	NodeSortPolicy    NodeSortingPolicy         `yaml:",omitempty" json:",omitempty"`
 	StateDumpFilePath string                    `yaml:",omitempty" json:",omitempty"`
 }
 
-// deprecated
+// The partition preemption configuration
 type PartitionPreemptionConfig struct {
-	Enabled bool
+	Enabled *bool `yaml:",omitempty" json:",omitempty"`
 }
 
 // The queue object for each queue:

--- a/pkg/common/configs/config_test.go
+++ b/pkg/common/configs/config_test.go
@@ -614,8 +614,28 @@ partitions:
   - name: default
     queues:
       - name: root
+  - name: "partition-0"
+    queues:
+      - name: root
+`
+	dataEnabled := `
+partitions:
+  - name: default
+    queues:
+      - name: root
     preemption:
       enabled: true
+  - name: "partition-0"
+    queues:
+      - name: root
+`
+	dataDisabled := `
+partitions:
+  - name: default
+    queues:
+      - name: root
+    preemption:
+      enabled: false
   - name: "partition-0"
     queues:
       - name: root
@@ -623,14 +643,15 @@ partitions:
 	// validate the config and check after the update
 	conf, err := CreateConfig(data)
 	assert.NilError(t, err, "should expect no error")
+	assert.Assert(t, conf.Partitions[0].Preemption.Enabled == nil, "default should be nil")
 
-	if !conf.Partitions[0].Preemption.Enabled {
-		t.Error("default partition's preemption should be enabled.")
-	}
+	conf, err = CreateConfig(dataEnabled)
+	assert.NilError(t, err, "should expect no error")
+	assert.Assert(t, *conf.Partitions[0].Preemption.Enabled, "preemption should be enabled")
 
-	if conf.Partitions[1].Preemption.Enabled {
-		t.Error("partition-0's preemption should NOT be enabled by default")
-	}
+	conf, err = CreateConfig(dataDisabled)
+	assert.NilError(t, err, "should expect no error")
+	assert.Assert(t, !*conf.Partitions[0].Preemption.Enabled, "preemption should be disabled")
 }
 
 func TestParseRule(t *testing.T) {

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -944,7 +944,7 @@ func (sa *Application) canReplace(request *AllocationAsk) bool {
 }
 
 // tryAllocate will perform a regular allocation of a pending request, includes placeholders.
-func (sa *Application) tryAllocate(headRoom *resources.Resource, preemptionDelay time.Duration, preemptAttemptsRemaining *int, nodeIterator func() NodeIterator, fullNodeIterator func() NodeIterator, getNodeFn func(string) *Node) *Allocation {
+func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption bool, preemptionDelay time.Duration, preemptAttemptsRemaining *int, nodeIterator func() NodeIterator, fullNodeIterator func() NodeIterator, getNodeFn func(string) *Node) *Allocation {
 	sa.Lock()
 	defer sa.Unlock()
 	if sa.sortedRequests == nil {
@@ -971,7 +971,7 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, preemptionDelay
 		// resource must fit in headroom otherwise skip the request (unless preemption could help)
 		if !headRoom.FitInMaxUndef(request.GetAllocatedResource()) {
 			// attempt preemption
-			if *preemptAttemptsRemaining > 0 {
+			if allowPreemption && *preemptAttemptsRemaining > 0 {
 				*preemptAttemptsRemaining--
 				fullIterator := fullNodeIterator()
 				if fullIterator != nil {
@@ -1034,7 +1034,7 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, preemptionDelay
 			}
 
 			// no nodes qualify, attempt preemption
-			if *preemptAttemptsRemaining > 0 {
+			if allowPreemption && *preemptAttemptsRemaining > 0 {
 				*preemptAttemptsRemaining--
 				fullIterator := fullNodeIterator()
 				if fullIterator != nil {

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -1778,7 +1778,7 @@ func TestTryAllocateNoRequests(t *testing.T) {
 
 	app := newApplication(appID1, "default", "root.unknown")
 	preemptionAttemptsRemaining := 0
-	alloc := app.tryAllocate(node.GetAvailableResource(), 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	alloc := app.tryAllocate(node.GetAvailableResource(), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Check(t, alloc == nil, "unexpected alloc")
 }
 
@@ -1803,7 +1803,7 @@ func TestTryAllocateFit(t *testing.T) {
 	assert.NilError(t, err)
 
 	preemptionAttemptsRemaining := 0
-	alloc := app.tryAllocate(node.GetAvailableResource(), 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	alloc := app.tryAllocate(node.GetAvailableResource(), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Assert(t, alloc != nil, "alloc expected")
 	assert.Equal(t, "node1", alloc.GetNodeID(), "wrong node")
 }
@@ -1845,19 +1845,19 @@ func TestTryAllocatePreemptQueue(t *testing.T) {
 
 	preemptionAttemptsRemaining := 10
 
-	alloc1 := app1.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10}), 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	alloc1 := app1.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Assert(t, alloc1 != nil, "alloc1 expected")
-	alloc2 := app1.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}), 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	alloc2 := app1.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Assert(t, alloc2 != nil, "alloc2 expected")
 
 	// on first attempt, not enough time has passed
-	alloc3 := app2.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}), 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	alloc3 := app2.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Assert(t, alloc3 == nil, "alloc3 not expected")
 	assert.Assert(t, !alloc2.IsPreempted(), "alloc2 should not have been preempted")
 
 	// pass the time and try again
 	ask3.createTime = ask3.createTime.Add(-30 * time.Second)
-	alloc3 = app2.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}), 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	alloc3 = app2.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Assert(t, alloc3 == nil, "alloc3 not expected")
 	assert.Assert(t, alloc2.IsPreempted(), "alloc2 should have been preempted")
 }
@@ -1913,20 +1913,20 @@ func TestTryAllocatePreemptNode(t *testing.T) {
 	preemptionAttemptsRemaining := 10
 
 	// consume capacity with 'unlimited' app
-	alloc00 := app0.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 40}), 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	alloc00 := app0.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 40}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Assert(t, alloc00 != nil, "alloc00 expected")
-	alloc01 := app0.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 39}), 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	alloc01 := app0.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 39}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Assert(t, alloc01 != nil, "alloc01 expected")
 
 	// consume remainder of space but not quota
-	alloc1 := app1.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 28}), 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	alloc1 := app1.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 28}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Assert(t, alloc1 != nil, "alloc1 expected")
-	alloc2 := app1.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 23}), 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	alloc2 := app1.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 23}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Assert(t, alloc2 != nil, "alloc2 expected")
 
 	// on first attempt, should see a reservation since we're after the reservation timeout
 	ask3.createTime = ask3.createTime.Add(-10 * time.Second)
-	alloc3 := app2.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 18}), 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	alloc3 := app2.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 18}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Assert(t, alloc3 != nil, "alloc3 expected")
 	assert.Equal(t, "node1", alloc3.GetNodeID(), "wrong node assignment")
 	assert.Equal(t, Reserved, alloc3.GetResult(), "expected reservation")
@@ -1936,7 +1936,7 @@ func TestTryAllocatePreemptNode(t *testing.T) {
 
 	// pass the time and try again
 	ask3.createTime = ask3.createTime.Add(-30 * time.Second)
-	alloc3 = app2.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 18}), 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	alloc3 = app2.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 18}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Assert(t, alloc3 != nil, "alloc3 expected")
 	assert.Assert(t, alloc1.IsPreempted(), "alloc1 should have been preempted")
 }
@@ -2259,7 +2259,7 @@ func TestAppDoesNotFitEvent(t *testing.T) {
 	app.sortedRequests = sr
 	attempts := 0
 
-	app.tryAllocate(headroom, time.Second, &attempts, func() NodeIterator {
+	app.tryAllocate(headroom, true, time.Second, &attempts, func() NodeIterator {
 		return nil
 	}, func() NodeIterator {
 		return nil

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -3306,6 +3306,30 @@ func TestRemoveAllocationAsk(t *testing.T) {
 	assertLimits(t, getTestUserGroup(), nil)
 }
 
+func TestUpdatePreemption(t *testing.T) {
+	var True = true
+	var False = false
+
+	partition, err := newBasePartition()
+	assert.NilError(t, err, "Partition creation failed")
+	assert.Assert(t, partition.isPreemptionEnabled(), "preeemption should be enabled by default")
+
+	partition.updatePreemption(configs.PartitionConfig{})
+	assert.Assert(t, partition.isPreemptionEnabled(), "preeemption should be enabled by empty config")
+
+	partition.updatePreemption(configs.PartitionConfig{Preemption: configs.PartitionPreemptionConfig{}})
+	assert.Assert(t, partition.isPreemptionEnabled(), "preeemption should be enabled by empty preemption section")
+
+	partition.updatePreemption(configs.PartitionConfig{Preemption: configs.PartitionPreemptionConfig{Enabled: nil}})
+	assert.Assert(t, partition.isPreemptionEnabled(), "preeemption should be enabled by explicit nil")
+
+	partition.updatePreemption(configs.PartitionConfig{Preemption: configs.PartitionPreemptionConfig{Enabled: &True}})
+	assert.Assert(t, partition.isPreemptionEnabled(), "preeemption should be enabled by explicit true")
+
+	partition.updatePreemption(configs.PartitionConfig{Preemption: configs.PartitionPreemptionConfig{Enabled: &False}})
+	assert.Assert(t, !partition.isPreemptionEnabled(), "preeemption should be disabled by explicit false")
+}
+
 func TestUpdateNodeSortingPolicy(t *testing.T) {
 	partition, err := newBasePartition()
 	if err != nil {


### PR DESCRIPTION
### What is this PR for?
Added configuration `service.disablePreemption` which can be used to disable the preemption subsystem entirely when set to `true`.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2107

### How should this be tested?
Added unit tests.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
