### PR TITLE
YUNIKORN-2175 Add queue headRoom for Rest API querying and improve logs

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -994,8 +994,7 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption
 					}
 				}
 			}
-
-			sa.appEvents.sendAppDoesNotFitEvent(request)
+			sa.appEvents.sendAppDoesNotFitEvent(request, headRoom)
 			continue
 		}
 

--- a/pkg/scheduler/objects/application_events.go
+++ b/pkg/scheduler/objects/application_events.go
@@ -20,12 +20,12 @@ package objects
 
 import (
 	"fmt"
-	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"time"
 
 	"golang.org/x/time/rate"
 
 	"github.com/apache/yunikorn-core/pkg/common"
+	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/events"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )

--- a/pkg/scheduler/objects/application_events.go
+++ b/pkg/scheduler/objects/application_events.go
@@ -40,7 +40,7 @@ func (evt *applicationEvents) sendAppDoesNotFitEvent(request *AllocationAsk, hea
 	if !evt.eventSystem.IsEventTrackingEnabled() || !evt.limiter.Allow() {
 		return
 	}
-	message := fmt.Sprintf("Application %s does not fit into %s queue, request resoure %s can't fit headroom %s", request.GetApplicationID(), evt.app.queuePath, request.GetAllocatedResource().String(), headroom.String())
+	message := fmt.Sprintf("Application %s does not fit into %s queue (request resoure %s, headroom %s)", request.GetApplicationID(), evt.app.queuePath, request.GetAllocatedResource(), headroom)
 	event := events.CreateRequestEventRecord(request.GetAllocationKey(), request.GetApplicationID(), message, request.GetAllocatedResource())
 	evt.eventSystem.AddEvent(event)
 }
@@ -49,7 +49,7 @@ func (evt *applicationEvents) sendPlaceholderLargerEvent(ph *Allocation, request
 	if !evt.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-	message := fmt.Sprintf("Task group '%s' in application '%s': allocation resources '%s' are not matching placeholder '%s' allocation with ID '%s'", ph.GetTaskGroup(), evt.app.ApplicationID, request.GetAllocatedResource().String(), ph.GetAllocatedResource().String(), ph.GetAllocationKey())
+	message := fmt.Sprintf("Task group '%s' in application '%s': allocation resources '%s' are not matching placeholder '%s' allocation with ID '%s'", ph.GetTaskGroup(), evt.app.ApplicationID, request.GetAllocatedResource(), ph.GetAllocatedResource(), ph.GetAllocationKey())
 	event := events.CreateRequestEventRecord(ph.GetAllocationKey(), evt.app.ApplicationID, message, request.GetAllocatedResource())
 	evt.eventSystem.AddEvent(event)
 }

--- a/pkg/scheduler/objects/application_events.go
+++ b/pkg/scheduler/objects/application_events.go
@@ -20,6 +20,7 @@ package objects
 
 import (
 	"fmt"
+	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -35,11 +36,11 @@ type applicationEvents struct {
 	limiter     *rate.Limiter
 }
 
-func (evt *applicationEvents) sendAppDoesNotFitEvent(request *AllocationAsk) {
+func (evt *applicationEvents) sendAppDoesNotFitEvent(request *AllocationAsk, headroom *resources.Resource) {
 	if !evt.eventSystem.IsEventTrackingEnabled() || !evt.limiter.Allow() {
 		return
 	}
-	message := fmt.Sprintf("Application %s does not fit into %s queue", request.GetApplicationID(), evt.app.queuePath)
+	message := fmt.Sprintf("Application %s does not fit into %s queue, request resoure %s can't fit headroom %s", request.GetApplicationID(), evt.app.queuePath, request.GetAllocatedResource().String(), headroom.String())
 	event := events.CreateRequestEventRecord(request.GetAllocationKey(), request.GetApplicationID(), message, request.GetAllocatedResource())
 	evt.eventSystem.AddEvent(event)
 }

--- a/pkg/scheduler/objects/application_events_test.go
+++ b/pkg/scheduler/objects/application_events_test.go
@@ -19,6 +19,7 @@
 package objects
 
 import (
+	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"testing"
 	"time"
 
@@ -55,7 +56,7 @@ func TestSendAppDoesNotFitEvent(t *testing.T) {
 	}
 	mock := newEventSystemMockDisabled()
 	appEvents := newApplicationEvents(app, mock)
-	appEvents.sendAppDoesNotFitEvent(&AllocationAsk{})
+	appEvents.sendAppDoesNotFitEvent(&AllocationAsk{}, &resources.Resource{})
 	assert.Equal(t, 0, len(mock.events), "unexpected event")
 
 	mock = newEventSystemMock()
@@ -63,7 +64,7 @@ func TestSendAppDoesNotFitEvent(t *testing.T) {
 	appEvents.sendAppDoesNotFitEvent(&AllocationAsk{
 		applicationID: appID0,
 		allocationKey: aKey,
-	})
+	}, &resources.Resource{})
 	assert.Equal(t, 1, len(mock.events), "event was not generated")
 }
 
@@ -82,7 +83,7 @@ func TestSendAppDoesNotFitEventWithRateLimiter(t *testing.T) {
 		appEvents.sendAppDoesNotFitEvent(&AllocationAsk{
 			applicationID: appID0,
 			allocationKey: aKey,
-		})
+		}, &resources.Resource{})
 		time.Sleep(10 * time.Millisecond)
 	}
 	assert.Equal(t, 1, len(mock.events), "event was not generated")

--- a/pkg/scheduler/objects/application_events_test.go
+++ b/pkg/scheduler/objects/application_events_test.go
@@ -19,13 +19,13 @@
 package objects
 
 import (
-	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"testing"
 	"time"
 
 	"gotest.tools/v3/assert"
 
 	"github.com/apache/yunikorn-core/pkg/common"
+	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -609,6 +609,7 @@ func (sq *Queue) GetPartitionQueueDAOInfo() dao.PartitionQueueDAOInfo {
 	queueInfo.GuaranteedResource = sq.guaranteedResource.DAOMap()
 	queueInfo.AllocatedResource = sq.allocatedResource.DAOMap()
 	queueInfo.PreemptingResource = sq.preemptingResource.DAOMap()
+	queueInfo.HeadRoom = sq.getHeadRoom().DAOMap()
 	queueInfo.IsLeaf = sq.isLeaf
 	queueInfo.IsManaged = sq.isManaged
 	queueInfo.CurrentPriority = sq.getCurrentPriority()

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1708,8 +1708,9 @@ func TestGetPartitionQueueDAOInfo(t *testing.T) {
 	// test resources
 	root.maxResource = getResource(t)
 	root.guaranteedResource = getResource(t)
-	assert.DeepEqual(t, root.GetMaxResource().DAOMap(), root.GetMaxResource().DAOMap())
-	assert.DeepEqual(t, root.GetGuaranteedResource().DAOMap(), root.GetGuaranteedResource().DAOMap())
+	assert.DeepEqual(t, root.GetMaxResource().DAOMap(), root.GetPartitionQueueDAOInfo().MaxResource)
+	assert.DeepEqual(t, root.GetGuaranteedResource().DAOMap(), root.GetPartitionQueueDAOInfo().GuaranteedResource)
+	assert.DeepEqual(t, root.getHeadRoom().DAOMap(), root.GetPartitionQueueDAOInfo().HeadRoom)
 
 	// test allocatingAcceptedApps
 	root.allocatingAcceptedApps = getAllocatingAcceptedApps()

--- a/pkg/webservice/dao/queue_info.go
+++ b/pkg/webservice/dao/queue_info.go
@@ -33,6 +33,7 @@ type PartitionQueueDAOInfo struct {
 	GuaranteedResource     map[string]int64        `json:"guaranteedResource,omitempty"`
 	AllocatedResource      map[string]int64        `json:"allocatedResource,omitempty"`
 	PreemptingResource     map[string]int64        `json:"preemptingResource,omitempty"`
+	HeadRoom               map[string]int64        `json:"headroom,omitempty"`
 	IsLeaf                 bool                    `json:"isLeaf"`    // no omitempty, a false value gives a quick way to understand whether it's leaf.
 	IsManaged              bool                    `json:"isManaged"` // no omitempty, a false value gives a quick way to understand whether it's managed.
 	Properties             map[string]string       `json:"properties,omitempty"`


### PR DESCRIPTION
### What is this PR for?
1. We should support query headroom using rest API.

2. And from the logs, i can't find any info about the headroom value, when application request can't meet the headroom.

```
Application **** does not fit into *** queue\" timestampNano:1700625301297929026 referenceID:\"******\" resource:{resources:{key:\"ephemeral-storage\" value:{}} resources:{key:\"memory\" value:{value:24000000000}} resources:{key:\"pods\" value:{value:1}} resources:{key:\"vcore\" value:{value:13000}}}"} 
```
We need to add more logs about this case!


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-2175
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
