### PR TITLE
[YUNIKORN-2238] Fix typo in SetPlaceholderCreateTime parameter

### DIFF
--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -264,10 +264,10 @@ func (a *Allocation) GetPlaceholderCreateTime() time.Time {
 }
 
 // SetPlaceholderCreateTime updates the placeholder's creation time
-func (a *Allocation) SetPlaceholderCreateTime(placeholdereCreateTime time.Time) {
+func (a *Allocation) SetPlaceholderCreateTime(placeholderCreateTime time.Time) {
 	a.Lock()
 	defer a.Unlock()
-	a.placeholderCreateTime = placeholdereCreateTime
+	a.placeholderCreateTime = placeholderCreateTime
 }
 
 // IsPlaceholder returns whether the allocation is a placeholder


### PR DESCRIPTION
### What is this PR for?
There's a typo inside SetPlaceholderCreateTime function. The parameter `placeholdereCreateTime` should be `placeholderCreateTime`.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
N/A

### What is the Jira issue?
[YUNIKORN-2238](https://issues.apache.org/jira/browse/YUNIKORN-2238)

### How should this be tested?
N/A

### Screenshots (if appropriate)
N/A

### Questions:
N/A