### PR TITLE
[YUNIKORN-2130] fix checkLimitResource

### DIFF
--- a/pkg/common/configs/configvalidator_test.go
+++ b/pkg/common/configs/configvalidator_test.go
@@ -872,6 +872,74 @@ func TestCheckLimitResource(t *testing.T) { //nolint:funlen
 			},
 			hasError: false,
 		},
+		{
+			name: "leaf queue user maxresources exceed grandparent queue user maxresources",
+			config: QueueConfig{
+				Name: "parent",
+				Limits: createLimitMaxResources(
+					map[string]map[string]string{
+						"test-user1": {"memory": "100"},
+						"test-user2": {"memory": "100"},
+					},
+					nil),
+				Queues: []QueueConfig{
+					{
+						Name: "child1",
+						Limits: createLimitMaxResources(
+							map[string]map[string]string{
+								"test-user1": {"memory": "50"},
+							},
+							nil),
+						Queues: []QueueConfig{
+							{
+								Name: "child2",
+								Limits: createLimitMaxResources(
+									map[string]map[string]string{
+										"test-user1": {"memory": "10"},
+										"test-user2": {"memory": "150"},
+									},
+									nil),
+							},
+						},
+					},
+				},
+			},
+			hasError: true,
+		},
+		{
+			name: "leaf queue group maxresources exceed grandparent queue group maxresources",
+			config: QueueConfig{
+				Name: "parent",
+				Limits: createLimitMaxResources(
+					nil,
+					map[string]map[string]string{
+						"test-group1": {"memory": "100"},
+						"test-group2": {"memory": "100"},
+					}),
+				Queues: []QueueConfig{
+					{
+						Name: "child1",
+						Limits: createLimitMaxResources(
+							nil,
+							map[string]map[string]string{
+								"test-group1": {"memory": "50"},
+							}),
+						Queues: []QueueConfig{
+							{
+								Name: "child2",
+								Limits: createLimitMaxResources(
+									nil,
+									map[string]map[string]string{
+										"test-group1": {"memory": "10"},
+										"test-group2": {"memory": "150"},
+									}),
+							},
+						},
+					},
+				},
+			},
+			hasError: true,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
### What is this PR for?

If there is missing limit in middle queue, the checkLimitResource doesn't populate parent limit to next level. Finally, we will fail to cover grandchild cases.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2130

### How should this be tested?

Covered by unit tests.
