### PR TITLE
[YUNIKORN-2197] remove FitInMaxUndef from node code

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -417,14 +417,22 @@ func subNonNegative(left, right *Resource) (*Resource, string) {
 	return out, message
 }
 
-// Check if smaller fits in larger
+// FitIn Checks if smaller fits in larger
 // Types not defined in the larger resource are considered 0 values for Quantity
 // A nil resource is treated as an empty resource (all types are 0)
+// Deprecated: use receiver version Resource.FitIn
 func FitIn(larger, smaller *Resource) bool {
 	return larger.fitIn(smaller, false)
 }
 
-// Check if smaller fits in the defined resource
+// FitIn checks if smaller fits in the defined resource
+// Types not defined in resource this is called against are considered 0 for Quantity
+// A nil resource is treated as an empty resource (no types defined)
+func (r *Resource) FitIn(smaller *Resource) bool {
+	return r.fitIn(smaller, false)
+}
+
+// FitInMaxUndef checks if smaller fits in the defined resource
 // Types not defined in resource this is called against are considered the maximum value for Quantity
 // A nil resource is treated as an empty resource (no types defined)
 func (r *Resource) FitInMaxUndef(smaller *Resource) bool {


### PR DESCRIPTION
### What is this PR for?
Nodes should perform a strict FitIn for the resources requested not allowing resource types in allocation that are not defined on the node. Includes start of the Resources.FitIn refactor

This is a followup of the cleanup from YUNIKORN-1125. Discovered while testing YUNIKORN-2174.

### What type of PR is it?
* [X] - Bug Fix
* [X] - Refactoring

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-2197

### How should this be tested?
Unit test cover the full change