### PR TITLE
[YUNIKORN-2126] Fixing gocritic lint issues

### DIFF
--- a/cmd/schedulerclient/client.go
+++ b/cmd/schedulerclient/client.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"time"
@@ -35,6 +36,12 @@ const (
 )
 
 func main() {
+	if err := mainNoExit(); err != nil {
+		log.Fatalf("error: %v", err)
+	}
+}
+
+func mainNoExit() error {
 	// Set up a connection to the server.
 	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -47,13 +54,13 @@ func main() {
 	defer cancel()
 	_, err = c.RegisterResourceManager(ctx, &si.RegisterResourceManagerRequest{})
 	if err != nil {
-		log.Fatalf("could not greet: %v", err)
+		return fmt.Errorf("could not greet: %v", err)
 	}
 	log.Printf("Responded")
 
 	stream, err := c.UpdateAllocation(ctx)
 	if err != nil {
-		log.Fatalf("error on update: %v", err)
+		return fmt.Errorf("error on update: %v", err)
 	}
 	done := make(chan bool)
 
@@ -104,4 +111,5 @@ func main() {
 
 	<-done
 	log.Printf("Finished")
+	return nil
 }

--- a/cmd/schedulerclient/client.go
+++ b/cmd/schedulerclient/client.go
@@ -69,9 +69,9 @@ func main() {
 			log.Print("Send request")
 			time.Sleep(time.Millisecond * 100)
 		}
-		// if err := stream.CloseSend(); err != nil {
+		//if err := stream.CloseSend(); err != nil {
 		//   log.Println(err)
-		// }
+		//}
 	}()
 
 	// second goroutine receives data from stream

--- a/cmd/schedulerclient/client.go
+++ b/cmd/schedulerclient/client.go
@@ -36,12 +36,12 @@ const (
 )
 
 func main() {
-	if err := mainNoExit(); err != nil {
+	if err := runApp(); err != nil {
 		log.Fatalf("error: %v", err)
 	}
 }
 
-func mainNoExit() error {
+func runApp() error {
 	// Set up a connection to the server.
 	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -76,9 +76,6 @@ func mainNoExit() error {
 			log.Print("Send request")
 			time.Sleep(time.Millisecond * 100)
 		}
-		// if err := stream.CloseSend(); err != nil {
-		//   log.Println(err)
-		// }
 	}()
 
 	// second goroutine receives data from stream

--- a/cmd/schedulerclient/client.go
+++ b/cmd/schedulerclient/client.go
@@ -69,9 +69,9 @@ func main() {
 			log.Print("Send request")
 			time.Sleep(time.Millisecond * 100)
 		}
-		//if err := stream.CloseSend(); err != nil {
+		// if err := stream.CloseSend(); err != nil {
 		//   log.Println(err)
-		//}
+		// }
 	}()
 
 	// second goroutine receives data from stream

--- a/pkg/scheduler/placement/rule.go
+++ b/pkg/scheduler/placement/rule.go
@@ -121,5 +121,5 @@ func normalise(name string) string {
 
 // Replace all dots in the generated queue name before making it a fully qualified name.
 func replaceDot(name string) string {
-	return strings.Replace(name, configs.DOT, configs.DotReplace, -1)
+	return strings.ReplaceAll(name, configs.DOT, configs.DotReplace)
 }

--- a/pkg/scheduler/placement/rule.go
+++ b/pkg/scheduler/placement/rule.go
@@ -121,5 +121,5 @@ func normalise(name string) string {
 
 // Replace all dots in the generated queue name before making it a fully qualified name.
 func replaceDot(name string) string {
-	return strings.ReplaceAll(name, configs.DOT, configs.DotReplace)
+	return strings.Replace(name, configs.DOT, configs.DotReplace, -1)
 }


### PR DESCRIPTION
### What is this PR for?
Resolve gocritic lint issue:
1) commentFormatting: put a space between `//`
2) exitAfterDefer: log.Fatalf will exit, and `defer cancel()` will not run
3) use strings.ReplaceAll method in `strings.Replace(name, configs.DOT, configs.DotReplace, -1)`


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [x] - Refactoring

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2126

### How should this be tested?
I tested this locally with make test, but noticed there are no test for this package (2) 

### Screenshots (if appropriate)
n/a

### Questions:
n/a
