### PR TITLE
[YUNIKORN-2120] Fix incorrect error message when check maxApplications in configValidator

### DIFF
--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -213,7 +213,7 @@ func checkQueueMaxApplications(cur QueueConfig) error {
 	var err error
 	for _, child := range cur.Queues {
 		if cur.MaxApplications != 0 && (cur.MaxApplications < child.MaxApplications || child.MaxApplications == 0) {
-			return fmt.Errorf("parent maxRunningApps must be larger than child maxRunningApps")
+			return fmt.Errorf("parent maxApplications must be larger than child maxApplications")
 		}
 		err = checkQueueMaxApplications(child)
 		if err != nil {


### PR DESCRIPTION
### What is this PR for?
The error message use terms maxRunningApps when setup incorrect maxapplications in ConfigMap. Would be more explicit if we replace `maxRunningApps` with `maxApplications`.
```
error: configmaps "yunikorn-configs" could not be patched: admission webhook "admission-webhook.yunikorn.validate-conf" denied the request: parent maxRunningApps must be larger than child maxRunningApps
```

### What type of PR is it?
* [x] - Improvement

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2120

### How should this be tested?
N/A

### Screenshots (if appropriate)
N/A

### Questions:
N/A