### PR TITLE
[YUNIKORN-2085] CurrentPriority field missing from Queues API respons…

### DIFF
--- a/pkg/webservice/dao/queue_info.go
+++ b/pkg/webservice/dao/queue_info.go
@@ -56,6 +56,6 @@ type PartitionQueueDAOInfo struct {
 	AbsUsedCapacity        map[string]int64        `json:"absUsedCapacity,omitempty"`
 	MaxRunningApps         uint64                  `json:"maxRunningApps,omitempty"`
 	RunningApps            uint64                  `json:"runningApps,omitempty"`
-	CurrentPriority        int32                   `json:"currentPriority,omitempty"`
+	CurrentPriority        int32                   `json:"currentPriority"` // no omitempty, as the current priority value may be 0, which is a valid priority level
 	AllocatingAcceptedApps []string                `json:"allocatingAcceptedApps,omitempty"`
 }


### PR DESCRIPTION
### What is this PR for?
The `CurrentPriority` field is currently tagged with "omitempty", which causes it to be omitted from json response when the value is 0. 

Omitting the field in this case could mislead consumers or cause potential errors when consuming the API, such as throwing exceptions upon finding the expected field missing from the response.
Removing omitempty ensures the field will always be included with its actual value, even if 0. This avoids situations where the field might be missing.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring


### What is the Jira issue?
https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-2085