### PR TITLE
[YUNIKORN-2161] Metrics code cleanup

### DIFF
--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -20,7 +20,7 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
-type eventMetrics struct {
+type EventMetrics struct {
 	totalEventsCreated      prometheus.Gauge
 	totalEventsChanneled    prometheus.Gauge
 	totalEventsNotChanneled prometheus.Gauge
@@ -30,8 +30,8 @@ type eventMetrics struct {
 	totalEventsCollected    prometheus.Gauge
 }
 
-func initEventMetrics() *eventMetrics {
-	metrics := &eventMetrics{}
+func initEventMetrics() *EventMetrics {
+	metrics := &EventMetrics{}
 
 	metrics.totalEventsCreated = prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -88,7 +88,7 @@ func initEventMetrics() *eventMetrics {
 
 // Reset all metrics that implement the Set functionality.
 // Should only be used in tests
-func (em *eventMetrics) Reset() {
+func (em *EventMetrics) Reset() {
 	em.totalEventsCollected.Set(0)
 	em.totalEventsCreated.Set(0)
 	em.totalEventsChanneled.Set(0)
@@ -98,30 +98,30 @@ func (em *eventMetrics) Reset() {
 	em.totalEventsProcessed.Set(0)
 }
 
-func (em *eventMetrics) IncEventsCreated() {
+func (em *EventMetrics) IncEventsCreated() {
 	em.totalEventsCreated.Inc()
 }
 
-func (em *eventMetrics) IncEventsChanneled() {
+func (em *EventMetrics) IncEventsChanneled() {
 	em.totalEventsChanneled.Inc()
 }
 
-func (em *eventMetrics) IncEventsNotChanneled() {
+func (em *EventMetrics) IncEventsNotChanneled() {
 	em.totalEventsNotChanneled.Inc()
 }
 
-func (em *eventMetrics) IncEventsProcessed() {
+func (em *EventMetrics) IncEventsProcessed() {
 	em.totalEventsProcessed.Inc()
 }
 
-func (em *eventMetrics) IncEventsStored() {
+func (em *EventMetrics) IncEventsStored() {
 	em.totalEventsStored.Inc()
 }
 
-func (em *eventMetrics) IncEventsNotStored() {
+func (em *EventMetrics) IncEventsNotStored() {
 	em.totalEventsNotStored.Inc()
 }
 
-func (em *eventMetrics) AddEventsCollected(collectedEvents int) {
+func (em *EventMetrics) AddEventsCollected(collectedEvents int) {
 	em.totalEventsCollected.Add(float64(collectedEvents))
 }

--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -30,7 +30,7 @@ type eventMetrics struct {
 	totalEventsCollected    prometheus.Gauge
 }
 
-func initEventMetrics() CoreEventMetrics {
+func initEventMetrics() *eventMetrics {
 	metrics := &eventMetrics{}
 
 	metrics.totalEventsCreated = prometheus.NewGauge(
@@ -86,6 +86,8 @@ func initEventMetrics() CoreEventMetrics {
 	return metrics
 }
 
+// Reset all metrics that implement the Set functionality.
+// Should only be used in tests
 func (em *eventMetrics) Reset() {
 	em.totalEventsCollected.Set(0)
 	em.totalEventsCreated.Set(0)

--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -39,7 +39,7 @@ var m *Metrics
 type Metrics struct {
 	scheduler *SchedulerMetrics
 	queues    map[string]*QueueMetrics
-	event     CoreEventMetrics
+	event     *eventMetrics
 	runtime   GoRuntimeMetrics
 	lock      sync.RWMutex
 }
@@ -48,19 +48,6 @@ type GoRuntimeMetrics interface {
 	Collect()
 	// Reset all metrics that implement the Reset functionality.
 	// should only be used in tests
-	Reset()
-}
-
-type CoreEventMetrics interface {
-	IncEventsCreated()
-	IncEventsChanneled()
-	IncEventsNotChanneled()
-	IncEventsProcessed()
-	IncEventsStored()
-	IncEventsNotStored()
-	AddEventsCollected(collectedEvents int)
-	// Reset all metrics that implement the Set functionality.
-	// Should only be used in tests
 	Reset()
 }
 
@@ -102,7 +89,7 @@ func GetQueueMetrics(name string) *QueueMetrics {
 	return queueMetrics
 }
 
-func GetEventMetrics() CoreEventMetrics {
+func GetEventMetrics() *eventMetrics {
 	return m.event
 }
 

--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -20,7 +20,6 @@ package metrics
 
 import (
 	"sync"
-	"time"
 )
 
 const (
@@ -38,7 +37,7 @@ var once sync.Once
 var m *Metrics
 
 type Metrics struct {
-	scheduler CoreSchedulerMetrics
+	scheduler *SchedulerMetrics
 	queues    map[string]*QueueMetrics
 	event     CoreEventMetrics
 	runtime   GoRuntimeMetrics
@@ -47,72 +46,6 @@ type Metrics struct {
 
 type GoRuntimeMetrics interface {
 	Collect()
-	// Reset all metrics that implement the Reset functionality.
-	// should only be used in tests
-	Reset()
-}
-
-// Declare all core metrics ops in this interface
-type CoreSchedulerMetrics interface {
-	// Metrics Ops related to ScheduledAllocationSuccesses
-	AddAllocatedContainers(value int)
-	getAllocatedContainers() (int, error)
-
-	// Metrics Ops related to ScheduledAllocationFailures
-	AddRejectedContainers(value int)
-
-	// Metrics Ops related to ScheduledAllocationErrors
-	IncSchedulingError()
-	GetSchedulingErrors() (int, error)
-
-	// Metrics Ops related to released allocations
-	AddReleasedContainers(value int)
-	getReleasedContainers() (int, error)
-	// Metrics Ops related to totalApplicationsAccepted
-	IncTotalApplicationsAccepted()
-	AddTotalApplicationsAccepted(value int)
-
-	// Metrics Ops related to TotalApplicationsRejected
-	IncTotalApplicationsRejected()
-	AddTotalApplicationsRejected(value int)
-	GetTotalApplicationsRejected() (int, error)
-
-	// Metrics Ops related to TotalApplicationsRunning
-	IncTotalApplicationsRunning()
-	DecTotalApplicationsRunning()
-	SubTotalApplicationsRunning(value int)
-	GetTotalApplicationsRunning() (int, error)
-
-	// Metrics Ops related to TotalApplicationsFailed
-	IncTotalApplicationsFailed()
-
-	// Metrics Ops related to TotalApplicationsCompleted
-	IncTotalApplicationsCompleted()
-	AddTotalApplicationsCompleted(value int)
-	GetTotalApplicationsCompleted() (int, error)
-
-	// Metrics Ops related to ActiveNodes
-	IncActiveNodes()
-	DecActiveNodes()
-	IncDrainingNodes()
-	DecDrainingNodes()
-	GetDrainingNodes() (int, error)
-	IncUnhealthyNodes()
-	DecUnhealthyNodes()
-	IncTotalDecommissionedNodes()
-
-	// Metrics Ops related to failedNodes
-	IncFailedNodes()
-	DecFailedNodes()
-	SetNodeResourceUsage(resourceName string, rangeIdx int, value float64)
-	GetFailedNodes() (int, error)
-
-	// Metrics Ops related to latency change
-	ObserveSchedulingLatency(start time.Time)
-	ObserveAppSortingLatency(start time.Time)
-	ObserveQueueSortingLatency(start time.Time)
-	ObserveTryNodeLatency(start time.Time)
-	ObserveTryPreemptionLatency(start time.Time)
 	// Reset all metrics that implement the Reset functionality.
 	// should only be used in tests
 	Reset()
@@ -154,7 +87,7 @@ func Reset() {
 	m.runtime.Reset()
 }
 
-func GetSchedulerMetrics() CoreSchedulerMetrics {
+func GetSchedulerMetrics() *SchedulerMetrics {
 	return m.scheduler
 }
 

--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -39,35 +39,10 @@ var m *Metrics
 
 type Metrics struct {
 	scheduler CoreSchedulerMetrics
-	queues    map[string]CoreQueueMetrics
+	queues    map[string]*QueueMetrics
 	event     CoreEventMetrics
 	runtime   GoRuntimeMetrics
 	lock      sync.RWMutex
-}
-
-type CoreQueueMetrics interface {
-	IncQueueApplicationsAccepted()
-	GetQueueApplicationsAccepted() (int, error)
-	IncQueueApplicationsRejected()
-	GetQueueApplicationsRejected() (int, error)
-	IncQueueApplicationsRunning()
-	DecQueueApplicationsRunning()
-	GetQueueApplicationsRunning() (int, error)
-	IncQueueApplicationsFailed()
-	GetQueueApplicationsFailed() (int, error)
-	IncQueueApplicationsCompleted()
-	GetQueueApplicationsCompleted() (int, error)
-	IncAllocatedContainer()
-	IncReleasedContainer()
-	AddReleasedContainers(value int)
-	SetQueueGuaranteedResourceMetrics(resourceName string, value float64)
-	SetQueueMaxResourceMetrics(resourceName string, value float64)
-	SetQueueAllocatedResourceMetrics(resourceName string, value float64)
-	SetQueuePendingResourceMetrics(resourceName string, value float64)
-	SetQueuePreemptingResourceMetrics(resourceName string, value float64)
-	// Reset all metrics that implement the Reset functionality.
-	// should only be used in tests
-	Reset()
 }
 
 type GoRuntimeMetrics interface {
@@ -160,7 +135,7 @@ func init() {
 	once.Do(func() {
 		m = &Metrics{
 			scheduler: InitSchedulerMetrics(),
-			queues:    make(map[string]CoreQueueMetrics),
+			queues:    make(map[string]*QueueMetrics),
 			event:     initEventMetrics(),
 			lock:      sync.RWMutex{},
 			runtime:   initRuntimeMetrics(),
@@ -183,7 +158,7 @@ func GetSchedulerMetrics() CoreSchedulerMetrics {
 	return m.scheduler
 }
 
-func GetQueueMetrics(name string) CoreQueueMetrics {
+func GetQueueMetrics(name string) *QueueMetrics {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	if qm, ok := m.queues[name]; ok {

--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -40,15 +40,8 @@ type Metrics struct {
 	scheduler *SchedulerMetrics
 	queues    map[string]*QueueMetrics
 	event     *EventMetrics
-	runtime   GoRuntimeMetrics
+	runtime   *RuntimeMetrics
 	lock      sync.RWMutex
-}
-
-type GoRuntimeMetrics interface {
-	Collect()
-	// Reset all metrics that implement the Reset functionality.
-	// should only be used in tests
-	Reset()
 }
 
 func init() {
@@ -93,7 +86,7 @@ func GetEventMetrics() *EventMetrics {
 	return m.event
 }
 
-func GetRuntimeMetrics() GoRuntimeMetrics {
+func GetRuntimeMetrics() *RuntimeMetrics {
 	return m.runtime
 }
 

--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -63,11 +63,8 @@ type CoreQueueMetrics interface {
 	SetQueueGuaranteedResourceMetrics(resourceName string, value float64)
 	SetQueueMaxResourceMetrics(resourceName string, value float64)
 	SetQueueAllocatedResourceMetrics(resourceName string, value float64)
-	AddQueueAllocatedResourceMetrics(resourceName string, value float64)
 	SetQueuePendingResourceMetrics(resourceName string, value float64)
-	AddQueuePendingResourceMetrics(resourceName string, value float64)
 	SetQueuePreemptingResourceMetrics(resourceName string, value float64)
-	AddQueuePreemptingResourceMetrics(resourceName string, value float64)
 	// Reset all metrics that implement the Reset functionality.
 	// should only be used in tests
 	Reset()
@@ -83,21 +80,17 @@ type GoRuntimeMetrics interface {
 // Declare all core metrics ops in this interface
 type CoreSchedulerMetrics interface {
 	// Metrics Ops related to ScheduledAllocationSuccesses
-	IncAllocatedContainer()
 	AddAllocatedContainers(value int)
 	getAllocatedContainers() (int, error)
 
 	// Metrics Ops related to ScheduledAllocationFailures
-	IncRejectedContainer()
 	AddRejectedContainers(value int)
 
 	// Metrics Ops related to ScheduledAllocationErrors
 	IncSchedulingError()
-	AddSchedulingErrors(value int)
 	GetSchedulingErrors() (int, error)
 
 	// Metrics Ops related to released allocations
-	IncReleasedContainer()
 	AddReleasedContainers(value int)
 	getReleasedContainers() (int, error)
 	// Metrics Ops related to totalApplicationsAccepted
@@ -111,10 +104,8 @@ type CoreSchedulerMetrics interface {
 
 	// Metrics Ops related to TotalApplicationsRunning
 	IncTotalApplicationsRunning()
-	AddTotalApplicationsRunning(value int)
 	DecTotalApplicationsRunning()
 	SubTotalApplicationsRunning(value int)
-	SetTotalApplicationsRunning(value int)
 	GetTotalApplicationsRunning() (int, error)
 
 	// Metrics Ops related to TotalApplicationsFailed
@@ -123,17 +114,11 @@ type CoreSchedulerMetrics interface {
 	// Metrics Ops related to TotalApplicationsCompleted
 	IncTotalApplicationsCompleted()
 	AddTotalApplicationsCompleted(value int)
-	DecTotalApplicationsCompleted()
-	SubTotalApplicationsCompleted(value int)
-	SetTotalApplicationsCompleted(value int)
 	GetTotalApplicationsCompleted() (int, error)
 
 	// Metrics Ops related to ActiveNodes
 	IncActiveNodes()
-	AddActiveNodes(value int)
 	DecActiveNodes()
-	SubActiveNodes(value int)
-	SetActiveNodes(value int)
 	IncDrainingNodes()
 	DecDrainingNodes()
 	GetDrainingNodes() (int, error)
@@ -143,16 +128,12 @@ type CoreSchedulerMetrics interface {
 
 	// Metrics Ops related to failedNodes
 	IncFailedNodes()
-	AddFailedNodes(value int)
 	DecFailedNodes()
-	SubFailedNodes(value int)
-	SetFailedNodes(value int)
 	SetNodeResourceUsage(resourceName string, rangeIdx int, value float64)
 	GetFailedNodes() (int, error)
 
 	// Metrics Ops related to latency change
 	ObserveSchedulingLatency(start time.Time)
-	ObserveNodeSortingLatency(start time.Time)
 	ObserveAppSortingLatency(start time.Time)
 	ObserveQueueSortingLatency(start time.Time)
 	ObserveTryNodeLatency(start time.Time)

--- a/pkg/metrics/init.go
+++ b/pkg/metrics/init.go
@@ -39,7 +39,7 @@ var m *Metrics
 type Metrics struct {
 	scheduler *SchedulerMetrics
 	queues    map[string]*QueueMetrics
-	event     *eventMetrics
+	event     *EventMetrics
 	runtime   GoRuntimeMetrics
 	lock      sync.RWMutex
 }
@@ -89,7 +89,7 @@ func GetQueueMetrics(name string) *QueueMetrics {
 	return queueMetrics
 }
 
-func GetEventMetrics() *eventMetrics {
+func GetEventMetrics() *EventMetrics {
 	return m.event
 }
 

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -224,22 +224,10 @@ func (m *QueueMetrics) SetQueueAllocatedResourceMetrics(resourceName string, val
 	m.setQueueResource("allocated", resourceName, value)
 }
 
-func (m *QueueMetrics) AddQueueAllocatedResourceMetrics(resourceName string, value float64) {
-	m.addQueueResource("allocated", resourceName, value)
-}
-
 func (m *QueueMetrics) SetQueuePendingResourceMetrics(resourceName string, value float64) {
 	m.setQueueResource("pending", resourceName, value)
 }
 
-func (m *QueueMetrics) AddQueuePendingResourceMetrics(resourceName string, value float64) {
-	m.addQueueResource("pending", resourceName, value)
-}
-
 func (m *QueueMetrics) SetQueuePreemptingResourceMetrics(resourceName string, value float64) {
 	m.setQueueResource("preempting", resourceName, value)
-}
-
-func (m *QueueMetrics) AddQueuePreemptingResourceMetrics(resourceName string, value float64) {
-	m.addQueueResource("preempting", resourceName, value)
 }

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -114,11 +114,6 @@ func (m *QueueMetrics) decQueueApplications(state string) {
 	m.appMetricsSubsystem.With(prometheus.Labels{"state": state}).Dec()
 }
 
-func (m *QueueMetrics) addQueueResource(state string, resourceName string, value float64) {
-	m.resourceMetricsLabel.With(prometheus.Labels{"state": state, "resource": resourceName}).Add(value)
-	m.resourceMetricsSubsystem.With(prometheus.Labels{"state": state, "resource": resourceName}).Add(value)
-}
-
 func (m *QueueMetrics) setQueueResource(state string, resourceName string, value float64) {
 	m.resourceMetricsLabel.With(prometheus.Labels{"state": state, "resource": resourceName}).Set(value)
 	m.resourceMetricsSubsystem.With(prometheus.Labels{"state": state, "resource": resourceName}).Set(value)

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -38,7 +38,7 @@ type QueueMetrics struct {
 }
 
 // InitQueueMetrics to initialize queue metrics
-func InitQueueMetrics(name string) CoreQueueMetrics {
+func InitQueueMetrics(name string) *QueueMetrics {
 	q := &QueueMetrics{}
 
 	replaceStr := formatMetricName(name)

--- a/pkg/metrics/queue_test.go
+++ b/pkg/metrics/queue_test.go
@@ -32,7 +32,7 @@ var qm *QueueMetrics
 
 func TestApplicationsRunning(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterQueueMetrics(t)
+	defer unregisterQueueMetrics()
 
 	qm.IncQueueApplicationsRunning()
 	verifyAppMetrics(t, "running")
@@ -40,7 +40,7 @@ func TestApplicationsRunning(t *testing.T) {
 
 func TestApplicationsAccepted(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterQueueMetrics(t)
+	defer unregisterQueueMetrics()
 
 	qm.IncQueueApplicationsAccepted()
 	verifyAppMetrics(t, "accepted")
@@ -48,7 +48,7 @@ func TestApplicationsAccepted(t *testing.T) {
 
 func TestApplicationsRejected(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterQueueMetrics(t)
+	defer unregisterQueueMetrics()
 
 	qm.IncQueueApplicationsRejected()
 	verifyAppMetrics(t, "rejected")
@@ -56,7 +56,7 @@ func TestApplicationsRejected(t *testing.T) {
 
 func TestApplicationsFailed(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterQueueMetrics(t)
+	defer unregisterQueueMetrics()
 
 	qm.IncQueueApplicationsFailed()
 	verifyAppMetrics(t, "failed")
@@ -64,7 +64,7 @@ func TestApplicationsFailed(t *testing.T) {
 
 func TestApplicationsCompleted(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterQueueMetrics(t)
+	defer unregisterQueueMetrics()
 
 	qm.IncQueueApplicationsCompleted()
 	verifyAppMetrics(t, "completed")
@@ -72,7 +72,7 @@ func TestApplicationsCompleted(t *testing.T) {
 
 func TestAllocatedContainers(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterQueueMetrics(t)
+	defer unregisterQueueMetrics()
 
 	qm.IncAllocatedContainer()
 	verifyContainerMetrics(t, "allocated", float64(1))
@@ -80,7 +80,7 @@ func TestAllocatedContainers(t *testing.T) {
 
 func TestReleasedContainers(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterQueueMetrics(t)
+	defer unregisterQueueMetrics()
 
 	qm.IncReleasedContainer()
 	verifyContainerMetrics(t, "released", float64(1))
@@ -88,7 +88,7 @@ func TestReleasedContainers(t *testing.T) {
 
 func TestAddReleasedContainers(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterQueueMetrics(t)
+	defer unregisterQueueMetrics()
 
 	qm.AddReleasedContainers(2)
 	verifyContainerMetrics(t, "released", float64(2))
@@ -96,7 +96,7 @@ func TestAddReleasedContainers(t *testing.T) {
 
 func TestQueueGuaranteedResourceMetrics(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterQueueMetrics(t)
+	defer unregisterQueueMetrics()
 
 	qm.SetQueueGuaranteedResourceMetrics("cpu", 1)
 	verifyResourceMetrics(t, "guaranteed", "cpu")
@@ -104,7 +104,7 @@ func TestQueueGuaranteedResourceMetrics(t *testing.T) {
 
 func TestQueueMaxResourceMetrics(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterQueueMetrics(t)
+	defer unregisterQueueMetrics()
 
 	qm.SetQueueMaxResourceMetrics("cpu", 1)
 	verifyResourceMetrics(t, "max", "cpu")
@@ -112,7 +112,7 @@ func TestQueueMaxResourceMetrics(t *testing.T) {
 
 func TestQueueAllocatedResourceMetrics(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterQueueMetrics(t)
+	defer unregisterQueueMetrics()
 
 	qm.SetQueueAllocatedResourceMetrics("cpu", 1)
 	verifyResourceMetrics(t, "allocated", "cpu")
@@ -120,7 +120,7 @@ func TestQueueAllocatedResourceMetrics(t *testing.T) {
 
 func TestQueuePendingResourceMetrics(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterQueueMetrics(t)
+	defer unregisterQueueMetrics()
 
 	qm.SetQueuePendingResourceMetrics("cpu", 1)
 	verifyResourceMetrics(t, "pending", "cpu")
@@ -128,7 +128,7 @@ func TestQueuePendingResourceMetrics(t *testing.T) {
 
 func TestQueuePreemptingResourceMetrics(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterQueueMetrics(t)
+	defer unregisterQueueMetrics()
 
 	qm.SetQueuePreemptingResourceMetrics("cpu", 1)
 	verifyResourceMetrics(t, "preempting", "cpu")
@@ -260,7 +260,7 @@ func verifyMetricsSubsytem(t *testing.T, checkLabel func(label []*dto.LabelPair)
 	assert.Assert(t, checked, "Failed to find metric")
 }
 
-func unregisterQueueMetrics(t *testing.T) {
+func unregisterQueueMetrics() {
 	prometheus.Unregister(qm.appMetricsLabel)
 	prometheus.Unregister(qm.appMetricsSubsystem)
 	prometheus.Unregister(qm.containerMetrics)

--- a/pkg/metrics/queue_test.go
+++ b/pkg/metrics/queue_test.go
@@ -128,7 +128,7 @@ func TestQueuePendingResourceMetrics(t *testing.T) {
 
 func TestQueuePreemptingResourceMetrics(t *testing.T) {
 	qm = getQueueMetrics()
-	defer unregisterMetrics(t)
+	defer unregisterQueueMetrics(t)
 
 	qm.SetQueuePreemptingResourceMetrics("cpu", 1)
 	verifyResourceMetrics(t, "preempting", "cpu")

--- a/pkg/metrics/queue_test.go
+++ b/pkg/metrics/queue_test.go
@@ -28,109 +28,109 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
-var cqm *QueueMetrics
+var qm *QueueMetrics
 
 func TestApplicationsRunning(t *testing.T) {
-	cqm = getQueueMetrics()
+	qm = getQueueMetrics()
 	defer unregisterQueueMetrics(t)
 
-	cqm.IncQueueApplicationsRunning()
+	qm.IncQueueApplicationsRunning()
 	verifyAppMetrics(t, "running")
 }
 
 func TestApplicationsAccepted(t *testing.T) {
-	cqm = getQueueMetrics()
+	qm = getQueueMetrics()
 	defer unregisterQueueMetrics(t)
 
-	cqm.IncQueueApplicationsAccepted()
+	qm.IncQueueApplicationsAccepted()
 	verifyAppMetrics(t, "accepted")
 }
 
 func TestApplicationsRejected(t *testing.T) {
-	cqm = getQueueMetrics()
+	qm = getQueueMetrics()
 	defer unregisterQueueMetrics(t)
 
-	cqm.IncQueueApplicationsRejected()
+	qm.IncQueueApplicationsRejected()
 	verifyAppMetrics(t, "rejected")
 }
 
 func TestApplicationsFailed(t *testing.T) {
-	cqm = getQueueMetrics()
+	qm = getQueueMetrics()
 	defer unregisterQueueMetrics(t)
 
-	cqm.IncQueueApplicationsFailed()
+	qm.IncQueueApplicationsFailed()
 	verifyAppMetrics(t, "failed")
 }
 
 func TestApplicationsCompleted(t *testing.T) {
-	cqm = getQueueMetrics()
+	qm = getQueueMetrics()
 	defer unregisterQueueMetrics(t)
 
-	cqm.IncQueueApplicationsCompleted()
+	qm.IncQueueApplicationsCompleted()
 	verifyAppMetrics(t, "completed")
 }
 
 func TestAllocatedContainers(t *testing.T) {
-	cqm = getQueueMetrics()
+	qm = getQueueMetrics()
 	defer unregisterQueueMetrics(t)
 
-	cqm.IncAllocatedContainer()
+	qm.IncAllocatedContainer()
 	verifyContainerMetrics(t, "allocated", float64(1))
 }
 
 func TestReleasedContainers(t *testing.T) {
-	cqm = getQueueMetrics()
+	qm = getQueueMetrics()
 	defer unregisterQueueMetrics(t)
 
-	cqm.IncReleasedContainer()
+	qm.IncReleasedContainer()
 	verifyContainerMetrics(t, "released", float64(1))
 }
 
 func TestAddReleasedContainers(t *testing.T) {
-	cqm = getQueueMetrics()
+	qm = getQueueMetrics()
 	defer unregisterQueueMetrics(t)
 
-	cqm.AddReleasedContainers(2)
+	qm.AddReleasedContainers(2)
 	verifyContainerMetrics(t, "released", float64(2))
 }
 
 func TestQueueGuaranteedResourceMetrics(t *testing.T) {
-	cqm = getQueueMetrics()
+	qm = getQueueMetrics()
 	defer unregisterQueueMetrics(t)
 
-	cqm.SetQueueGuaranteedResourceMetrics("cpu", 1)
+	qm.SetQueueGuaranteedResourceMetrics("cpu", 1)
 	verifyResourceMetrics(t, "guaranteed", "cpu")
 }
 
 func TestQueueMaxResourceMetrics(t *testing.T) {
-	cqm = getQueueMetrics()
+	qm = getQueueMetrics()
 	defer unregisterQueueMetrics(t)
 
-	cqm.SetQueueMaxResourceMetrics("cpu", 1)
+	qm.SetQueueMaxResourceMetrics("cpu", 1)
 	verifyResourceMetrics(t, "max", "cpu")
 }
 
 func TestQueueAllocatedResourceMetrics(t *testing.T) {
-	cqm = getQueueMetrics()
+	qm = getQueueMetrics()
 	defer unregisterQueueMetrics(t)
 
-	cqm.SetQueueAllocatedResourceMetrics("cpu", 1)
+	qm.SetQueueAllocatedResourceMetrics("cpu", 1)
 	verifyResourceMetrics(t, "allocated", "cpu")
 }
 
 func TestQueuePendingResourceMetrics(t *testing.T) {
-	cqm = getQueueMetrics()
+	qm = getQueueMetrics()
 	defer unregisterQueueMetrics(t)
 
-	cqm.SetQueuePendingResourceMetrics("cpu", 1)
+	qm.SetQueuePendingResourceMetrics("cpu", 1)
 	verifyResourceMetrics(t, "pending", "cpu")
 }
 
 func TestQueuePreemptingResourceMetrics(t *testing.T) {
-	cqm = getQueueMetrics()
+	qm = getQueueMetrics()
 	defer unregisterMetrics(t)
 
-	cqm.SetQueuePreemptingResourceMetrics("cpu", 1)
+	qm.SetQueuePreemptingResourceMetrics("cpu", 1)
 	verifyResourceMetrics(t, "preempting", "cpu")
 }
 
@@ -261,9 +261,9 @@ func verifyMetricsSubsytem(t *testing.T, checkLabel func(label []*dto.LabelPair)
 }
 
 func unregisterQueueMetrics(t *testing.T) {
-	prometheus.Unregister(cqm.appMetricsLabel)
-	prometheus.Unregister(cqm.appMetricsSubsystem)
-	prometheus.Unregister(cqm.containerMetrics)
-	prometheus.Unregister(cqm.resourceMetricsLabel)
-	prometheus.Unregister(cqm.resourceMetricsSubsystem)
+	prometheus.Unregister(qm.appMetricsLabel)
+	prometheus.Unregister(qm.appMetricsSubsystem)
+	prometheus.Unregister(qm.containerMetrics)
+	prometheus.Unregister(qm.resourceMetricsLabel)
+	prometheus.Unregister(qm.resourceMetricsSubsystem)
 }

--- a/pkg/metrics/queue_test.go
+++ b/pkg/metrics/queue_test.go
@@ -28,7 +28,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
-var cqm CoreQueueMetrics
+var cqm *QueueMetrics
 
 func TestApplicationsRunning(t *testing.T) {
 	cqm = getQueueMetrics()
@@ -134,7 +134,7 @@ func TestQueuePreemptingResourceMetrics(t *testing.T) {
 	verifyResourceMetrics(t, "preempting", "cpu")
 }
 
-func getQueueMetrics() CoreQueueMetrics {
+func getQueueMetrics() *QueueMetrics {
 	return InitQueueMetrics("root.test")
 }
 
@@ -261,14 +261,9 @@ func verifyMetricsSubsytem(t *testing.T, checkLabel func(label []*dto.LabelPair)
 }
 
 func unregisterQueueMetrics(t *testing.T) {
-	qm, ok := cqm.(*QueueMetrics)
-	if !ok {
-		t.Fatalf("Type assertion failed, metrics is not QueueMetrics")
-	}
-
-	prometheus.Unregister(qm.appMetricsLabel)
-	prometheus.Unregister(qm.appMetricsSubsystem)
-	prometheus.Unregister(qm.containerMetrics)
-	prometheus.Unregister(qm.resourceMetricsLabel)
-	prometheus.Unregister(qm.resourceMetricsSubsystem)
+	prometheus.Unregister(cqm.appMetricsLabel)
+	prometheus.Unregister(cqm.appMetricsSubsystem)
+	prometheus.Unregister(cqm.containerMetrics)
+	prometheus.Unregister(cqm.resourceMetricsLabel)
+	prometheus.Unregister(cqm.resourceMetricsSubsystem)
 }

--- a/pkg/metrics/runtime.go
+++ b/pkg/metrics/runtime.go
@@ -47,6 +47,8 @@ type RuntimeMetrics struct {
 	*GenericMetrics
 }
 
+// Reset all metrics that implement the Reset functionality.
+// should only be used in tests
 func (a *RuntimeMetrics) Reset() {
 	a.MStatsMetrics.Reset()
 	a.GenericMetrics.Reset()

--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -169,10 +169,6 @@ func (m *SchedulerMetrics) ObserveSchedulingLatency(start time.Time) {
 	m.schedulingLatency.Observe(SinceInSeconds(start))
 }
 
-func (m *SchedulerMetrics) ObserveNodeSortingLatency(start time.Time) {
-	m.sortingLatency.With(prometheus.Labels{"level": "node"}).Observe(SinceInSeconds(start))
-}
-
 func (m *SchedulerMetrics) ObserveAppSortingLatency(start time.Time) {
 	m.sortingLatency.With(prometheus.Labels{"level": "app"}).Observe(SinceInSeconds(start))
 }
@@ -189,10 +185,6 @@ func (m *SchedulerMetrics) ObserveTryPreemptionLatency(start time.Time) {
 	m.tryPreemptionLatency.Observe(SinceInSeconds(start))
 }
 
-func (m *SchedulerMetrics) IncAllocatedContainer() {
-	m.containerAllocation.With(prometheus.Labels{"state": "allocated"}).Inc()
-}
-
 func (m *SchedulerMetrics) AddAllocatedContainers(value int) {
 	m.containerAllocation.With(prometheus.Labels{"state": "allocated"}).Add(float64(value))
 }
@@ -204,10 +196,6 @@ func (m *SchedulerMetrics) getAllocatedContainers() (int, error) {
 		return int(*metricDto.Counter.Value), nil
 	}
 	return -1, err
-}
-
-func (m *SchedulerMetrics) IncReleasedContainer() {
-	m.containerAllocation.With(prometheus.Labels{"state": "released"}).Inc()
 }
 
 func (m *SchedulerMetrics) AddReleasedContainers(value int) {
@@ -223,20 +211,12 @@ func (m *SchedulerMetrics) getReleasedContainers() (int, error) {
 	return -1, err
 }
 
-func (m *SchedulerMetrics) IncRejectedContainer() {
-	m.containerAllocation.With(prometheus.Labels{"state": "rejected"}).Inc()
-}
-
 func (m *SchedulerMetrics) AddRejectedContainers(value int) {
 	m.containerAllocation.With(prometheus.Labels{"state": "rejected"}).Add(float64(value))
 }
 
 func (m *SchedulerMetrics) IncSchedulingError() {
 	m.containerAllocation.With(prometheus.Labels{"state": "error"}).Inc()
-}
-
-func (m *SchedulerMetrics) AddSchedulingErrors(value int) {
-	m.containerAllocation.With(prometheus.Labels{"state": "error"}).Add(float64(value))
 }
 
 func (m *SchedulerMetrics) GetSchedulingErrors() (int, error) {
@@ -277,20 +257,12 @@ func (m *SchedulerMetrics) IncTotalApplicationsRunning() {
 	m.application.With(prometheus.Labels{"state": "running"}).Inc()
 }
 
-func (m *SchedulerMetrics) AddTotalApplicationsRunning(value int) {
-	m.application.With(prometheus.Labels{"state": "running"}).Add(float64(value))
-}
-
 func (m *SchedulerMetrics) DecTotalApplicationsRunning() {
 	m.application.With(prometheus.Labels{"state": "running"}).Dec()
 }
 
 func (m *SchedulerMetrics) SubTotalApplicationsRunning(value int) {
 	m.application.With(prometheus.Labels{"state": "running"}).Sub(float64(value))
-}
-
-func (m *SchedulerMetrics) SetTotalApplicationsRunning(value int) {
-	m.application.With(prometheus.Labels{"state": "running"}).Set(float64(value))
 }
 
 func (m *SchedulerMetrics) GetTotalApplicationsRunning() (int, error) {
@@ -314,18 +286,6 @@ func (m *SchedulerMetrics) AddTotalApplicationsCompleted(value int) {
 	m.application.With(prometheus.Labels{"state": "completed"}).Add(float64(value))
 }
 
-func (m *SchedulerMetrics) DecTotalApplicationsCompleted() {
-	m.application.With(prometheus.Labels{"state": "completed"}).Dec()
-}
-
-func (m *SchedulerMetrics) SubTotalApplicationsCompleted(value int) {
-	m.application.With(prometheus.Labels{"state": "completed"}).Sub(float64(value))
-}
-
-func (m *SchedulerMetrics) SetTotalApplicationsCompleted(value int) {
-	m.application.With(prometheus.Labels{"state": "completed"}).Set(float64(value))
-}
-
 func (m *SchedulerMetrics) GetTotalApplicationsCompleted() (int, error) {
 	metricDto := &dto.Metric{}
 	err := m.application.With(prometheus.Labels{"state": "completed"}).Write(metricDto)
@@ -339,41 +299,18 @@ func (m *SchedulerMetrics) IncActiveNodes() {
 	m.node.With(prometheus.Labels{"state": "active"}).Inc()
 }
 
-func (m *SchedulerMetrics) AddActiveNodes(value int) {
-	m.node.With(prometheus.Labels{"state": "active"}).Add(float64(value))
-}
-
 func (m *SchedulerMetrics) DecActiveNodes() {
 	m.node.With(prometheus.Labels{"state": "active"}).Dec()
-}
-
-func (m *SchedulerMetrics) SubActiveNodes(value int) {
-	m.node.With(prometheus.Labels{"state": "active"}).Sub(float64(value))
-}
-
-func (m *SchedulerMetrics) SetActiveNodes(value int) {
-	m.node.With(prometheus.Labels{"state": "active"}).Set(float64(value))
 }
 
 func (m *SchedulerMetrics) IncFailedNodes() {
 	m.node.With(prometheus.Labels{"state": "failed"}).Inc()
 }
 
-func (m *SchedulerMetrics) AddFailedNodes(value int) {
-	m.node.With(prometheus.Labels{"state": "failed"}).Add(float64(value))
-}
-
 func (m *SchedulerMetrics) DecFailedNodes() {
 	m.node.With(prometheus.Labels{"state": "failed"}).Dec()
 }
 
-func (m *SchedulerMetrics) SubFailedNodes(value int) {
-	m.node.With(prometheus.Labels{"state": "failed"}).Sub(float64(value))
-}
-
-func (m *SchedulerMetrics) SetFailedNodes(value int) {
-	m.node.With(prometheus.Labels{"state": "failed"}).Set(float64(value))
-}
 func (m *SchedulerMetrics) GetFailedNodes() (int, error) {
 	metricDto := &dto.Metric{}
 	err := m.node.With(prometheus.Labels{"state": "failed"}).Write(metricDto)

--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -154,6 +154,8 @@ func InitSchedulerMetrics() *SchedulerMetrics {
 	return s
 }
 
+// Reset all metrics that implement the Reset functionality.
+// should only be used in tests
 func (m *SchedulerMetrics) Reset() {
 	m.node.Reset()
 	m.application.Reset()

--- a/pkg/metrics/scheduler_test.go
+++ b/pkg/metrics/scheduler_test.go
@@ -30,43 +30,43 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-var csm *SchedulerMetrics
+var sm *SchedulerMetrics
 
 func TestDrainingNodes(t *testing.T) {
-	csm = getSchedulerMetrics(t)
+	sm = getSchedulerMetrics(t)
 	defer unregisterMetrics(t)
 
-	csm.IncDrainingNodes()
+	sm.IncDrainingNodes()
 	verifyMetric(t, 1, "draining")
 
-	csm.DecDrainingNodes()
+	sm.DecDrainingNodes()
 	verifyMetric(t, 0, "draining")
 }
 
 func TestTotalDecommissionedNodes(t *testing.T) {
-	csm = getSchedulerMetrics(t)
+	sm = getSchedulerMetrics(t)
 	defer unregisterMetrics(t)
 
-	csm.IncTotalDecommissionedNodes()
+	sm.IncTotalDecommissionedNodes()
 	verifyMetric(t, 1, "decommissioned")
 }
 
 func TestUnhealthyNodes(t *testing.T) {
-	csm = getSchedulerMetrics(t)
+	sm = getSchedulerMetrics(t)
 	defer unregisterMetrics(t)
 
-	csm.IncUnhealthyNodes()
+	sm.IncUnhealthyNodes()
 	verifyMetric(t, 1, "unhealthy")
 
-	csm.DecUnhealthyNodes()
+	sm.DecUnhealthyNodes()
 	verifyMetric(t, 0, "unhealthy")
 }
 
 func TestTryPreemptionLatency(t *testing.T) {
-	csm = getSchedulerMetrics(t)
+	sm = getSchedulerMetrics(t)
 	defer unregisterMetrics(t)
 
-	csm.ObserveTryPreemptionLatency(time.Now().Add(-1 * time.Minute))
+	sm.ObserveTryPreemptionLatency(time.Now().Add(-1 * time.Minute))
 	verifyHistogram(t, "trypreemption_latency_milliseconds", 60, 1)
 }
 

--- a/pkg/metrics/scheduler_test.go
+++ b/pkg/metrics/scheduler_test.go
@@ -34,7 +34,7 @@ var sm *SchedulerMetrics
 
 func TestDrainingNodes(t *testing.T) {
 	sm = getSchedulerMetrics(t)
-	defer unregisterMetrics(t)
+	defer unregisterMetrics()
 
 	sm.IncDrainingNodes()
 	verifyMetric(t, 1, "draining")
@@ -45,7 +45,7 @@ func TestDrainingNodes(t *testing.T) {
 
 func TestTotalDecommissionedNodes(t *testing.T) {
 	sm = getSchedulerMetrics(t)
-	defer unregisterMetrics(t)
+	defer unregisterMetrics()
 
 	sm.IncTotalDecommissionedNodes()
 	verifyMetric(t, 1, "decommissioned")
@@ -53,7 +53,7 @@ func TestTotalDecommissionedNodes(t *testing.T) {
 
 func TestUnhealthyNodes(t *testing.T) {
 	sm = getSchedulerMetrics(t)
-	defer unregisterMetrics(t)
+	defer unregisterMetrics()
 
 	sm.IncUnhealthyNodes()
 	verifyMetric(t, 1, "unhealthy")
@@ -64,14 +64,14 @@ func TestUnhealthyNodes(t *testing.T) {
 
 func TestTryPreemptionLatency(t *testing.T) {
 	sm = getSchedulerMetrics(t)
-	defer unregisterMetrics(t)
+	defer unregisterMetrics()
 
 	sm.ObserveTryPreemptionLatency(time.Now().Add(-1 * time.Minute))
 	verifyHistogram(t, "trypreemption_latency_milliseconds", 60, 1)
 }
 
 func getSchedulerMetrics(t *testing.T) *SchedulerMetrics {
-	unregisterMetrics(t)
+	unregisterMetrics()
 	return InitSchedulerMetrics()
 }
 
@@ -112,7 +112,7 @@ func verifyMetric(t *testing.T, expectedCounter float64, expectedState string) {
 	assert.Assert(t, checked, "Failed to find metric")
 }
 
-func unregisterMetrics(t *testing.T) {
+func unregisterMetrics() {
 	sm := GetSchedulerMetrics()
 	prometheus.Unregister(sm.containerAllocation)
 	prometheus.Unregister(sm.applicationSubmission)

--- a/pkg/metrics/scheduler_test.go
+++ b/pkg/metrics/scheduler_test.go
@@ -30,7 +30,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-var csm CoreSchedulerMetrics
+var csm *SchedulerMetrics
 
 func TestDrainingNodes(t *testing.T) {
 	csm = getSchedulerMetrics(t)
@@ -113,11 +113,7 @@ func verifyMetric(t *testing.T, expectedCounter float64, expectedState string) {
 }
 
 func unregisterMetrics(t *testing.T) {
-	sm, ok := GetSchedulerMetrics().(*SchedulerMetrics)
-	if !ok {
-		t.Fatalf("Type assertion failed, metrics is not SchedulerMetrics")
-	}
-
+	sm := GetSchedulerMetrics()
 	prometheus.Unregister(sm.containerAllocation)
 	prometheus.Unregister(sm.applicationSubmission)
 	prometheus.Unregister(sm.application)

--- a/pkg/scheduler/health_checker.go
+++ b/pkg/scheduler/health_checker.go
@@ -189,7 +189,7 @@ func updateSchedulerLastHealthStatus(latest *dao.SchedulerHealthDAOInfo, schedul
 	schedulerContext.SetLastHealthCheckResult(latest)
 }
 
-func GetSchedulerHealthStatus(metrics metrics.CoreSchedulerMetrics, schedulerContext *ClusterContext) dao.SchedulerHealthDAOInfo {
+func GetSchedulerHealthStatus(metrics *metrics.SchedulerMetrics, schedulerContext *ClusterContext) dao.SchedulerHealthDAOInfo {
 	var healthInfo []dao.HealthCheckInfo
 	healthInfo = append(healthInfo, checkSchedulingErrors(metrics))
 	healthInfo = append(healthInfo, checkFailedNodes(metrics))
@@ -214,7 +214,7 @@ func CreateCheckInfo(succeeded bool, name, description, message string) dao.Heal
 		DiagnosisMessage: message,
 	}
 }
-func checkSchedulingErrors(metrics metrics.CoreSchedulerMetrics) dao.HealthCheckInfo {
+func checkSchedulingErrors(metrics *metrics.SchedulerMetrics) dao.HealthCheckInfo {
 	schedulingErrors, err := metrics.GetSchedulingErrors()
 	if err != nil {
 		return CreateCheckInfo(false, "Scheduling errors", "Check for scheduling error entries in metrics", err.Error())
@@ -223,7 +223,7 @@ func checkSchedulingErrors(metrics metrics.CoreSchedulerMetrics) dao.HealthCheck
 	return CreateCheckInfo(schedulingErrors == 0, "Scheduling errors", "Check for scheduling error entries in metrics", diagnosisMsg)
 }
 
-func checkFailedNodes(metrics metrics.CoreSchedulerMetrics) dao.HealthCheckInfo {
+func checkFailedNodes(metrics *metrics.SchedulerMetrics) dao.HealthCheckInfo {
 	failedNodes, err := metrics.GetFailedNodes()
 	if err != nil {
 		return CreateCheckInfo(false, "Failed nodes", "Check for failed nodes entries in metrics", err.Error())


### PR DESCRIPTION
### What is this PR for?
- Remove unused method in queue.go and scheduler.go
- Remove interface CoreEventMetrics, CoreSchedulerMetrics, CoreQueueMetrics, GoRuntimeMetrics.
- Fix TestQueuePreemptingResourceMetrics use the wrong unregister method

### What type of PR is it?
* [x] - Improvement

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2161

### How should this be tested?
N/A, only refactoring out unused code and redundant interfaces.

### Screenshots (if appropriate)
N/A

### Questions:
N/A