### PR TITLE
[YUNIKORN-2169] Fix queue resource update through configmaps

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -379,8 +379,8 @@ func (sq *Queue) setResources(resource configs.Resources) error {
 	case resources.StrictlyGreaterThanZero(maxResource):
 		log.Log(log.SchedQueue).Debug("setting max resources",
 			zap.String("queue", sq.QueuePath),
-			zap.Stringer("current max res", sq.maxResource),
-			zap.Stringer("new max res", maxResource))
+			zap.Stringer("current", sq.maxResource),
+			zap.Stringer("new", maxResource))
 		if !resources.Equals(sq.maxResource, maxResource) && sq.queueEvents != nil {
 			sq.queueEvents.sendMaxResourceChangedEvent()
 		}
@@ -389,23 +389,24 @@ func (sq *Queue) setResources(resource configs.Resources) error {
 	case sq.maxResource != nil:
 		log.Log(log.SchedQueue).Debug("setting max resources",
 			zap.String("queue", sq.QueuePath),
-			zap.Stringer("current max res", sq.maxResource),
-			zap.Stringer("new max res", maxResource))
+			zap.Stringer("current", sq.maxResource),
+			zap.Stringer("new", maxResource))
 		if sq.queueEvents != nil {
 			sq.queueEvents.sendMaxResourceChangedEvent()
 		}
 		sq.maxResource = nil
 		sq.updateMaxResourceMetrics()
 	default:
-		log.Log(log.SchedQueue).Debug("max resources setting ignored: cannot set zero max resources", zap.String("queue", sq.QueuePath))
+		log.Log(log.SchedQueue).Warn("max resources setting ignored: cannot set zero max resources",
+			zap.String("queue", sq.QueuePath))
 	}
 
 	switch {
 	case resources.StrictlyGreaterThanZero(guaranteedResource):
 		log.Log(log.SchedQueue).Debug("setting guaranteed resources",
 			zap.String("queue", sq.QueuePath),
-			zap.Stringer("current guaranteed res", sq.guaranteedResource),
-			zap.Stringer("new guaranteed res", guaranteedResource))
+			zap.Stringer("current", sq.guaranteedResource),
+			zap.Stringer("new", guaranteedResource))
 		if !resources.Equals(sq.guaranteedResource, guaranteedResource) && sq.queueEvents != nil {
 			sq.queueEvents.sendGuaranteedResourceChangedEvent()
 		}
@@ -414,15 +415,16 @@ func (sq *Queue) setResources(resource configs.Resources) error {
 	case sq.guaranteedResource != nil:
 		log.Log(log.SchedQueue).Debug("setting guaranteed resources",
 			zap.String("queue", sq.QueuePath),
-			zap.Stringer("current guaranteed res", sq.guaranteedResource),
-			zap.Stringer("new guaranteed res", guaranteedResource))
+			zap.Stringer("current", sq.guaranteedResource),
+			zap.Stringer("new", guaranteedResource))
 		if sq.queueEvents != nil {
 			sq.queueEvents.sendGuaranteedResourceChangedEvent()
 		}
 		sq.guaranteedResource = nil
 		sq.updateGuaranteedResourceMetrics()
 	default:
-		log.Log(log.SchedQueue).Debug("guaranteed resources setting ignored: cannot set zero max resources", zap.String("queue", sq.QueuePath))
+		log.Log(log.SchedQueue).Warn("guaranteed resources setting ignored: cannot set zero guaranteed resources",
+			zap.String("queue", sq.QueuePath))
 	}
 	return nil
 }
@@ -1302,8 +1304,8 @@ func (sq *Queue) SetMaxResource(max *resources.Resource) {
 	case resources.StrictlyGreaterThanZero(max):
 		log.Log(log.SchedQueue).Debug("setting max resources",
 			zap.String("queue", sq.QueuePath),
-			zap.Stringer("current max res", sq.maxResource),
-			zap.Stringer("new max res", max))
+			zap.Stringer("current", sq.maxResource),
+			zap.Stringer("new", max))
 		if !resources.Equals(sq.maxResource, max) && sq.queueEvents != nil {
 			sq.queueEvents.sendMaxResourceChangedEvent()
 		}
@@ -1312,15 +1314,16 @@ func (sq *Queue) SetMaxResource(max *resources.Resource) {
 	case sq.maxResource != nil:
 		log.Log(log.SchedQueue).Debug("setting max resources",
 			zap.String("queue", sq.QueuePath),
-			zap.Stringer("current max res", sq.maxResource),
-			zap.Stringer("new max res", max))
+			zap.Stringer("current", sq.maxResource),
+			zap.Stringer("new", max))
 		if sq.queueEvents != nil {
 			sq.queueEvents.sendMaxResourceChangedEvent()
 		}
 		sq.maxResource = nil
 		sq.updateMaxResourceMetrics()
 	default:
-		log.Log(log.SchedQueue).Debug("max resources setting ignored: cannot set zero max resources", zap.String("queue", sq.QueuePath))
+		log.Log(log.SchedQueue).Warn("max resources setting ignored: cannot set zero max resources",
+			zap.String("queue", sq.QueuePath))
 	}
 }
 

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -375,7 +375,8 @@ func (sq *Queue) setResources(resource configs.Resources) error {
 		return err
 	}
 
-	if resources.StrictlyGreaterThanZero(maxResource) {
+	switch {
+	case resources.StrictlyGreaterThanZero(maxResource):
 		log.Log(log.SchedQueue).Debug("setting max resources",
 			zap.String("queue", sq.QueuePath),
 			zap.Stringer("current max res", sq.maxResource),
@@ -385,7 +386,7 @@ func (sq *Queue) setResources(resource configs.Resources) error {
 		}
 		sq.maxResource = maxResource
 		sq.updateMaxResourceMetrics()
-	} else if sq.maxResource != nil {
+	case sq.maxResource != nil:
 		log.Log(log.SchedQueue).Debug("setting max resources",
 			zap.String("queue", sq.QueuePath),
 			zap.Stringer("current max res", sq.maxResource),
@@ -395,11 +396,12 @@ func (sq *Queue) setResources(resource configs.Resources) error {
 		}
 		sq.maxResource = nil
 		sq.updateMaxResourceMetrics()
-	} else {
+	default:
 		log.Log(log.SchedQueue).Debug("max resources setting ignored: cannot set zero max resources", zap.String("queue", sq.QueuePath))
 	}
 
-	if resources.StrictlyGreaterThanZero(guaranteedResource) {
+	switch {
+	case resources.StrictlyGreaterThanZero(guaranteedResource):
 		log.Log(log.SchedQueue).Debug("setting guaranteed resources",
 			zap.String("queue", sq.QueuePath),
 			zap.Stringer("current guaranteed res", sq.guaranteedResource),
@@ -409,7 +411,7 @@ func (sq *Queue) setResources(resource configs.Resources) error {
 		}
 		sq.guaranteedResource = guaranteedResource
 		sq.updateGuaranteedResourceMetrics()
-	} else if sq.guaranteedResource != nil {
+	case sq.guaranteedResource != nil:
 		log.Log(log.SchedQueue).Debug("setting guaranteed resources",
 			zap.String("queue", sq.QueuePath),
 			zap.Stringer("current guaranteed res", sq.guaranteedResource),
@@ -419,7 +421,7 @@ func (sq *Queue) setResources(resource configs.Resources) error {
 		}
 		sq.guaranteedResource = nil
 		sq.updateGuaranteedResourceMetrics()
-	} else {
+	default:
 		log.Log(log.SchedQueue).Debug("guaranteed resources setting ignored: cannot set zero max resources", zap.String("queue", sq.QueuePath))
 	}
 	return nil
@@ -1296,7 +1298,8 @@ func (sq *Queue) SetMaxResource(max *resources.Resource) {
 		zap.Stringer("current max", sq.maxResource),
 		zap.Stringer("new max", max))
 
-	if resources.StrictlyGreaterThanZero(max) {
+	switch {
+	case resources.StrictlyGreaterThanZero(max):
 		log.Log(log.SchedQueue).Debug("setting max resources",
 			zap.String("queue", sq.QueuePath),
 			zap.Stringer("current max res", sq.maxResource),
@@ -1306,7 +1309,7 @@ func (sq *Queue) SetMaxResource(max *resources.Resource) {
 		}
 		sq.maxResource = max.Clone()
 		sq.updateMaxResourceMetrics()
-	} else if sq.maxResource != nil {
+	case sq.maxResource != nil:
 		log.Log(log.SchedQueue).Debug("setting max resources",
 			zap.String("queue", sq.QueuePath),
 			zap.Stringer("current max res", sq.maxResource),
@@ -1316,7 +1319,7 @@ func (sq *Queue) SetMaxResource(max *resources.Resource) {
 		}
 		sq.maxResource = nil
 		sq.updateMaxResourceMetrics()
-	} else {
+	default:
 		log.Log(log.SchedQueue).Debug("max resources setting ignored: cannot set zero max resources", zap.String("queue", sq.QueuePath))
 	}
 }

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1773,8 +1773,7 @@ func TestSetResources(t *testing.T) {
 	assert.DeepEqual(t, queue.maxResource, expectedMaxResource)
 
 	// case 1: empty resource would set the queue resources to 'nil' if it has been set already
-	var nilResource *resources.Resource
-	nilResource = nil
+	var nilResource *resources.Resource = nil
 	err = queue.setResources(configs.Resources{
 		Guaranteed: make(map[string]string),
 		Max:        make(map[string]string),

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1772,23 +1772,25 @@ func TestSetResources(t *testing.T) {
 	assert.NilError(t, err, "failed to parse resource: %v", err)
 	assert.DeepEqual(t, queue.maxResource, expectedMaxResource)
 
-	// case 1: empty resource won't change the resources
+	// case 1: empty resource would set the queue resources to 'nil' if it has been set already
+	var nilResource *resources.Resource
+	nilResource = nil
 	err = queue.setResources(configs.Resources{
 		Guaranteed: make(map[string]string),
 		Max:        make(map[string]string),
 	})
 	assert.NilError(t, err, "failed to set resources: %v", err)
-	assert.DeepEqual(t, queue.guaranteedResource, expectedGuaranteedResource)
-	assert.DeepEqual(t, queue.maxResource, expectedMaxResource)
+	assert.DeepEqual(t, queue.guaranteedResource, nilResource)
+	assert.DeepEqual(t, queue.maxResource, nilResource)
 
-	// case 2: zero resource won't change the resources
+	// case 2: zero resource won't change the queue resources as it is 'nil' already
 	err = queue.setResources(configs.Resources{
 		Guaranteed: getZeroResourceConf(),
 		Max:        getZeroResourceConf(),
 	})
 	assert.NilError(t, err, "failed to set resources: %v", err)
-	assert.DeepEqual(t, queue.guaranteedResource, expectedGuaranteedResource)
-	assert.DeepEqual(t, queue.maxResource, expectedMaxResource)
+	assert.DeepEqual(t, queue.guaranteedResource, nilResource)
+	assert.DeepEqual(t, queue.maxResource, nilResource)
 }
 
 func TestPreemptingResource(t *testing.T) {

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1350,19 +1350,21 @@ func TestCreateDeepQueueConfig(t *testing.T) {
 
 func assertUpdateQueues(t *testing.T, resourceType string, resMap map[string]string) {
 	var resExpect *resources.Resource
+	var err error
 	if len(resMap) > 0 {
-		resExpect, _ = resources.NewResourceFromConf(resMap)
-		//assert.NilError(t, err, "resource from conf failed")
+		resExpect, err = resources.NewResourceFromConf(resMap)
+		assert.NilError(t, err, "resource from conf failed")
 	} else {
 		resExpect = nil
 	}
 
 	var res configs.Resources
-	if resourceType == "max" {
+	switch resourceType {
+	case "max":
 		res = configs.Resources{Max: resMap}
-	} else if resourceType == "guaranteed" {
+	case "guaranteed":
 		res = configs.Resources{Guaranteed: resMap}
-	} else {
+	default:
 		res = configs.Resources{Max: resMap, Guaranteed: resMap}
 	}
 
@@ -1396,13 +1398,14 @@ func assertUpdateQueues(t *testing.T, resourceType string, resMap map[string]str
 	if parent == nil {
 		t.Fatal("parent queue should still exist")
 	}
-	if resourceType == "max" {
+	switch resourceType {
+	case "max":
 		assert.Assert(t, resources.Equals(parent.GetMaxResource(), resExpect), "parent queue max resource should have been updated")
 		assert.Assert(t, resources.Equals(parent.GetGuaranteedResource(), nil), "parent queue guaranteed resource should have been updated")
-	} else if resourceType == "guaranteed" {
+	case "guaranteed":
 		assert.Assert(t, resources.Equals(parent.GetMaxResource(), nil), "parent queue max resource should have been updated")
 		assert.Assert(t, resources.Equals(parent.GetGuaranteedResource(), resExpect), "parent queue guaranteed resource should have been updated")
-	} else {
+	default:
 		assert.Assert(t, resources.Equals(parent.GetMaxResource(), resExpect), "parent queue max resource should have been updated")
 		assert.Assert(t, resources.Equals(parent.GetGuaranteedResource(), resExpect), "parent queue guaranteed resource should have been updated")
 	}
@@ -1410,7 +1413,6 @@ func assertUpdateQueues(t *testing.T, resourceType string, resMap map[string]str
 	if leaf == nil {
 		t.Fatal("leaf queue should have been created")
 	}
-
 }
 
 func TestUpdateQueues(t *testing.T) {

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -2559,6 +2559,31 @@ func TestUpdateRootQueue(t *testing.T) {
 	// make sure the update went through
 	assert.Equal(t, partition.GetQueue("root.leaf").CurrentState(), objects.Draining.String(), "leaf queue should have been marked for removal")
 	assert.Equal(t, partition.GetQueue("root.parent").CurrentState(), objects.Draining.String(), "parent queue should have been marked for removal")
+
+	// add new node, node 3 with 'memory' resource type
+	res1, err1 := resources.NewResourceFromConf(map[string]string{"vcore": "20", "memory": "50"})
+	assert.NilError(t, err1, "resource creation failed")
+	err = partition.AddNode(newNodeMaxResource("node-3", res1), nil)
+	assert.NilError(t, err, "test node3 add failed unexpected")
+
+	// root max resource gets updated with 'memory' resource type
+	expRes, err1 := resources.NewResourceFromConf(map[string]string{"vcore": "40", "memory": "50"})
+	assert.NilError(t, err1, "resource creation failed")
+	assert.Assert(t, resources.Equals(expRes, partition.root.GetMaxResource()), "root max resource not set as expected")
+
+	// remove node, node 3. root max resource won't have 'memory' resource type and updated with less 'vcore'
+	partition.removeNode("node-3")
+	assert.Assert(t, resources.Equals(res, partition.root.GetMaxResource()), "root max resource not set as expected")
+
+	// remove node, node 2. root max resource gets updated with less 'vcores'
+	partition.removeNode("node-2")
+	expRes1, err1 := resources.NewResourceFromConf(map[string]string{"vcore": "10"})
+	assert.NilError(t, err1, "resource creation failed")
+	assert.Assert(t, resources.Equals(expRes1, partition.root.GetMaxResource()), "root max resource not set as expected")
+
+	// remove node, node 1. root max resource should set to nil
+	partition.removeNode("node-1")
+	assert.Assert(t, resources.Equals(nil, partition.root.GetMaxResource()), "root max resource not set as expected")
 }
 
 // transition an application to completed state and wait for it to be processed into the completedApplications map

--- a/pkg/scheduler/tests/application_tracking_test.go
+++ b/pkg/scheduler/tests/application_tracking_test.go
@@ -73,8 +73,8 @@ func TestApplicationHistoryTracking(t *testing.T) {
 	ms.mockRM.waitForAcceptedNode(t, "node-1:1234", 1000)
 	events, err = client.GetEvents()
 	assert.NilError(t, err)
-	assert.Equal(t, 4, len(events.EventRecords), "number of events generated")
-	verifyNodeAddedEvents(t, events.EventRecords[2:])
+	assert.Equal(t, 5, len(events.EventRecords), "number of events generated")
+	verifyNodeAddedAndQueueMaxSetEvents(t, events.EventRecords[2:])
 
 	// Add application & check events
 	err = ms.proxy.UpdateApplication(&si.ApplicationRequest{
@@ -85,8 +85,8 @@ func TestApplicationHistoryTracking(t *testing.T) {
 	ms.mockRM.waitForAcceptedApplication(t, appID1, 1000)
 	events, err = client.GetEvents()
 	assert.NilError(t, err)
-	assert.Equal(t, 6, len(events.EventRecords), "number of events generated")
-	verifyAppAddedEvents(t, events.EventRecords[4:])
+	assert.Equal(t, 7, len(events.EventRecords), "number of events generated")
+	verifyAppAddedEvents(t, events.EventRecords[5:])
 
 	// Add allocation ask & check events
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
@@ -109,8 +109,8 @@ func TestApplicationHistoryTracking(t *testing.T) {
 	ms.mockRM.waitForAllocations(t, 1, 1000)
 	events, err = client.GetEvents()
 	assert.NilError(t, err)
-	assert.Equal(t, 11, len(events.EventRecords), "number of events generated")
-	verifyAllocationAskAddedEvents(t, events.EventRecords[6:])
+	assert.Equal(t, 12, len(events.EventRecords), "number of events generated")
+	verifyAllocationAskAddedEvents(t, events.EventRecords[7:])
 
 	allocations := ms.mockRM.getAllocations()
 	assert.Equal(t, 1, len(allocations), "number of allocations")
@@ -144,8 +144,8 @@ func TestApplicationHistoryTracking(t *testing.T) {
 
 	events, err = client.GetEvents()
 	assert.NilError(t, err)
-	assert.Equal(t, 14, len(events.EventRecords), "number of events generated")
-	verifyAllocationCancelledEvents(t, events.EventRecords[11:])
+	assert.Equal(t, 15, len(events.EventRecords), "number of events generated")
+	verifyAllocationCancelledEvents(t, events.EventRecords[12:])
 }
 
 func verifyQueueEvents(t *testing.T, events []*si.EventRecord) {
@@ -162,7 +162,7 @@ func verifyQueueEvents(t *testing.T, events []*si.EventRecord) {
 	assert.Equal(t, si.EventRecord_DETAILS_NONE, events[1].EventChangeDetail)
 }
 
-func verifyNodeAddedEvents(t *testing.T, events []*si.EventRecord) {
+func verifyNodeAddedAndQueueMaxSetEvents(t *testing.T, events []*si.EventRecord) {
 	assert.Equal(t, "node-1:1234", events[0].ObjectID)
 	assert.Equal(t, "schedulable: true", events[0].Message)
 	assert.Equal(t, "", events[0].ReferenceID)
@@ -170,12 +170,18 @@ func verifyNodeAddedEvents(t *testing.T, events []*si.EventRecord) {
 	assert.Equal(t, si.EventRecord_SET, events[0].EventChangeType)
 	assert.Equal(t, si.EventRecord_NODE_SCHEDULABLE, events[0].EventChangeDetail)
 
-	assert.Equal(t, "node-1:1234", events[1].ObjectID)
-	assert.Equal(t, "Node added to the scheduler", events[1].Message)
+	assert.Equal(t, "root", events[1].ObjectID)
+	assert.Equal(t, "", events[1].Message)
 	assert.Equal(t, "", events[1].ReferenceID)
-	assert.Equal(t, si.EventRecord_NODE, events[1].Type)
-	assert.Equal(t, si.EventRecord_ADD, events[1].EventChangeType)
-	assert.Equal(t, si.EventRecord_DETAILS_NONE, events[1].EventChangeDetail)
+	assert.Equal(t, si.EventRecord_SET, events[1].EventChangeType)
+	assert.Equal(t, si.EventRecord_QUEUE_MAX, events[1].EventChangeDetail)
+
+	assert.Equal(t, "node-1:1234", events[2].ObjectID)
+	assert.Equal(t, "Node added to the scheduler", events[2].Message)
+	assert.Equal(t, "", events[2].ReferenceID)
+	assert.Equal(t, si.EventRecord_NODE, events[2].Type)
+	assert.Equal(t, si.EventRecord_ADD, events[2].EventChangeType)
+	assert.Equal(t, si.EventRecord_DETAILS_NONE, events[2].EventChangeDetail)
 }
 
 func verifyAppAddedEvents(t *testing.T, events []*si.EventRecord) {

--- a/pkg/scheduler/tests/mockscheduler_test.go
+++ b/pkg/scheduler/tests/mockscheduler_test.go
@@ -21,6 +21,7 @@ package tests
 import (
 	"github.com/apache/yunikorn-core/pkg/common"
 	"github.com/apache/yunikorn-core/pkg/entrypoint"
+	"github.com/apache/yunikorn-core/pkg/events"
 	"github.com/apache/yunikorn-core/pkg/scheduler"
 	"github.com/apache/yunikorn-core/pkg/scheduler/objects"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/api"
@@ -48,6 +49,7 @@ func (m *mockScheduler) Init(config string, autoSchedule bool, withWebapp bool) 
 	BuildInfoMap := make(map[string]string)
 	BuildInfoMap["k"] = "v"
 
+	events.Init()
 	m.serviceContext = entrypoint.StartAllServicesWithParams(!autoSchedule, withWebapp)
 
 	m.proxy = m.serviceContext.RMProxy


### PR DESCRIPTION
### What is this PR for?
Queue resource update should work for any changes as expected. For example, adding any new resource types to current resources, removing any resource types from current resources, setting whole queue current resource to nil etc.

Also send queue resource change events accordingly.

### What type of PR is it?
* [ ] - Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2169

### How should this be tested?
Using unit tests

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
