### PR TITLE
[YUNIKORN-2164] Use ParseUint instead of ParseInt in getEvents()

### DIFF
--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -914,25 +914,25 @@ func getEvents(w http.ResponseWriter, r *http.Request) {
 	var start uint64
 
 	if countStr := r.URL.Query().Get("count"); countStr != "" {
-		c, err := strconv.ParseUint(countStr, 10, 64)
+		var err error
+		count, err = strconv.ParseUint(countStr, 10, 64)
 		if err != nil {
 			buildJSONErrorResponse(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		if c == 0 {
+		if count == 0 {
 			buildJSONErrorResponse(w, `0 is not a valid value for "count"`, http.StatusBadRequest)
 			return
 		}
-		count = c
 	}
 
 	if startStr := r.URL.Query().Get("start"); startStr != "" {
-		i, err := strconv.ParseUint(startStr, 10, 64)
+		var err error
+		start, err = strconv.ParseUint(startStr, 10, 64)
 		if err != nil {
 			buildJSONErrorResponse(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		start = i
 	}
 
 	records, lowestID, highestID := eventSystem.GetEventsFromID(start, count)

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -914,29 +914,25 @@ func getEvents(w http.ResponseWriter, r *http.Request) {
 	var start uint64
 
 	if countStr := r.URL.Query().Get("count"); countStr != "" {
-		c, err := strconv.ParseInt(countStr, 10, 64)
+		c, err := strconv.ParseUint(countStr, 10, 64)
 		if err != nil {
 			buildJSONErrorResponse(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		if c <= 0 {
-			buildJSONErrorResponse(w, fmt.Sprintf("Illegal number of events: %d", c), http.StatusBadRequest)
+		if c == 0 {
+			buildJSONErrorResponse(w, `0 is not a valid value for "count"`, http.StatusBadRequest)
 			return
 		}
-		count = uint64(c)
+		count = c
 	}
 
 	if startStr := r.URL.Query().Get("start"); startStr != "" {
-		i, err := strconv.ParseInt(startStr, 10, 64)
+		i, err := strconv.ParseUint(startStr, 10, 64)
 		if err != nil {
 			buildJSONErrorResponse(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		if i < 0 {
-			buildJSONErrorResponse(w, fmt.Sprintf("Illegal id: %d", i), http.StatusBadRequest)
-			return
-		}
-		start = uint64(i)
+		start = i
 	}
 
 	records, lowestID, highestID := eventSystem.GetEventsFromID(start, count)


### PR DESCRIPTION
### What is this PR for?
Use ParseUint() instead of ParseInt(), because the query parameters will be treated as `uint64`.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2164

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
