### PR TITLE
[YUNIKORN-2033] Add MaxApplications in Template

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -208,6 +208,7 @@ func newDynamicQueueInternal(name string, leaf bool, parent *Queue) (*Queue, err
 
 // applyTemplate uses input template to initialize properties, maxResource, and guaranteedResource
 func (sq *Queue) applyTemplate(childTemplate *template.Template) {
+	sq.maxRunningApps = childTemplate.GetMaxApplications()
 	sq.properties = childTemplate.GetProperties()
 	// the resources in template are already checked
 	sq.guaranteedResource = childTemplate.GetGuaranteedResource()

--- a/pkg/scheduler/objects/template/template.go
+++ b/pkg/scheduler/objects/template/template.go
@@ -25,6 +25,7 @@ import (
 )
 
 type Template struct {
+	maxApplications    uint64
 	properties         map[string]string
 	maxResource        *resources.Resource
 	guaranteedResource *resources.Resource
@@ -44,7 +45,7 @@ func FromConf(template *configs.ChildTemplate) (*Template, error) {
 		return true
 	}
 
-	if template == nil || (isMapEmpty(template.Properties) && isMapEmpty(template.Resources.Guaranteed) && isMapEmpty(template.Resources.Max)) {
+	if template == nil || (template.MaxApplications == 0 && isMapEmpty(template.Properties) && isMapEmpty(template.Resources.Guaranteed) && isMapEmpty(template.Resources.Max)) {
 		return nil, nil
 	}
 
@@ -58,11 +59,12 @@ func FromConf(template *configs.ChildTemplate) (*Template, error) {
 		return nil, err
 	}
 
-	return newTemplate(template.Properties, maxResource, guaranteedResource), nil
+	return newTemplate(template.MaxApplications, template.Properties, maxResource, guaranteedResource), nil
 }
 
-func newTemplate(properties map[string]string, maxResource *resources.Resource, guaranteedResource *resources.Resource) *Template {
+func newTemplate(maxApplications uint64, properties map[string]string, maxResource *resources.Resource, guaranteedResource *resources.Resource) *Template {
 	template := &Template{
+		maxApplications:    maxApplications,
 		properties:         make(map[string]string),
 		maxResource:        nil,
 		guaranteedResource: nil,
@@ -82,6 +84,11 @@ func newTemplate(properties map[string]string, maxResource *resources.Resource, 
 		}
 	}
 	return template
+}
+
+// GetMaxApplications returns max applications.
+func (t *Template) GetMaxApplications() uint64 {
+	return t.maxApplications
 }
 
 // GetProperties returns a copy of properties. An empty map replaces the null value
@@ -115,6 +122,7 @@ func (t *Template) GetTemplateInfo() *dao.TemplateInfo {
 		return nil
 	}
 	return &dao.TemplateInfo{
+		MaxApplications:    t.GetMaxApplications(),
 		Properties:         t.GetProperties(),
 		MaxResource:        t.maxResource.DAOMap(),
 		GuaranteedResource: t.guaranteedResource.DAOMap(),

--- a/pkg/scheduler/objects/template/template.go
+++ b/pkg/scheduler/objects/template/template.go
@@ -35,17 +35,7 @@ type Template struct {
 // It returns error if it fails to parse configs.
 // It returns nil value if the configs.ChildTemplate is empty
 func FromConf(template *configs.ChildTemplate) (*Template, error) {
-	// A non-empty list of empty property values is also empty
-	isMapEmpty := func(m map[string]string) bool {
-		for k, v := range m {
-			if k != "" && v != "" {
-				return false
-			}
-		}
-		return true
-	}
-
-	if template == nil || (template.MaxApplications == 0 && isMapEmpty(template.Properties) && isMapEmpty(template.Resources.Guaranteed) && isMapEmpty(template.Resources.Max)) {
+	if template == nil || isChildTemplateEmpty(template) {
 		return nil, nil
 	}
 
@@ -60,6 +50,23 @@ func FromConf(template *configs.ChildTemplate) (*Template, error) {
 	}
 
 	return newTemplate(template.MaxApplications, template.Properties, maxResource, guaranteedResource), nil
+}
+
+func isChildTemplateEmpty(template *configs.ChildTemplate) bool {
+	return template.MaxApplications == 0 &&
+		isMapEmpty(template.Properties) &&
+		isMapEmpty(template.Resources.Guaranteed) &&
+		isMapEmpty(template.Resources.Max)
+}
+
+// A non-empty list of empty property values is also empty
+func isMapEmpty(m map[string]string) bool {
+	for k, v := range m {
+		if k != "" && v != "" {
+			return false
+		}
+	}
+	return true
 }
 
 func newTemplate(maxApplications uint64, properties map[string]string, maxResource *resources.Resource, guaranteedResource *resources.Resource) *Template {

--- a/pkg/scheduler/objects/template/template_test.go
+++ b/pkg/scheduler/objects/template/template_test.go
@@ -48,13 +48,15 @@ func getResource(t *testing.T) *resources.Resource {
 	return r
 }
 
-func checkMembers(t *testing.T, template *Template, properties map[string]string, maxResource *resources.Resource, guaranteedResource *resources.Resource) {
+func checkMembers(t *testing.T, template *Template, maxApplications uint64, properties map[string]string, maxResource *resources.Resource, guaranteedResource *resources.Resource) {
 	// test inner members
+	assert.Equal(t, template.maxApplications, maxApplications)
 	assert.DeepEqual(t, template.properties, properties)
 	assert.DeepEqual(t, template.maxResource, maxResource)
 	assert.DeepEqual(t, template.guaranteedResource, guaranteedResource)
 
 	// test all getters
+	assert.Equal(t, template.GetMaxApplications(), maxApplications)
 	assert.DeepEqual(t, template.GetProperties(), properties)
 	assert.DeepEqual(t, template.GetMaxResource(), maxResource)
 	assert.DeepEqual(t, template.GetGuaranteedResource(), guaranteedResource)
@@ -64,18 +66,21 @@ func TestNewTemplate(t *testing.T) {
 	properties := getProperties()
 	guaranteedResource := getResource(t)
 	maxResource := getResource(t)
+	maxApplications := uint64(1)
 
-	checkMembers(t, newTemplate(properties, maxResource, guaranteedResource), properties, maxResource, guaranteedResource)
+	checkMembers(t, newTemplate(maxApplications, properties, maxResource, guaranteedResource), maxApplications, properties, maxResource, guaranteedResource)
 }
 
 func TestFromConf(t *testing.T) {
+	maxApplications := uint64(1)
 	properties := getProperties()
 	guaranteedResourceConf := getResourceConf()
 	maxResourceConf := getResourceConf()
 
 	// case 0: normal case
 	template, err := FromConf(&configs.ChildTemplate{
-		Properties: properties,
+		MaxApplications: maxApplications,
+		Properties:      properties,
 		Resources: configs.Resources{
 			Max:        maxResourceConf,
 			Guaranteed: guaranteedResourceConf,
@@ -87,7 +92,7 @@ func TestFromConf(t *testing.T) {
 	assert.NilError(t, err, "failed to parse resource: %v", err)
 	guaranteedResource, err := resources.NewResourceFromConf(guaranteedResourceConf)
 	assert.NilError(t, err, "failed to parse resource: %v", err)
-	checkMembers(t, template, properties, maxResource, guaranteedResource)
+	checkMembers(t, template, maxApplications, properties, maxResource, guaranteedResource)
 
 	// case 1: empty map produces nil template
 	empty0, err := FromConf(&configs.ChildTemplate{

--- a/pkg/webservice/dao/queue_info.go
+++ b/pkg/webservice/dao/queue_info.go
@@ -18,6 +18,7 @@ limitations under the License.
 package dao
 
 type TemplateInfo struct {
+	MaxApplications    uint64            `json:"maxApplications,omitempty"`
 	MaxResource        map[string]int64  `json:"maxResource,omitempty"`
 	GuaranteedResource map[string]int64  `json:"guaranteedResource,omitempty"`
 	Properties         map[string]string `json:"properties,omitempty"`

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -154,6 +154,7 @@ partitions:
         properties:
           application.sort.policy: stateaware
         childtemplate:
+          maxapplications: 10
           properties:
             application.sort.policy: stateaware
           resources:
@@ -943,6 +944,7 @@ func TestGetPartitionQueuesHandler(t *testing.T) {
 	assert.Equal(t, partitionQueuesDao.Children[2].Parent, "root")
 	assert.Equal(t, len(partitionQueuesDao.Properties), 1)
 	assert.Equal(t, partitionQueuesDao.Properties["application.sort.policy"], "stateaware")
+	assert.Equal(t, partitionQueuesDao.TemplateInfo.MaxApplications, uint64(10))
 	assert.Equal(t, len(partitionQueuesDao.TemplateInfo.Properties), 1)
 	assert.Equal(t, partitionQueuesDao.TemplateInfo.Properties["application.sort.policy"], "stateaware")
 


### PR DESCRIPTION
### What is this PR for?
This is a follow up in YUNIKORN-193.
Currently we leave MaxApplications in ChildTemplate while Template didn't use it.

### What type of PR is it?
* [x] - Improvement

### Todos
* [ ] - Add e2e tests for child template max applications in k8shim (will fire another jira after this pr merged)

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2033

### How should this be tested?
covered by unit tests

### Screenshots (if appropriate)
N/A

### Questions:
N/A