### PR TITLE
[YUNIKORN-2098] Change go lint SHA detection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
+      - name: Fetch all branches and tags
+        run: git fetch --all
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,9 @@ $(GOLANGCI_LINT_BIN):
 # In dev setup look at all changes on top of master
 lint: $(GOLANGCI_LINT_BIN)
 	@echo "running golangci-lint"
-	@git symbolic-ref -q HEAD && REV="origin/HEAD" || REV="HEAD^" ; \
+	@git show-ref
+	@REV="origin/HEAD"; \
+	git rev-parse $${REV} || REV="HEAD^"; \
 	headSHA=$$(git rev-parse --short=12 $${REV}) ; \
 	echo "checking against commit sha $${headSHA}" ; \
 	"${GOLANGCI_LINT_BIN}" run --new-from-rev=$${headSHA}


### PR DESCRIPTION
### What is this PR for?
In [YUNIKORN-285](https://issues.apache.org/jira/browse/YUNIKORN-285), we previously included git symbolic-ref -q HEAD because Travis CI often encountered a detached head situation. However, now that we have switched to GitHub Actions, we can utilize the checkout@v3 action, which efficiently fetches all Git references.

Consequently, we can remove `git symbolic-ref -q HEAD` Instead, we can initially set `REV='origin/HEAD'` If git rev-parse fails, we can fall back to `REV=HEAD^`

Regarding the modification from `fetch-depth: 2` to `fetch-depth: 0` , I have compared the GitHub Action times before this pull request and with the master. The duration of the git checkout action remained around 2 seconds. Therefore, I believe this change is acceptable, as it does not introduce significant overhead.

I encountered this issue when I manually triggered a GitHub Action in the k8shim fork repository. In contrast, manually triggering GitHub Actions in the core repository does not lead to this issue. This is because, in the core repository, the Golang CI is only executed when submitting a Pull Request. 

However, I believe ensuring consistency in the `make lint` process between k8shim and core is the correct approach.

Perhaps we could consider aligning k8shim's GolangCI behavior with that of the core? (only triggering during PR)
cc @craigcondit @wilfred-s




### What type of PR is it?
* [x] - Improvement


### What is the Jira issue?
[YUNIKORN-2098](https://issues.apache.org/jira/browse/YUNIKORN-2098)