### PR TITLE
YUNIKORN-2188 Improve state transition event to include the eventinfo

### DIFF
--- a/pkg/scheduler/objects/application_events.go
+++ b/pkg/scheduler/objects/application_events.go
@@ -117,11 +117,11 @@ func (evt *applicationEvents) sendRemoveApplicationEvent() {
 	evt.eventSystem.AddEvent(event)
 }
 
-func (evt *applicationEvents) sendStateChangeEvent(changeDetail si.EventRecord_ChangeDetail) {
+func (evt *applicationEvents) sendStateChangeEvent(changeDetail si.EventRecord_ChangeDetail, eventInfo string) {
 	if !evt.eventSystem.IsEventTrackingEnabled() || !evt.app.sendStateChangeEvents {
 		return
 	}
-	event := events.CreateAppEventRecord(evt.app.ApplicationID, "", "", si.EventRecord_SET, changeDetail, evt.app.allocatedResource)
+	event := events.CreateAppEventRecord(evt.app.ApplicationID, eventInfo, "", si.EventRecord_SET, changeDetail, evt.app.allocatedResource)
 	evt.eventSystem.AddEvent(event)
 }
 

--- a/pkg/scheduler/objects/application_events.go
+++ b/pkg/scheduler/objects/application_events.go
@@ -117,14 +117,6 @@ func (evt *applicationEvents) sendRemoveApplicationEvent() {
 	evt.eventSystem.AddEvent(event)
 }
 
-func (evt *applicationEvents) sendRejectApplicationEvent(eventInfo string) {
-	if !evt.eventSystem.IsEventTrackingEnabled() {
-		return
-	}
-	event := events.CreateAppEventRecord(evt.app.ApplicationID, eventInfo, "", si.EventRecord_REMOVE, si.EventRecord_APP_REJECT, evt.app.allocatedResource)
-	evt.eventSystem.AddEvent(event)
-}
-
 func (evt *applicationEvents) sendStateChangeEvent(changeDetail si.EventRecord_ChangeDetail) {
 	if !evt.eventSystem.IsEventTrackingEnabled() || !evt.app.sendStateChangeEvents {
 		return

--- a/pkg/scheduler/objects/application_events_test.go
+++ b/pkg/scheduler/objects/application_events_test.go
@@ -354,17 +354,33 @@ func TestSendStateChangeEvent(t *testing.T) {
 	}
 	mock := newEventSystemMockDisabled()
 	appEvents := newApplicationEvents(app, mock)
-	appEvents.sendStateChangeEvent(si.EventRecord_APP_RUNNING)
+	appEvents.sendStateChangeEvent(si.EventRecord_APP_RUNNING, "")
 	assert.Equal(t, 0, len(mock.events), "unexpected event")
 
 	mock = newEventSystemMock()
 	appEvents = newApplicationEvents(app, mock)
-	appEvents.sendStateChangeEvent(si.EventRecord_APP_RUNNING)
+	appEvents.sendStateChangeEvent(si.EventRecord_APP_RUNNING, "The application is running")
 	event := mock.events[0]
 	assert.Equal(t, si.EventRecord_APP, event.Type)
 	assert.Equal(t, si.EventRecord_SET, event.EventChangeType)
 	assert.Equal(t, si.EventRecord_APP_RUNNING, event.EventChangeDetail)
 	assert.Equal(t, "app-0", event.ObjectID)
 	assert.Equal(t, "", event.ReferenceID)
-	assert.Equal(t, "", event.Message)
+	assert.Equal(t, "The application is running", event.Message)
+
+	mock = newEventSystemMockDisabled()
+	appEvents = newApplicationEvents(app, mock)
+	appEvents.sendStateChangeEvent(si.EventRecord_APP_RUNNING, "ResourceReservationTimeout")
+	assert.Equal(t, 0, len(mock.events), "unexpected event")
+
+	mock = newEventSystemMock()
+	appEvents = newApplicationEvents(app, mock)
+	appEvents.sendStateChangeEvent(si.EventRecord_APP_REJECT, "Failed to add application to partition (placement rejected)")
+	event = mock.events[0]
+	assert.Equal(t, si.EventRecord_APP, event.Type)
+	assert.Equal(t, si.EventRecord_SET, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_APP_REJECT, event.EventChangeDetail)
+	assert.Equal(t, "app-0", event.ObjectID)
+	assert.Equal(t, "", event.ReferenceID)
+	assert.Equal(t, "Failed to add application to partition (placement rejected)", event.Message)
 }

--- a/pkg/scheduler/objects/application_events_test.go
+++ b/pkg/scheduler/objects/application_events_test.go
@@ -346,28 +346,6 @@ func TestSendRemoveApplicationEvent(t *testing.T) {
 	assert.Equal(t, "", event.Message)
 }
 
-func TestSendRejectApplicationEvent(t *testing.T) {
-	app := &Application{
-		ApplicationID: appID0,
-		queuePath:     "root.test",
-	}
-	mock := newEventSystemMockDisabled()
-	appEvents := newApplicationEvents(app, mock)
-	appEvents.sendRejectApplicationEvent("ResourceReservationTimeout")
-	assert.Equal(t, 0, len(mock.events), "unexpected event")
-
-	mock = newEventSystemMock()
-	appEvents = newApplicationEvents(app, mock)
-	appEvents.sendRejectApplicationEvent("ResourceReservationTimeout")
-	event := mock.events[0]
-	assert.Equal(t, si.EventRecord_APP, event.Type)
-	assert.Equal(t, si.EventRecord_REMOVE, event.EventChangeType)
-	assert.Equal(t, si.EventRecord_APP_REJECT, event.EventChangeDetail)
-	assert.Equal(t, "app-0", event.ObjectID)
-	assert.Equal(t, "", event.ReferenceID)
-	assert.Equal(t, "ResourceReservationTimeout", event.Message)
-}
-
 func TestSendStateChangeEvent(t *testing.T) {
 	app := &Application{
 		ApplicationID:         appID0,

--- a/pkg/scheduler/objects/application_state.go
+++ b/pkg/scheduler/objects/application_state.go
@@ -149,8 +149,10 @@ func NewAppState() *fsm.FSM {
 					zap.String("source", event.Src),
 					zap.String("destination", event.Dst),
 					zap.String("event", event.Event))
+
+				eventInfo := ""
 				if len(event.Args) == 2 {
-					eventInfo := event.Args[1].(string) //nolint:errcheck
+					eventInfo = event.Args[1].(string) //nolint:errcheck
 					app.OnStateChange(event, eventInfo)
 				} else {
 					app.OnStateChange(event, "")
@@ -161,7 +163,7 @@ func NewAppState() *fsm.FSM {
 						zap.String("state", event.Dst))
 					return
 				}
-				app.appEvents.sendStateChangeEvent(eventDetails)
+				app.appEvents.sendStateChangeEvent(eventDetails, eventInfo)
 			},
 			"leave_state": func(_ context.Context, event *fsm.Event) {
 				event.Args[0].(*Application).clearStateTimer() //nolint:errcheck


### PR DESCRIPTION
### What is this PR for?
1. The PR remove the sendRejectApplicationEvent to change to use state change event, but we need to support eventinfo for every state change.

https://github.com/apache/yunikorn-core/pull/629

2. we should remove the unsued older sendRejectApplicationEvent related logic.


### What type of PR is it?
* [x] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-2188
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
