### PR TITLE
[YUNIKORN-2127] fix stateAwareFilter

### DIFF
--- a/pkg/scheduler/objects/sorters_test.go
+++ b/pkg/scheduler/objects/sorters_test.go
@@ -385,6 +385,18 @@ func TestSortAppsStateAware(t *testing.T) {
 	assert.NilError(t, err, "state change failed for app-3")
 	list = sortApplications(input, policies.StateAwarePolicy, false, nil)
 	assertAppListLength(t, list, []string{appID0, appID1, appID3}, "state not app-2")
+
+	// move 3rd to starting: 1st, 3rd and 4th in that order
+	err = input[appID2].HandleApplicationEvent(RunApplication)
+	assert.NilError(t, err, "state change failed for app-2")
+	list = sortApplications(input, policies.StateAwarePolicy, false, nil)
+	assertAppListLength(t, list, []string{appID0, appID2, appID3}, "state not app-1")
+
+	// move 2nd to starting: 1st, 2nd and 4th in that order
+	err = input[appID1].HandleApplicationEvent(RunApplication)
+	assert.NilError(t, err, "state change failed for app-1")
+	list = sortApplications(input, policies.StateAwarePolicy, false, nil)
+	assertAppListLength(t, list, []string{appID0, appID1, appID3}, "state not app-2")
 }
 
 func queueNames(list []*Queue) string {


### PR DESCRIPTION
### What is this PR for?

In stateAwareFilter description, it only allows one (1) application with a state that is not running in the list of candidates. The non-running state can be Starting or Accepted. However, in the function, it can allow more than one starting application. We should either update the description or fix the function.


### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2127

### How should this be tested?

Covered by unit tests.
