### PR TITLE
[YUNIKORN-809] Remove old behavior that dynamical queue can extend application.sort.policy from parent

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -919,23 +919,13 @@ func (sq *Queue) addChildQueue(child *Queue) error {
 		if child.isManaged {
 			return nil
 		}
-		// this is a story about compatibility. the template is a new feature, and we want to keep old behavior.
-		// 1) try to use template if it is not nil
-		// 2) otherwise, child leaf copy the configs.ApplicationSortPolicy from parent (old behavior)
+		// try to use template if it is not nil
 		if sq.template != nil {
 			log.Log(log.SchedQueue).Debug("applying child template to new leaf queue",
 				zap.String("child queue", child.QueuePath),
 				zap.String("parent queue", sq.QueuePath),
 				zap.Any("template", sq.template))
 			child.applyTemplate(sq.template)
-		} else {
-			policyValue, ok := sq.properties[configs.ApplicationSortPolicy]
-			if ok {
-				log.Log(log.Deprecation).Warn("inheriting application sort policy is deprecated, use child templates",
-					zap.String("child queue", child.QueuePath),
-					zap.String("parent queue", sq.QueuePath))
-				child.properties[configs.ApplicationSortPolicy] = policyValue
-			}
 		}
 		return nil
 	}

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1524,15 +1524,6 @@ func TestQueueProps(t *testing.T) {
 	assert.Assert(t, leaf.isLeaf && leaf.isManaged, "leaf queue is not marked as managed leaf")
 	assert.Equal(t, len(leaf.properties), 2, "leaf queue properties size incorrect")
 
-	props = map[string]string{"first": "not inherited", configs.ApplicationSortPolicy: "stateaware"}
-	parent, err = createManagedQueueWithProps(root, "parent2", true, nil, props)
-	assert.NilError(t, err, "failed to create parent queue")
-	assert.Equal(t, len(parent.properties), 2, "parent queue properties size incorrect")
-	leaf, err = createDynamicQueue(parent, "leaf", false)
-	assert.NilError(t, err, "failed to create leaf queue")
-	assert.Assert(t, leaf.isLeaf && !leaf.isManaged, "leaf queue is not marked as unmanaged leaf")
-	assert.Equal(t, leaf.properties[configs.ApplicationSortPolicy], "stateaware", "leaf queue property value not as expected")
-
 	props = map[string]string{}
 	leaf, err = createManagedQueueWithProps(parent, "leaf", false, nil, props)
 	assert.NilError(t, err, "failed to create leaf queue")


### PR DESCRIPTION
### What is this PR for?
Remove deprecated behavior. The old behavior is replaced by child template (see [YUNIKORN-193](https://issues.apache.org/jira/browse/YUNIKORN-193)).

### What type of PR is it?
* [x] - Improvement

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-809

### How should this be tested?
Remove deprecated code, properties should be set in child template and the behavior is covered by unit test. 

### Screenshots (if appropriate)
N/A

### Questions:
N/A
