### PR TITLE
[YUNIKORN-2124] Fix incorrect test in queue_test.go#TestNewConfiguredQueue

### DIFF
--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -2222,23 +2222,18 @@ func TestNewConfiguredQueue(t *testing.T) {
 	assert.Assert(t, resources.Equals(resourceStruct, parent.template.GetMaxResource()))
 	assert.Assert(t, resources.Equals(resourceStruct, parent.template.GetGuaranteedResource()))
 
-	// case 0: leaf can use template
+	// case 0: managed leaf queue can't use template
 	leafConfig := configs.QueueConfig{
-		Name:       "leaf_queue",
-		Parent:     false,
-		Properties: getProperties(),
-		Resources: configs.Resources{
-			Max:        getResourceConf(),
-			Guaranteed: getResourceConf(),
-		},
+		Name:   "leaf_queue",
+		Parent: false,
 	}
 	childLeaf, err := NewConfiguredQueue(leafConfig, parent)
 	assert.NilError(t, err, "failed to create queue: %v", err)
 	assert.Equal(t, childLeaf.QueuePath, "parent_queue.leaf_queue")
 	assert.Assert(t, childLeaf.template == nil)
-	assert.DeepEqual(t, childLeaf.properties, parent.template.GetProperties())
-	assert.Assert(t, resources.Equals(childLeaf.maxResource, parent.template.GetMaxResource()))
-	assert.Assert(t, resources.Equals(childLeaf.guaranteedResource, parent.template.GetGuaranteedResource()))
+	assert.Assert(t, !reflect.DeepEqual(childLeaf.properties, parent.template.GetProperties()))
+	assert.Assert(t, !resources.Equals(childLeaf.maxResource, parent.template.GetMaxResource()))
+	assert.Assert(t, !resources.Equals(childLeaf.guaranteedResource, parent.template.GetGuaranteedResource()))
 
 	// case 1: non-leaf can't use template but it can inherit template from parent
 	NonLeafConfig := configs.QueueConfig{

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -2224,16 +2224,25 @@ func TestNewConfiguredQueue(t *testing.T) {
 
 	// case 0: managed leaf queue can't use template
 	leafConfig := configs.QueueConfig{
-		Name:   "leaf_queue",
-		Parent: false,
+		Name:       "leaf_queue",
+		Parent:     false,
+		Properties: getProperties(),
+		Resources: configs.Resources{
+			Max:        getResourceConf(),
+			Guaranteed: getResourceConf(),
+		},
 	}
 	childLeaf, err := NewConfiguredQueue(leafConfig, parent)
 	assert.NilError(t, err, "failed to create queue: %v", err)
 	assert.Equal(t, childLeaf.QueuePath, "parent_queue.leaf_queue")
 	assert.Assert(t, childLeaf.template == nil)
-	assert.Assert(t, !reflect.DeepEqual(childLeaf.properties, parent.template.GetProperties()))
-	assert.Assert(t, !resources.Equals(childLeaf.maxResource, parent.template.GetMaxResource()))
-	assert.Assert(t, !resources.Equals(childLeaf.guaranteedResource, parent.template.GetGuaranteedResource()))
+	assert.Assert(t, reflect.DeepEqual(childLeaf.properties, leafConfig.Properties))
+	childLeafMax, err := resources.NewResourceFromConf(leafConfig.Resources.Max)
+	assert.NilError(t, err, "Resource creation failed")
+	assert.Assert(t, resources.Equals(childLeaf.maxResource, childLeafMax))
+	childLeafGuaranteed, err := resources.NewResourceFromConf(leafConfig.Resources.Guaranteed)
+	assert.NilError(t, err, "Resource creation failed")
+	assert.Assert(t, resources.Equals(childLeaf.guaranteedResource, childLeafGuaranteed))
 
 	// case 1: non-leaf can't use template but it can inherit template from parent
 	NonLeafConfig := configs.QueueConfig{


### PR DESCRIPTION
### What is this PR for?
in unit test queue_test.go#TestNewConfiguredQueue

`// case 0: leaf can use template`
https://github.com/apache/yunikorn-core/blob/284cc92974a7330c95ad3c6ecdf05ea68b9eee9d/pkg/scheduler/objects/queue_test.go#L2225-L2226

This test is flawed as it erroneously allows managed leaf queues to utilize child template and it consistently passes because the `getResourceConf` and `getProperties` lack the required randomness.

### What type of PR is it?
* [x] - Bug Fix

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2124

### How should this be tested?
covered by unit test

### Screenshots (if appropriate)
N/A

### Questions:
N/A