### PR TITLE
[YUNIKORN-2168] Generate more random data in queue_test.go and template.go

### DIFF
--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -20,6 +20,7 @@ package objects
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
 	"sort"
 	"strconv"
@@ -1728,7 +1729,7 @@ func getAllocatingAcceptedApps() map[string]bool {
 
 func getResourceConf() map[string]string {
 	resource := make(map[string]string)
-	resource["memory"] = strconv.Itoa(time.Now().Second()%1000 + 100)
+	resource["memory"] = strconv.Itoa(rand.Intn(10000) + 100)
 	return resource
 }
 
@@ -1747,7 +1748,7 @@ func getZeroResourceConf() map[string]string {
 
 func getProperties() map[string]string {
 	properties := make(map[string]string)
-	properties[strconv.Itoa(time.Now().Second())] = strconv.Itoa(time.Now().Second())
+	properties[strconv.Itoa(rand.Intn(10000))] = strconv.Itoa(rand.Intn(10000))
 	return properties
 }
 

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1729,7 +1729,7 @@ func getAllocatingAcceptedApps() map[string]bool {
 
 func getResourceConf() map[string]string {
 	resource := make(map[string]string)
-	resource["memory"] = strconv.Itoa(rand.Intn(10000) + 100)
+	resource["memory"] = strconv.Itoa(rand.Intn(10000) + 100) //nolint:gosec
 	return resource
 }
 
@@ -1748,7 +1748,7 @@ func getZeroResourceConf() map[string]string {
 
 func getProperties() map[string]string {
 	properties := make(map[string]string)
-	properties[strconv.Itoa(rand.Intn(10000))] = strconv.Itoa(rand.Intn(10000))
+	properties[strconv.Itoa(rand.Intn(10000))] = strconv.Itoa(rand.Intn(10000)) //nolint:gosec
 	return properties
 }
 

--- a/pkg/scheduler/objects/template/template_test.go
+++ b/pkg/scheduler/objects/template/template_test.go
@@ -19,9 +19,9 @@
 package template
 
 import (
+	"math/rand"
 	"strconv"
 	"testing"
-	"time"
 
 	"gotest.tools/v3/assert"
 
@@ -31,14 +31,14 @@ import (
 
 func getResourceConf() map[string]string {
 	resource := make(map[string]string)
-	resource["memory"] = strconv.Itoa(time.Now().Second()%1000 + 10)
-	resource["vcore"] = strconv.Itoa(time.Now().Second()%1000 + 10)
+	resource["memory"] = strconv.Itoa(rand.Intn(10000) + 10)
+	resource["vcore"] = strconv.Itoa(rand.Intn(10000) + 10)
 	return resource
 }
 
 func getProperties() map[string]string {
 	properties := make(map[string]string)
-	properties[strconv.Itoa(time.Now().Second()%1000)] = strconv.Itoa(time.Now().Second() % 1000)
+	properties[strconv.Itoa(rand.Intn(10000))] = strconv.Itoa(rand.Intn(10000))
 	return properties
 }
 

--- a/pkg/scheduler/objects/template/template_test.go
+++ b/pkg/scheduler/objects/template/template_test.go
@@ -31,14 +31,14 @@ import (
 
 func getResourceConf() map[string]string {
 	resource := make(map[string]string)
-	resource["memory"] = strconv.Itoa(rand.Intn(10000) + 10)
-	resource["vcore"] = strconv.Itoa(rand.Intn(10000) + 10)
+	resource["memory"] = strconv.Itoa(rand.Intn(10000) + 10) //nolint:gosec
+	resource["vcore"] = strconv.Itoa(rand.Intn(10000) + 10)  //nolint:gosec
 	return resource
 }
 
 func getProperties() map[string]string {
 	properties := make(map[string]string)
-	properties[strconv.Itoa(rand.Intn(10000))] = strconv.Itoa(rand.Intn(10000))
+	properties[strconv.Itoa(rand.Intn(10000))] = strconv.Itoa(rand.Intn(10000)) //nolint:gosec
 	return properties
 }
 


### PR DESCRIPTION
### What is this PR for?
quoted from https://github.com/apache/yunikorn-core/pull/696#issuecomment-1820206504

> Generate more random data in getResourceConf(), something more in the direction of rand.Intn(10000) instead of the seconds based setup.

In queue_test.go and template_test.go both use getResourceConf() that use seconds based random data. And not only getResourceConf(), template_test.go#getProperties() use seconds based random data too. Use rand.Intn instead of using seconds based random data could generate more random data.

### What type of PR is it?
* [x] - Improvement

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2168

### How should this be tested?
covered by unit test

### Screenshots (if appropriate)
N/A

### Questions:
N/A
