### PR TITLE
[YUNIKORN-2087] reinstate node utilisation rest endpoint

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -1005,7 +1005,7 @@ func (r *Resource) DominantResourceType(capacity *Resource) string {
 	if r == nil || capacity == nil {
 		return ""
 	}
-	var div float64
+	var div, temp float64
 	dominant := ""
 	for name, usedVal := range r.Resources {
 		capVal, ok := capacity.Resources[name]
@@ -1015,15 +1015,20 @@ func (r *Resource) DominantResourceType(capacity *Resource) string {
 			continue
 		}
 		// calculate the ratio between usage and capacity
-		// filter out 0 just to be safe should never happen: make it fully used
+		// ratio should be somewhere between 0 and 1, but do not restrict
+		// handle 0 values specifically just to be safe should never happen
 		if capVal == 0 {
-			capVal = usedVal
+			if usedVal == 0 {
+				temp = 0 // no usage, no cap: consider empty
+			} else {
+				temp = 1 // usage, no cap: fully used
+			}
+		} else {
+			temp = float64(usedVal) / float64(capVal) // both not zero calculate ratio
 		}
-		// ratio should be somewhere between 0 and 1
 		// if we have exactly the same use the latest one
-		temp := float64(usedVal) / float64(capVal)
 		if temp >= div {
-			div = float64(usedVal) / float64(capVal)
+			div = temp
 			dominant = name
 		}
 	}

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -1701,3 +1701,29 @@ func TestIsEmpty(t *testing.T) {
 		})
 	}
 }
+
+func TestResource_DominantResource(t *testing.T) {
+	tests := []struct {
+		name     string
+		used     *Resource
+		capacity *Resource
+		wantName string
+	}{
+		{"nil receiver", nil, Zero, ""},
+		{"nil cap", Zero, nil, ""},
+		{"zero cap", NewResourceFromMap(map[string]Quantity{"A": 10}), Zero, ""},
+		{"over cap", NewResourceFromMap(map[string]Quantity{"A": 20}), NewResourceFromMap(map[string]Quantity{"A": 10}), "A"},
+		{"zero usage exist", NewResourceFromMap(map[string]Quantity{"A": 0}), NewResourceFromMap(map[string]Quantity{"A": 10}), "A"},
+		{"usage not in cap", NewResourceFromMap(map[string]Quantity{"B": 10}), NewResourceFromMap(map[string]Quantity{"A": 10}), ""},
+		{"multiple usages", NewResourceFromMap(map[string]Quantity{"B": 10, "A": 10}), NewResourceFromMap(map[string]Quantity{"A": 10, "B": 20}), "A"},
+		{"0 usage with 0 cap", NewResourceFromMap(map[string]Quantity{"A": 0}), NewResourceFromMap(map[string]Quantity{"A": 0}), "A"},
+		{"usage with 0 cap", NewResourceFromMap(map[string]Quantity{"A": 10, "B": 5}), NewResourceFromMap(map[string]Quantity{"A": 0, "B": 10}), "A"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.used.DominantResourceType(tt.capacity); got != tt.wantName {
+				t.Errorf("DominantResourceType() = %v, want %v", got, tt.wantName)
+			}
+		})
+	}
+}

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -757,6 +757,7 @@ func TestGetNodeUtilisation(t *testing.T) {
 	getNodeUtilisation(resp, req)
 	utilisation = &dao.NodesUtilDAOInfo{}
 	err = json.Unmarshal(resp.outputBytes, utilisation)
+	assert.NilError(t, err, "getNodeUtilisation should have returned an object")
 	assert.Equal(t, utilisation.ResourceType, "", "unexpected type returned")
 	assert.Equal(t, len(utilisation.NodesUtil), 10, "empty usage: unexpected bucket count returned")
 	assert.Assert(t, confirmNodeCount(utilisation.NodesUtil, 0), "unexpected number of nodes returned should be 2")
@@ -772,6 +773,7 @@ func TestGetNodeUtilisation(t *testing.T) {
 	getNodeUtilisation(resp, req)
 	utilisation = &dao.NodesUtilDAOInfo{}
 	err = json.Unmarshal(resp.outputBytes, utilisation)
+	assert.NilError(t, err, "getNodeUtilisation should have returned an object")
 	assert.Equal(t, utilisation.ResourceType, "first", "expected first as type returned")
 	assert.Equal(t, len(utilisation.NodesUtil), 10, "empty usage: unexpected bucket count returned")
 	assert.Assert(t, confirmNodeCount(utilisation.NodesUtil, 2), "unexpected number of nodes returned should be 2")
@@ -787,6 +789,7 @@ func TestGetNodeUtilisation(t *testing.T) {
 	getNodeUtilisation(resp, req)
 	utilisation = &dao.NodesUtilDAOInfo{}
 	err = json.Unmarshal(resp.outputBytes, utilisation)
+	assert.NilError(t, err, "getNodeUtilisation should have returned an object")
 	assert.Equal(t, utilisation.ResourceType, "second", "expected second as type returned")
 	assert.Equal(t, len(utilisation.NodesUtil), 10, "empty usage: unexpected bucket count returned")
 	assert.Assert(t, confirmNodeCount(utilisation.NodesUtil, 1), "unexpected number of nodes returned should be 1")

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -661,11 +661,14 @@ func TestGetNodesUtilJSON(t *testing.T) {
 
 	// create test nodes
 	nodeRes := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000}).ToProto()
-	nodeRes2 := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000, "GPU": 10}).ToProto()
 	node1ID := "node-1"
 	node1 := objects.NewNode(&si.NodeInfo{NodeID: node1ID, SchedulableResource: nodeRes})
 	node2ID := "node-2"
+	nodeRes2 := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000, "GPU": 10}).ToProto()
 	node2 := objects.NewNode(&si.NodeInfo{NodeID: node2ID, SchedulableResource: nodeRes2})
+	node3ID := "node-3"
+	nodeCPU := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1000}).ToProto()
+	node3 := objects.NewNode(&si.NodeInfo{NodeID: node3ID, SchedulableResource: nodeCPU})
 
 	// create test allocations
 	resAlloc1 := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 500, siCommon.CPU: 300})
@@ -678,36 +681,123 @@ func TestGetNodesUtilJSON(t *testing.T) {
 	allocs = []*objects.Allocation{objects.NewAllocation("alloc-2-uuid", node2ID, ask2)}
 	err = partition.AddNode(node2, allocs)
 	assert.NilError(t, err, "add node to partition should not have failed")
+	err = partition.AddNode(node3, nil)
+	assert.NilError(t, err, "add node to partition should not have failed")
+
+	// two nodes advertise memory: must show up in the list
+	result := getNodesUtilJSON(partition, siCommon.Memory)
+	subResult := result.NodesUtil
+	assert.Equal(t, result.ResourceType, siCommon.Memory)
+	assert.Equal(t, subResult[2].NumOfNodes, int64(1))
+	assert.Equal(t, subResult[4].NumOfNodes, int64(1))
+	assert.Equal(t, subResult[2].NodeNames[0], node2ID)
+	assert.Equal(t, subResult[4].NodeNames[0], node1ID)
+
+	// three nodes advertise cpu: must show up in the list
+	result = getNodesUtilJSON(partition, siCommon.CPU)
+	subResult = result.NodesUtil
+	assert.Equal(t, result.ResourceType, siCommon.CPU)
+	assert.Equal(t, subResult[0].NumOfNodes, int64(1))
+	assert.Equal(t, subResult[0].NodeNames[0], node3ID)
+	assert.Equal(t, subResult[2].NumOfNodes, int64(1))
+	assert.Equal(t, subResult[2].NodeNames[0], node1ID)
+	assert.Equal(t, subResult[4].NumOfNodes, int64(1))
+	assert.Equal(t, subResult[4].NodeNames[0], node2ID)
+
+	// one node advertise GPU: must show up in the list
+	result = getNodesUtilJSON(partition, "GPU")
+	subResult = result.NodesUtil
+	assert.Equal(t, result.ResourceType, "GPU")
+	assert.Equal(t, subResult[4].NumOfNodes, int64(1))
+	assert.Equal(t, subResult[4].NodeNames[0], node2ID)
+
+	result = getNodesUtilJSON(partition, "non-exist")
+	subResult = result.NodesUtil
+	assert.Equal(t, result.ResourceType, "non-exist")
+	assert.Equal(t, subResult[0].NumOfNodes, int64(0))
+	assert.Equal(t, len(subResult[0].NodeNames), 0)
+}
+
+func TestGetNodeUtilisation(t *testing.T) {
+	NewWebApp(&scheduler.ClusterContext{}, nil)
+
+	// var req *http.Request
+	req, err := http.NewRequest("GET", "/ws/v1/scheduler/node-utilization", strings.NewReader(""))
+	assert.NilError(t, err, "Get node utilisation Handler request failed")
+	req = req.WithContext(context.TODO())
+	resp := &MockResponseWriter{}
+
+	getNodeUtilisation(resp, req)
+	var errInfo dao.YAPIError
+	err = json.Unmarshal(resp.outputBytes, &errInfo)
+	assert.NilError(t, err, "getNodeUtilisation should have returned and error")
+
+	partition := setup(t, configDefault, 1)
+	utilisation := &dao.NodesUtilDAOInfo{}
+	err = json.Unmarshal(resp.outputBytes, utilisation)
+	assert.NilError(t, err, "getNodeUtilisation should have returned an empty object")
+	assert.Equal(t, utilisation.ResourceType, "", "unexpected type returned")
+	assert.Equal(t, len(utilisation.NodesUtil), 0, "no nodes should be returned")
+	assert.Assert(t, confirmNodeCount(utilisation.NodesUtil, 0), "unexpected number of nodes returned should be 0")
+
+	// create test nodes
+	nodeRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10}).ToProto()
+	nodeRes2 := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "second": 5}).ToProto()
+	node1ID := "node-1"
+	node1 := objects.NewNode(&si.NodeInfo{NodeID: node1ID, SchedulableResource: nodeRes})
+	node2ID := "node-2"
+	node2 := objects.NewNode(&si.NodeInfo{NodeID: node2ID, SchedulableResource: nodeRes2})
+
+	err = partition.AddNode(node1, nil)
+	assert.NilError(t, err, "add node to partition should not have failed")
+	err = partition.AddNode(node2, nil)
+	assert.NilError(t, err, "add node to partition should not have failed")
 
 	// get nodes utilization
-	res1 := getNodesUtilJSON(partition, siCommon.Memory)
-	res2 := getNodesUtilJSON(partition, siCommon.CPU)
-	res3 := getNodesUtilJSON(partition, "GPU")
-	resNon := getNodesUtilJSON(partition, "non-exist")
-	subres1 := res1.NodesUtil
-	subres2 := res2.NodesUtil
-	subres3 := res3.NodesUtil
-	subresNon := resNon.NodesUtil
+	getNodeUtilisation(resp, req)
+	utilisation = &dao.NodesUtilDAOInfo{}
+	err = json.Unmarshal(resp.outputBytes, utilisation)
+	assert.Equal(t, utilisation.ResourceType, "", "unexpected type returned")
+	assert.Equal(t, len(utilisation.NodesUtil), 10, "empty usage: unexpected bucket count returned")
+	assert.Assert(t, confirmNodeCount(utilisation.NodesUtil, 0), "unexpected number of nodes returned should be 2")
 
-	assert.Equal(t, res1.ResourceType, siCommon.Memory)
-	assert.Equal(t, subres1[2].NumOfNodes, int64(1))
-	assert.Equal(t, subres1[4].NumOfNodes, int64(1))
-	assert.Equal(t, subres1[2].NodeNames[0], node2ID)
-	assert.Equal(t, subres1[4].NodeNames[0], node1ID)
+	resAlloc := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
+	ask := objects.NewAllocationAsk("alloc-1", "app", resAlloc)
+	alloc := objects.NewAllocation("alloc-1-uuid", node1ID, ask)
+	assert.Assert(t, node1.AddAllocation(alloc), "unexpected failure adding allocation to node")
+	rootQ := partition.GetQueue("root")
+	err = rootQ.IncAllocatedResource(resAlloc, false)
+	assert.NilError(t, err, "unexpected error returned setting allocated resource on queue")
+	// get nodes utilization
+	getNodeUtilisation(resp, req)
+	utilisation = &dao.NodesUtilDAOInfo{}
+	err = json.Unmarshal(resp.outputBytes, utilisation)
+	assert.Equal(t, utilisation.ResourceType, "first", "expected first as type returned")
+	assert.Equal(t, len(utilisation.NodesUtil), 10, "empty usage: unexpected bucket count returned")
+	assert.Assert(t, confirmNodeCount(utilisation.NodesUtil, 2), "unexpected number of nodes returned should be 2")
 
-	assert.Equal(t, res2.ResourceType, siCommon.CPU)
-	assert.Equal(t, subres2[2].NumOfNodes, int64(1))
-	assert.Equal(t, subres2[4].NumOfNodes, int64(1))
-	assert.Equal(t, subres2[2].NodeNames[0], node1ID)
-	assert.Equal(t, subres2[4].NodeNames[0], node2ID)
+	// make second type dominant by using all
+	resAlloc = resources.NewResourceFromMap(map[string]resources.Quantity{"second": 5})
+	ask = objects.NewAllocationAsk("alloc-2", "app", resAlloc)
+	alloc = objects.NewAllocation("alloc-2-uuid", node2ID, ask)
+	assert.Assert(t, node2.AddAllocation(alloc), "unexpected failure adding allocation to node")
+	err = rootQ.IncAllocatedResource(resAlloc, false)
+	assert.NilError(t, err, "unexpected error returned setting allocated resource on queue")
+	// get nodes utilization
+	getNodeUtilisation(resp, req)
+	utilisation = &dao.NodesUtilDAOInfo{}
+	err = json.Unmarshal(resp.outputBytes, utilisation)
+	assert.Equal(t, utilisation.ResourceType, "second", "expected second as type returned")
+	assert.Equal(t, len(utilisation.NodesUtil), 10, "empty usage: unexpected bucket count returned")
+	assert.Assert(t, confirmNodeCount(utilisation.NodesUtil, 1), "unexpected number of nodes returned should be 1")
+}
 
-	assert.Equal(t, res3.ResourceType, "GPU")
-	assert.Equal(t, subres3[4].NumOfNodes, int64(1))
-	assert.Equal(t, subres3[4].NodeNames[0], node2ID)
-
-	assert.Equal(t, resNon.ResourceType, "non-exist")
-	assert.Equal(t, subresNon[0].NumOfNodes, int64(0))
-	assert.Equal(t, len(subresNon[0].NodeNames), 0)
+func confirmNodeCount(info []*dao.NodeUtilDAOInfo, count int64) bool {
+	var total int64
+	for _, node := range info {
+		total += node.NumOfNodes
+	}
+	return total == count
 }
 
 func addAndConfirmApplicationExists(t *testing.T, partitionName string, partition *scheduler.PartitionContext, appName string) *objects.Application {

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -760,7 +760,7 @@ func TestGetNodeUtilisation(t *testing.T) {
 	assert.NilError(t, err, "getNodeUtilisation should have returned an object")
 	assert.Equal(t, utilisation.ResourceType, "", "unexpected type returned")
 	assert.Equal(t, len(utilisation.NodesUtil), 10, "empty usage: unexpected bucket count returned")
-	assert.Assert(t, confirmNodeCount(utilisation.NodesUtil, 0), "unexpected number of nodes returned should be 2")
+	assert.Assert(t, confirmNodeCount(utilisation.NodesUtil, 0), "unexpected number of nodes returned should be 0")
 
 	resAlloc := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
 	ask := objects.NewAllocationAsk("alloc-1", "app", resAlloc)

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -253,4 +253,10 @@ var webRoutes = routes{
 		"/ws/v1/scheduler/healthcheck",
 		checkHealthStatus,
 	},
+	route{
+		"Scheduler",
+		"GET",
+		"/ws/v1/scheduler/node-utilization",
+		getNodeUtilisation,
+	},
 }

--- a/pkg/webservice/webservice.go
+++ b/pkg/webservice/webservice.go
@@ -20,6 +20,7 @@ package webservice
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -60,6 +61,7 @@ func loggingHandler(inner http.Handler, name string) http.HandlerFunc {
 	}
 }
 
+// StartWebApp starts the web app on the default port.
 // TODO we need the port to be configurable
 func (m *WebService) StartWebApp() {
 	router := newRouter()
@@ -68,7 +70,7 @@ func (m *WebService) StartWebApp() {
 	log.Log(log.REST).Info("web-app started", zap.Int("port", 9080))
 	go func() {
 		httpError := m.httpServer.ListenAndServe()
-		if httpError != nil && httpError != http.ErrServerClosed {
+		if httpError != nil && !errors.Is(httpError, http.ErrServerClosed) {
 			log.Log(log.REST).Error("HTTP serving error",
 				zap.Error(httpError))
 		}


### PR DESCRIPTION
### What is this PR for?
The node utilisation endpoint is required to be exposed for the dashboard to work after YUNIKORN-325
Moving the endpoint to /ws/v1/scheduler/node-utilization The endpoint will need to change as part of YUNIKORN-2088

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-2087

### How should this be tested?
Dashboard fails to show without the fix
Deploy YuniKorn from master with the web UI from master needs to include fix from YUNIKORN-2087 also: dashboard works

### Screenshots (if appropriate)
NA