### PR TITLE
YUNIKORN-2141 Should not preempt placeholders which has been released

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -1752,6 +1752,11 @@ func (sq *Queue) findEligiblePreemptionVictims(results map[string]*QueuePreempti
 					continue
 				}
 
+				// skip placeholder tasks which are marked released
+				if alloc.IsReleased() {
+					continue
+				}
+
 				// if we have encountered a fence then all tasks are eligible for preemption
 				// otherwise the task is a candidate if its priority is less than or equal to the ask priority
 				if fenced || int64(alloc.GetPriority()) <= askPriority {

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1943,6 +1943,13 @@ func TestFindEligiblePreemptionVictims(t *testing.T) {
 	assert.Equal(t, alloc3.allocationKey, victims(snapshot)[0].allocationKey, "wrong alloc")
 	alloc2.GetAsk().SetRequiredNode("")
 
+	// placeholder which has been marked released should not be considered
+	alloc2.released = true
+	snapshot = leaf1.FindEligiblePreemptionVictims(leaf1.QueuePath, ask)
+	assert.Equal(t, 1, len(victims(snapshot)), "wrong victim count")
+	assert.Equal(t, alloc3.allocationKey, victims(snapshot)[0].allocationKey, "wrong alloc")
+	alloc2.released = false
+
 	// setting priority offset on parent2 queue should remove leaf2 victims
 	parent2.priorityOffset = 1001
 	snapshot = leaf1.FindEligiblePreemptionVictims(leaf1.QueuePath, ask)


### PR DESCRIPTION
### What is this PR for?
We should not preempt placeholders which has been released, it will cause the real pod pending due to not get the response:
```
The real pod will always pending, because the core side doesn't receive the release response for PLACEHOLDER_REPLACED
// if we have an uuid the termination type is important
if release.TerminationType == si.TerminationType_PLACEHOLDER_REPLACED {
    log.Logger().Info("replacing placeholder allocation",
       zap.String("appID", appID),
       zap.String("allocationId", uuid))
    if alloc := app.ReplaceAllocation(uuid); alloc != nil {
       released = append(released, alloc)
    }
} else {
    log.Logger().Info("removing allocation from application",
       zap.String("appID", appID),
       zap.String("allocationId", uuid),
       zap.String("terminationType", release.TerminationType.String()))
    if alloc := app.RemoveAllocation(uuid); alloc != nil {
       released = append(released, alloc)
    }
} 
```

Details are in the jira description:
https://issues.apache.org/jira/browse/YUNIKORN-2141

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-2141
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
