### PR TITLE
[YUNIKORN-2167] check webapp is ready in mockScheduler.Init

### DIFF
--- a/pkg/scheduler/tests/mockscheduler_test.go
+++ b/pkg/scheduler/tests/mockscheduler_test.go
@@ -19,6 +19,10 @@
 package tests
 
 import (
+	"fmt"
+	"net"
+	"time"
+
 	"github.com/apache/yunikorn-core/pkg/common"
 	"github.com/apache/yunikorn-core/pkg/entrypoint"
 	"github.com/apache/yunikorn-core/pkg/scheduler"
@@ -54,6 +58,20 @@ func (m *mockScheduler) Init(config string, autoSchedule bool, withWebapp bool) 
 	m.scheduler = m.serviceContext.Scheduler
 
 	m.mockRM = newMockRMCallbackHandler()
+
+	if withWebapp {
+		err := common.WaitFor(500*time.Millisecond, 2*time.Second, func() bool {
+			conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", "9080"), time.Second)
+			if err == nil {
+				defer conn.Close()
+				return true
+			}
+			return false
+		})
+		if err != nil {
+			return fmt.Errorf("webapp failed to start in 2 seconds")
+		}
+	}
 
 	_, err := m.proxy.RegisterResourceManager(
 		&si.RegisterResourceManagerRequest{


### PR DESCRIPTION
### What is this PR for?

We start webservice in a goroutine. https://github.com/apache/yunikorn-core/blob/db70ca6e0ed46eb93362fc1bf48545781146f534/pkg/webservice/webservice.go#L71-L77

Sometime, client sends request before webservice is running (client.GetEvents faster than webservice in ms.Init). https://github.com/apache/yunikorn-core/blob/db70ca6e0ed46eb93362fc1bf48545781146f534/pkg/scheduler/tests/application_tracking_test.go#L45-L50

In this case, we will get `application_tracking_test.go:51: assertion failed: error is not nil: Get "http://localhost:9080/ws/v1/events/batch": dial tcp [::1]:9080: connect: connection refused`.

CI reference: https://github.com/apache/yunikorn-core/actions/runs/6920928414/job/18825954111


### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2167
