### PR TITLE
[YUNIKORN-2119] check wildcard limit in different queue level

### DIFF
--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -172,6 +172,11 @@ func checkLimitResource(cur QueueConfig, users map[string]map[string]*resources.
 				}
 				// Override with min resource
 				users[curQueuePath][user] = resources.ComponentWiseMinPermissive(limitMaxResources, userMaxResource)
+			} else if wildcardMaxResource, ok := users[queuePath][common.Wildcard]; user != common.Wildcard && ok {
+				if !wildcardMaxResource.FitInMaxUndef(limitMaxResources) {
+					return fmt.Errorf("user %s max resource %s of queue %s is greater than wildcard maximum resource %s of immediate or ancestor parent queue", user, limitMaxResources.String(), cur.Name, wildcardMaxResource.String())
+				}
+				users[curQueuePath][user] = limitMaxResources
 			} else {
 				users[curQueuePath][user] = limitMaxResources
 			}
@@ -184,6 +189,11 @@ func checkLimitResource(cur QueueConfig, users map[string]map[string]*resources.
 				}
 				// Override with min resource
 				groups[curQueuePath][group] = resources.ComponentWiseMinPermissive(limitMaxResources, groupMaxResource)
+			} else if wildcardMaxResource, ok := groups[queuePath][common.Wildcard]; group != common.Wildcard && ok {
+				if !wildcardMaxResource.FitInMaxUndef(limitMaxResources) {
+					return fmt.Errorf("group %s max resource %s of queue %s is greater than wildcard maximum resource %s of immediate or ancestor parent queue", group, limitMaxResources.String(), cur.Name, wildcardMaxResource.String())
+				}
+				groups[curQueuePath][group] = limitMaxResources
 			} else {
 				groups[curQueuePath][group] = limitMaxResources
 			}


### PR DESCRIPTION
### What is this PR for?

If a non-wildcard limit is not defined in parent queue, but it's defined in child queue, we need to check whether it's large than wildcard limit in parent queue.

### What type of PR is it?
* [X] - Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2119

### How should this be tested?
Covered by unit test.
