### PR TITLE
[YUNIKORN-2137] Remove defer cleanup in checkLimits

### DIFF
--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -583,16 +583,6 @@ func checkLimits(limits []Limit, obj string, queue *QueueConfig) error {
 	existedUserName := make(map[string]bool)
 	existedGroupName := make(map[string]bool)
 
-	defer func() {
-		for k := range existedUserName {
-			delete(existedUserName, k)
-		}
-
-		for k := range existedGroupName {
-			delete(existedGroupName, k)
-		}
-	}()
-
 	for _, limit := range limits {
 		if err := checkLimit(limit, existedUserName, existedGroupName, queue); err != nil {
 			return err


### PR DESCRIPTION
### What is this PR for?
There're 2 defer function inside `checkLimits` ( `existedUserName` and `existedGroupName` ).  These variables will be GC after the goroutine leaves the function. So it's safe to remove them.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
[YUNIKORN-2137](https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-2137)

### How should this be tested?
The unit tests have passed.
