### PR TITLE
[YUNIKORN-2139] Move queuepath split from user and group trackers to …

### DIFF
--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -19,11 +19,9 @@
 package ugm
 
 import (
-	"strings"
 	"sync"
 
 	"github.com/apache/yunikorn-core/pkg/common"
-	"github.com/apache/yunikorn-core/pkg/common/configs"
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/webservice/dao"
 )
@@ -46,17 +44,17 @@ func newGroupTracker(group string) *GroupTracker {
 	return groupTracker
 }
 
-func (gt *GroupTracker) increaseTrackedResource(queuePath, applicationID string, usage *resources.Resource, user string) bool {
+func (gt *GroupTracker) increaseTrackedResource(hierarchy []string, applicationID string, usage *resources.Resource, user string) bool {
 	if gt == nil {
 		return true
 	}
 	gt.Lock()
 	defer gt.Unlock()
 	gt.applications[applicationID] = user
-	return gt.queueTracker.increaseTrackedResource(strings.Split(queuePath, configs.DOT), applicationID, group, usage)
+	return gt.queueTracker.increaseTrackedResource(hierarchy, applicationID, group, usage)
 }
 
-func (gt *GroupTracker) decreaseTrackedResource(queuePath, applicationID string, usage *resources.Resource, removeApp bool) (bool, bool) {
+func (gt *GroupTracker) decreaseTrackedResource(hierarchy []string, applicationID string, usage *resources.Resource, removeApp bool) (bool, bool) {
 	if gt == nil {
 		return false, true
 	}
@@ -65,7 +63,7 @@ func (gt *GroupTracker) decreaseTrackedResource(queuePath, applicationID string,
 	if removeApp {
 		delete(gt.applications, applicationID)
 	}
-	return gt.queueTracker.decreaseTrackedResource(strings.Split(queuePath, configs.DOT), applicationID, usage, removeApp)
+	return gt.queueTracker.decreaseTrackedResource(hierarchy, applicationID, usage, removeApp)
 }
 
 func (gt *GroupTracker) getTrackedApplications() map[string]string {
@@ -74,16 +72,16 @@ func (gt *GroupTracker) getTrackedApplications() map[string]string {
 	return gt.applications
 }
 
-func (gt *GroupTracker) setLimits(queuePath string, resource *resources.Resource, maxApps uint64) {
+func (gt *GroupTracker) setLimits(hierarchy []string, resource *resources.Resource, maxApps uint64) {
 	gt.Lock()
 	defer gt.Unlock()
-	gt.queueTracker.setLimit(strings.Split(queuePath, configs.DOT), resource, maxApps)
+	gt.queueTracker.setLimit(hierarchy, resource, maxApps)
 }
 
-func (gt *GroupTracker) headroom(queuePath string) *resources.Resource {
+func (gt *GroupTracker) headroom(hierarchy []string) *resources.Resource {
 	gt.Lock()
 	defer gt.Unlock()
-	return gt.queueTracker.headroom(strings.Split(queuePath, configs.DOT), group)
+	return gt.queueTracker.headroom(hierarchy, group)
 }
 
 func (gt *GroupTracker) GetGroupResourceUsageDAOInfo() *dao.GroupResourceUsageDAOInfo {
@@ -100,22 +98,22 @@ func (gt *GroupTracker) GetGroupResourceUsageDAOInfo() *dao.GroupResourceUsageDA
 	return groupResourceUsage
 }
 
-func (gt *GroupTracker) IsQueuePathTrackedCompletely(queuePath string) bool {
+func (gt *GroupTracker) IsQueuePathTrackedCompletely(hierarchy []string) bool {
 	gt.RLock()
 	defer gt.RUnlock()
-	return gt.queueTracker.IsQueuePathTrackedCompletely(strings.Split(queuePath, configs.DOT))
+	return gt.queueTracker.IsQueuePathTrackedCompletely(hierarchy)
 }
 
-func (gt *GroupTracker) IsUnlinkRequired(queuePath string) bool {
+func (gt *GroupTracker) IsUnlinkRequired(hierarchy []string) bool {
 	gt.RLock()
 	defer gt.RUnlock()
-	return gt.queueTracker.IsUnlinkRequired(strings.Split(queuePath, configs.DOT))
+	return gt.queueTracker.IsUnlinkRequired(hierarchy)
 }
 
-func (gt *GroupTracker) UnlinkQT(queuePath string) bool {
+func (gt *GroupTracker) UnlinkQT(hierarchy []string) bool {
 	gt.RLock()
 	defer gt.RUnlock()
-	return gt.queueTracker.UnlinkQT(strings.Split(queuePath, configs.DOT))
+	return gt.queueTracker.UnlinkQT(hierarchy)
 }
 
 func (gt *GroupTracker) canBeRemoved() bool {
@@ -131,13 +129,13 @@ func (gt *GroupTracker) getName() string {
 	return gt.groupName
 }
 
-func (gt *GroupTracker) decreaseAllTrackedResourceUsage(queuePath string) map[string]string {
+func (gt *GroupTracker) decreaseAllTrackedResourceUsage(hierarchy []string) map[string]string {
 	if gt == nil {
 		return nil
 	}
 	gt.Lock()
 	defer gt.Unlock()
-	applications := gt.queueTracker.decreaseTrackedResourceUsageDownwards(strings.Split(queuePath, configs.DOT))
+	applications := gt.queueTracker.decreaseTrackedResourceUsageDownwards(hierarchy)
 	removedApplications := make(map[string]string)
 	for app := range applications {
 		if u, ok := gt.applications[app]; ok {
@@ -147,8 +145,8 @@ func (gt *GroupTracker) decreaseAllTrackedResourceUsage(queuePath string) map[st
 	return removedApplications
 }
 
-func (gt *GroupTracker) canRunApp(queuePath, applicationID string) bool {
+func (gt *GroupTracker) canRunApp(hierarchy []string, applicationID string) bool {
 	gt.Lock()
 	defer gt.Unlock()
-	return gt.queueTracker.canRunApp(strings.Split(queuePath, configs.DOT), applicationID, group)
+	return gt.queueTracker.canRunApp(hierarchy, applicationID, group)
 }

--- a/pkg/scheduler/ugm/group_tracker_test.go
+++ b/pkg/scheduler/ugm/group_tracker_test.go
@@ -40,36 +40,36 @@ func TestGTIncreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
 	}
-	result := groupTracker.increaseTrackedResource(queuePath1, TestApp1, usage1, user.User)
+	result := groupTracker.increaseTrackedResource(hierarchy1, TestApp1, usage1, user.User)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, usage1)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy1, TestApp1, usage1)
 	}
 
 	usage2, err := resources.NewResourceFromConf(map[string]string{"mem": "20M", "vcore": "20"})
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage2)
 	}
-	result = groupTracker.increaseTrackedResource(queuePath2, TestApp2, usage2, user.User)
+	result = groupTracker.increaseTrackedResource(hierarchy2, TestApp2, usage2, user.User)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath2, TestApp2, usage2)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy2, TestApp2, usage2)
 	}
 
 	usage3, err := resources.NewResourceFromConf(map[string]string{"mem": "30M", "vcore": "30"})
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
-	result = groupTracker.increaseTrackedResource(queuePath3, TestApp3, usage3, user.User)
+	result = groupTracker.increaseTrackedResource(hierarchy3, TestApp3, usage3, user.User)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath3, TestApp3, usage3)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy3, TestApp3, usage3)
 	}
 
 	usage4, err := resources.NewResourceFromConf(map[string]string{"mem": "20M", "vcore": "20"})
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
-	result = groupTracker.increaseTrackedResource(queuePath4, TestApp4, usage4, user.User)
+	result = groupTracker.increaseTrackedResource(hierarchy4, TestApp4, usage4, user.User)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath4, TestApp4, usage4)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy4, TestApp4, usage4)
 	}
 	actualResources := getGroupResource(groupTracker)
 
@@ -94,9 +94,9 @@ func TestGTDecreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
 	}
-	result := groupTracker.increaseTrackedResource(queuePath1, TestApp1, usage1, user.User)
+	result := groupTracker.increaseTrackedResource(hierarchy1, TestApp1, usage1, user.User)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, usage1)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy1, TestApp1, usage1)
 	}
 	assert.Equal(t, 1, len(groupTracker.getTrackedApplications()))
 
@@ -104,9 +104,9 @@ func TestGTDecreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage2)
 	}
-	result = groupTracker.increaseTrackedResource(queuePath2, TestApp2, usage2, user.User)
+	result = groupTracker.increaseTrackedResource(hierarchy2, TestApp2, usage2, user.User)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath2, TestApp2, usage2)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy2, TestApp2, usage2)
 	}
 	actualResources := getGroupResource(groupTracker)
 
@@ -120,15 +120,15 @@ func TestGTDecreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
-	removeQT, decreased := groupTracker.decreaseTrackedResource(queuePath1, TestApp1, usage3, false)
+	removeQT, decreased := groupTracker.decreaseTrackedResource(hierarchy1, TestApp1, usage3, false)
 	if !decreased {
-		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, usage3, err)
+		t.Fatalf("unable to decrease tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy1, TestApp1, usage3, err)
 	}
 	assert.Equal(t, removeQT, false, "wrong remove queue tracker value")
 
-	removeQT, decreased = groupTracker.decreaseTrackedResource(queuePath2, TestApp2, usage3, false)
+	removeQT, decreased = groupTracker.decreaseTrackedResource(hierarchy2, TestApp2, usage3, false)
 	if !decreased {
-		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage3, err)
+		t.Fatalf("unable to decrease tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy2, TestApp2, usage3, err)
 	}
 	assert.Equal(t, removeQT, false, "wrong remove queue tracker value")
 
@@ -144,9 +144,9 @@ func TestGTDecreaseTrackedResource(t *testing.T) {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
 
-	removeQT, decreased = groupTracker.decreaseTrackedResource(queuePath1, TestApp1, usage4, true)
+	removeQT, decreased = groupTracker.decreaseTrackedResource(hierarchy1, TestApp1, usage4, true)
 	if !decreased {
-		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, usage1, err)
+		t.Fatalf("unable to decrease tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy1, TestApp1, usage1, err)
 	}
 	assert.Equal(t, 1, len(groupTracker.getTrackedApplications()))
 	assert.Equal(t, removeQT, false, "wrong remove queue tracker value")
@@ -156,9 +156,9 @@ func TestGTDecreaseTrackedResource(t *testing.T) {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
 
-	removeQT, decreased = groupTracker.decreaseTrackedResource(queuePath2, TestApp2, usage5, true)
+	removeQT, decreased = groupTracker.decreaseTrackedResource(hierarchy2, TestApp2, usage5, true)
 	if !decreased {
-		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage2, err)
+		t.Fatalf("unable to decrease tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy2, TestApp2, usage2, err)
 	}
 	assert.Equal(t, 0, len(groupTracker.getTrackedApplications()))
 	assert.Equal(t, removeQT, true, "wrong remove queue tracker value")
@@ -167,6 +167,8 @@ func TestGTDecreaseTrackedResource(t *testing.T) {
 func TestGTSetMaxLimits(t *testing.T) {
 	// Queue setup:
 	// root->parent->child1
+	// Initialize ugm
+	GetUserManager()
 	user := security.UserGroup{User: "test", Groups: []string{"test"}}
 	groupTracker := newGroupTracker(user.User)
 	usage1, err := resources.NewResourceFromConf(map[string]string{"mem": "10M", "vcore": "10"})
@@ -174,24 +176,24 @@ func TestGTSetMaxLimits(t *testing.T) {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
 	}
 
-	result := groupTracker.increaseTrackedResource(queuePath1, TestApp1, usage1, user.User)
+	result := groupTracker.increaseTrackedResource(hierarchy1, TestApp1, usage1, user.User)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, usage1)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy1, TestApp1, usage1)
 	}
 
-	groupTracker.setLimits(queuePath1, resources.Multiply(usage1, 5), 5)
-	groupTracker.setLimits("root.parent", resources.Multiply(usage1, 10), 10)
+	groupTracker.setLimits(hierarchy1, resources.Multiply(usage1, 5), 5)
+	groupTracker.setLimits(hierarchy5, resources.Multiply(usage1, 10), 10)
 
-	result = groupTracker.increaseTrackedResource(queuePath1, TestApp2, usage1, user.User)
+	result = groupTracker.increaseTrackedResource(hierarchy1, TestApp2, usage1, user.User)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp2, usage1)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy1, TestApp2, usage1)
 	}
-	result = groupTracker.increaseTrackedResource(queuePath1, TestApp3, usage1, user.User)
+	result = groupTracker.increaseTrackedResource(hierarchy1, TestApp3, usage1, user.User)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp2, usage1)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy1, TestApp3, usage1)
 	}
-	groupTracker.setLimits(queuePath1, usage1, 1)
-	groupTracker.setLimits("root.parent", usage1, 1)
+	groupTracker.setLimits(hierarchy1, usage1, 1)
+	groupTracker.setLimits(hierarchy5, usage1, 1)
 }
 
 func getGroupResource(gt *GroupTracker) map[string]*resources.Resource {

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -19,13 +19,11 @@
 package ugm
 
 import (
-	"strings"
 	"sync"
 
 	"go.uber.org/zap"
 
 	"github.com/apache/yunikorn-core/pkg/common"
-	"github.com/apache/yunikorn-core/pkg/common/configs"
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/log"
 	"github.com/apache/yunikorn-core/pkg/webservice/dao"
@@ -54,24 +52,23 @@ func newUserTracker(user string) *UserTracker {
 	return userTracker
 }
 
-func (ut *UserTracker) increaseTrackedResource(queuePath, applicationID string, usage *resources.Resource) bool {
+func (ut *UserTracker) increaseTrackedResource(hierarchy []string, applicationID string, usage *resources.Resource) bool {
 	ut.Lock()
 	defer ut.Unlock()
-	hierarchy := strings.Split(queuePath, configs.DOT)
 	increased := ut.queueTracker.increaseTrackedResource(hierarchy, applicationID, user, usage)
 	if increased {
 		gt := ut.appGroupTrackers[applicationID]
 		log.Log(log.SchedUGM).Debug("Increasing resource usage for group",
 			zap.String("group", gt.getName()),
-			zap.String("queue path", queuePath),
+			zap.Any("queue path", hierarchy),
 			zap.String("application", applicationID),
 			zap.Stringer("resource", usage))
-		increasedGroupUsage := gt.increaseTrackedResource(queuePath, applicationID, usage, ut.userName)
+		increasedGroupUsage := gt.increaseTrackedResource(hierarchy, applicationID, usage, ut.userName)
 		if !increasedGroupUsage {
 			_, decreased := ut.queueTracker.decreaseTrackedResource(hierarchy, applicationID, usage, false)
 			if !decreased {
 				log.Log(log.SchedUGM).Error("User resource usage rollback has failed",
-					zap.String("queue path", queuePath),
+					zap.Any("queue path", hierarchy),
 					zap.String("application", applicationID),
 					zap.String("user", ut.userName))
 			}
@@ -81,13 +78,13 @@ func (ut *UserTracker) increaseTrackedResource(queuePath, applicationID string, 
 	return increased
 }
 
-func (ut *UserTracker) decreaseTrackedResource(queuePath, applicationID string, usage *resources.Resource, removeApp bool) (bool, bool) {
+func (ut *UserTracker) decreaseTrackedResource(hierarchy []string, applicationID string, usage *resources.Resource, removeApp bool) (bool, bool) {
 	ut.Lock()
 	defer ut.Unlock()
 	if removeApp {
 		delete(ut.appGroupTrackers, applicationID)
 	}
-	return ut.queueTracker.decreaseTrackedResource(strings.Split(queuePath, configs.DOT), applicationID, usage, removeApp)
+	return ut.queueTracker.decreaseTrackedResource(hierarchy, applicationID, usage, removeApp)
 }
 
 func (ut *UserTracker) hasGroupForApp(applicationID string) bool {
@@ -118,16 +115,16 @@ func (ut *UserTracker) getTrackedApplications() map[string]*GroupTracker {
 	return ut.appGroupTrackers
 }
 
-func (ut *UserTracker) setLimits(queuePath string, resource *resources.Resource, maxApps uint64) {
+func (ut *UserTracker) setLimits(hierarchy []string, resource *resources.Resource, maxApps uint64) {
 	ut.Lock()
 	defer ut.Unlock()
-	ut.queueTracker.setLimit(strings.Split(queuePath, configs.DOT), resource, maxApps)
+	ut.queueTracker.setLimit(hierarchy, resource, maxApps)
 }
 
-func (ut *UserTracker) headroom(queuePath string) *resources.Resource {
+func (ut *UserTracker) headroom(hierarchy []string) *resources.Resource {
 	ut.Lock()
 	defer ut.Unlock()
-	return ut.queueTracker.headroom(strings.Split(queuePath, configs.DOT), user)
+	return ut.queueTracker.headroom(hierarchy, user)
 }
 
 func (ut *UserTracker) GetUserResourceUsageDAOInfo() *dao.UserResourceUsageDAOInfo {
@@ -146,22 +143,22 @@ func (ut *UserTracker) GetUserResourceUsageDAOInfo() *dao.UserResourceUsageDAOIn
 	return userResourceUsage
 }
 
-func (ut *UserTracker) IsQueuePathTrackedCompletely(queuePath string) bool {
+func (ut *UserTracker) IsQueuePathTrackedCompletely(hierarchy []string) bool {
 	ut.RLock()
 	defer ut.RUnlock()
-	return ut.queueTracker.IsQueuePathTrackedCompletely(strings.Split(queuePath, configs.DOT))
+	return ut.queueTracker.IsQueuePathTrackedCompletely(hierarchy)
 }
 
-func (ut *UserTracker) IsUnlinkRequired(queuePath string) bool {
+func (ut *UserTracker) IsUnlinkRequired(hierarchy []string) bool {
 	ut.RLock()
 	defer ut.RUnlock()
-	return ut.queueTracker.IsUnlinkRequired(strings.Split(queuePath, configs.DOT))
+	return ut.queueTracker.IsUnlinkRequired(hierarchy)
 }
 
-func (ut *UserTracker) UnlinkQT(queuePath string) bool {
+func (ut *UserTracker) UnlinkQT(hierarchy []string) bool {
 	ut.RLock()
 	defer ut.RUnlock()
-	return ut.queueTracker.UnlinkQT(strings.Split(queuePath, configs.DOT))
+	return ut.queueTracker.UnlinkQT(hierarchy)
 }
 
 func (ut *UserTracker) canBeRemoved() bool {
@@ -170,8 +167,8 @@ func (ut *UserTracker) canBeRemoved() bool {
 	return ut.queueTracker.canBeRemoved()
 }
 
-func (ut *UserTracker) canRunApp(queuePath, applicationID string) bool {
+func (ut *UserTracker) canRunApp(hierarchy []string, applicationID string) bool {
 	ut.Lock()
 	defer ut.Unlock()
-	return ut.queueTracker.canRunApp(strings.Split(queuePath, configs.DOT), applicationID, user)
+	return ut.queueTracker.canRunApp(hierarchy, applicationID, user)
 }

--- a/pkg/scheduler/ugm/user_tracker_test.go
+++ b/pkg/scheduler/ugm/user_tracker_test.go
@@ -39,20 +39,28 @@ const (
 	queuePath4 = "root.parent.child12"
 )
 
+var hierarchy1 = []string{"root", "parent", "child1"}
+var hierarchy2 = []string{"root", "parent", "child2"}
+var hierarchy3 = []string{"root", "parent", "child1", "child12"}
+var hierarchy4 = []string{"root", "parent", "child12"}
+var hierarchy5 = []string{"root", "parent"}
+
 func TestIncreaseTrackedResource(t *testing.T) {
 	// Queue setup:
 	// root->parent->child1->child12
 	// root->parent->child2
 	// root->parent->child12 (similar name like above leaf queue, but it is being treated differently as similar names are allowed)
+	// Initialize ugm
+	GetUserManager()
 	user := security.UserGroup{User: "test", Groups: []string{"test"}}
 	userTracker := newUserTracker(user.User)
 	usage1, err := resources.NewResourceFromConf(map[string]string{"mem": "10M", "vcore": "10"})
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
 	}
-	result := userTracker.increaseTrackedResource(queuePath1, TestApp1, usage1)
+	result := userTracker.increaseTrackedResource(hierarchy1, TestApp1, usage1)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, usage1)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy1, TestApp1, usage1)
 	}
 	groupTracker := newGroupTracker(user.User)
 	userTracker.setGroupForApp(TestApp1, groupTracker)
@@ -61,9 +69,9 @@ func TestIncreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage2)
 	}
-	result = userTracker.increaseTrackedResource(queuePath2, TestApp2, usage2)
+	result = userTracker.increaseTrackedResource(hierarchy2, TestApp2, usage2)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage2, err)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy2, TestApp2, usage2, err)
 	}
 	userTracker.setGroupForApp(TestApp2, groupTracker)
 
@@ -71,9 +79,9 @@ func TestIncreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
-	result = userTracker.increaseTrackedResource(queuePath3, TestApp3, usage3)
+	result = userTracker.increaseTrackedResource(hierarchy3, TestApp3, usage3)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath3, TestApp3, usage3, err)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy3, TestApp3, usage3, err)
 	}
 	userTracker.setGroupForApp(TestApp3, groupTracker)
 
@@ -81,9 +89,9 @@ func TestIncreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
-	result = userTracker.increaseTrackedResource(queuePath4, TestApp4, usage4)
+	result = userTracker.increaseTrackedResource(hierarchy4, TestApp4, usage4)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath4, TestApp4, usage4, err)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy4, TestApp4, usage4, err)
 	}
 	userTracker.setGroupForApp(TestApp4, groupTracker)
 
@@ -104,6 +112,8 @@ func TestDecreaseTrackedResource(t *testing.T) {
 	// Queue setup:
 	// root->parent->child1
 	// root->parent->child2
+	// Initialize ugm
+	GetUserManager()
 	user := security.UserGroup{User: "test", Groups: []string{"test"}}
 	userTracker := newUserTracker(user.User)
 
@@ -111,9 +121,9 @@ func TestDecreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
 	}
-	result := userTracker.increaseTrackedResource(queuePath1, TestApp1, usage1)
+	result := userTracker.increaseTrackedResource(hierarchy1, TestApp1, usage1)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, usage1, err)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy1, TestApp1, usage1, err)
 	}
 	groupTracker := newGroupTracker(user.User)
 	userTracker.setGroupForApp(TestApp1, groupTracker)
@@ -123,9 +133,9 @@ func TestDecreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage2)
 	}
-	result = userTracker.increaseTrackedResource(queuePath2, TestApp2, usage2)
+	result = userTracker.increaseTrackedResource(hierarchy2, TestApp2, usage2)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage2, err)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy2, TestApp2, usage2, err)
 	}
 	userTracker.setGroupForApp(TestApp2, groupTracker)
 	actualResources := getUserResource(userTracker)
@@ -140,15 +150,15 @@ func TestDecreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
-	removeQT, decreased := userTracker.decreaseTrackedResource(queuePath1, TestApp1, usage3, false)
+	removeQT, decreased := userTracker.decreaseTrackedResource(hierarchy1, TestApp1, usage3, false)
 	if !decreased {
-		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, usage3, err)
+		t.Fatalf("unable to decrease tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy1, TestApp1, usage3, err)
 	}
 	assert.Equal(t, removeQT, false, "wrong remove queue tracker value")
 
-	removeQT, decreased = userTracker.decreaseTrackedResource(queuePath2, TestApp2, usage3, false)
+	removeQT, decreased = userTracker.decreaseTrackedResource(hierarchy2, TestApp2, usage3, false)
 	if !decreased {
-		t.Fatalf("unable to decrease tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage3, err)
+		t.Fatalf("unable to decrease tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy2, TestApp2, usage3, err)
 	}
 	actualResources1 := getUserResource(userTracker)
 
@@ -163,9 +173,9 @@ func TestDecreaseTrackedResource(t *testing.T) {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
 
-	removeQT, decreased = userTracker.decreaseTrackedResource(queuePath1, TestApp1, usage4, true)
+	removeQT, decreased = userTracker.decreaseTrackedResource(hierarchy1, TestApp1, usage4, true)
 	if !decreased {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, usage1, err)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy1, TestApp1, usage1, err)
 	}
 	assert.Equal(t, 1, len(userTracker.getTrackedApplications()))
 	assert.Equal(t, removeQT, false, "wrong remove queue tracker value")
@@ -174,9 +184,9 @@ func TestDecreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage5)
 	}
-	removeQT, decreased = userTracker.decreaseTrackedResource(queuePath2, TestApp2, usage5, true)
+	removeQT, decreased = userTracker.decreaseTrackedResource(hierarchy2, TestApp2, usage5, true)
 	if !decreased {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath2, TestApp2, usage2, err)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy2, TestApp2, usage2, err)
 	}
 	assert.Equal(t, 0, len(userTracker.getTrackedApplications()))
 	assert.Equal(t, removeQT, true, "wrong remove queue tracker value")
@@ -185,31 +195,33 @@ func TestDecreaseTrackedResource(t *testing.T) {
 func TestSetMaxLimits(t *testing.T) {
 	// Queue setup:
 	// root->parent->child1
+	// Initialize ugm
+	GetUserManager()
 	user := security.UserGroup{User: "test", Groups: []string{"test"}}
 	userTracker := newUserTracker(user.User)
 	usage1, err := resources.NewResourceFromConf(map[string]string{"mem": "10M", "vcore": "10"})
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
 	}
-	result := userTracker.increaseTrackedResource(queuePath1, TestApp1, usage1)
+	result := userTracker.increaseTrackedResource(hierarchy1, TestApp1, usage1)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v, error %t", queuePath1, TestApp1, usage1, err)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy1, TestApp1, usage1, err)
 	}
 
-	userTracker.setLimits(queuePath1, resources.Multiply(usage1, 5), 5)
-	userTracker.setLimits("root.parent", resources.Multiply(usage1, 10), 10)
+	userTracker.setLimits(hierarchy1, resources.Multiply(usage1, 5), 5)
+	userTracker.setLimits(hierarchy5, resources.Multiply(usage1, 10), 10)
 
-	result = userTracker.increaseTrackedResource(queuePath1, TestApp1, usage1)
+	result = userTracker.increaseTrackedResource(hierarchy1, TestApp1, usage1)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp1, usage1)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy1, TestApp1, usage1)
 	}
 
-	result = userTracker.increaseTrackedResource(queuePath1, TestApp2, usage1)
+	result = userTracker.increaseTrackedResource(hierarchy1, TestApp2, usage1)
 	if !result {
-		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath1, TestApp2, usage1)
+		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy1, TestApp2, usage1)
 	}
-	userTracker.setLimits(queuePath1, usage1, 1)
-	userTracker.setLimits("root.parent", usage1, 1)
+	userTracker.setLimits(hierarchy1, usage1, 1)
+	userTracker.setLimits(hierarchy5, usage1, 1)
 }
 
 func getUserResource(ut *UserTracker) map[string]*resources.Resource {


### PR DESCRIPTION
…manager.go

### What is this PR for?
Instead of doing strings.split on queue path all over the places, keep it in one place (manager.go) for ease of maintanence. Also some code clean up.


### What type of PR is it?
* [ ] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2139

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
