### PR TITLE
[YUNIKORN-2235] Add new RESTful API for retrieving application

### DIFF
--- a/pkg/scheduler/objects/application_state.go
+++ b/pkg/scheduler/objects/application_state.go
@@ -60,6 +60,7 @@ func (ae applicationEvent) String() string {
 // ----------------------------------
 type applicationState int
 
+// Application states are used for filtering in the webservice handlers. Please check&update the logic as needed if the state machine is modified
 const (
 	New applicationState = iota
 	Accepted

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -425,6 +425,10 @@ func (pc *PartitionContext) removeAppInternal(appID string) *objects.Application
 	return app
 }
 
+func (pc *PartitionContext) GetApplication(appID string) *objects.Application {
+	return pc.getApplication(appID)
+}
+
 func (pc *PartitionContext) getApplication(appID string) *objects.Application {
 	pc.RLock()
 	defer pc.RUnlock()

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1451,6 +1451,23 @@ func TestUpdateQueues(t *testing.T) {
 	assertUpdateQueues(t, "both", map[string]string{})
 }
 
+func TestGetApplication(t *testing.T) {
+	partition, err := newBasePartition()
+	assert.NilError(t, err, "partition create failed")
+	app := newApplication(appID1, "default", defQueue)
+	err = partition.AddApplication(app)
+	assert.NilError(t, err, "no error expected while adding the application")
+	assert.Equal(t, partition.GetApplication(appID1), app, "partition failed to add app incorrect app returned")
+	app2 := newApplication(appID2, "default", "unknown")
+	err = partition.AddApplication(app2)
+	if err == nil {
+		t.Error("app-2 should not have been added to the partition")
+	}
+	if partition.GetApplication(appID2) != nil {
+		t.Fatal("partition added app incorrectly should have failed")
+	}
+}
+
 func TestGetQueue(t *testing.T) {
 	// get the partition
 	partition, err := newBasePartition()

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -61,24 +61,24 @@ const (
 )
 
 var allowedActiveStatusMsg string
-var allowedAppActiveStates map[string]bool
+var allowedAppActiveStatuses map[string]bool
 
 func init() {
-	allowedAppActiveStates = make(map[string]bool)
+	allowedAppActiveStatuses = make(map[string]bool)
 
-	allowedAppActiveStates["new"] = true
-	allowedAppActiveStates["accepted"] = true
-	allowedAppActiveStates["starting"] = true
-	allowedAppActiveStates["running"] = true
-	allowedAppActiveStates["completing"] = true
-	allowedAppActiveStates["failing"] = true
-	allowedAppActiveStates["resuming"] = true
+	allowedAppActiveStatuses["new"] = true
+	allowedAppActiveStatuses["accepted"] = true
+	allowedAppActiveStatuses["starting"] = true
+	allowedAppActiveStatuses["running"] = true
+	allowedAppActiveStatuses["completing"] = true
+	allowedAppActiveStatuses["failing"] = true
+	allowedAppActiveStatuses["resuming"] = true
 
-	var activeStates []string
-	for k := range allowedAppActiveStates {
-		activeStates = append(activeStates, k)
+	var activeStatuses []string
+	for k := range allowedAppActiveStatuses {
+		activeStatuses = append(activeStatuses, k)
 	}
-	allowedActiveStatusMsg = fmt.Sprintf("Only following active states are allowed: %s", strings.Join(activeStates, ","))
+	allowedActiveStatusMsg = fmt.Sprintf("Only following active statuses are allowed: %s", strings.Join(activeStatuses, ","))
 }
 
 func getStackInfo(w http.ResponseWriter, r *http.Request) {
@@ -659,7 +659,7 @@ func getPartitionApplicationsByState(w http.ResponseWriter, r *http.Request) {
 	switch appState {
 	case "active":
 		if status := strings.ToLower(r.URL.Query().Get("status")); status != "" {
-			if !allowedAppActiveStates[status] {
+			if !allowedAppActiveStatuses[status] {
 				buildJSONErrorResponse(w, allowedActiveStatusMsg, http.StatusBadRequest)
 				return
 			}

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -661,8 +661,8 @@ func getPartitionApplicationsByState(w http.ResponseWriter, r *http.Request) {
 		buildJSONErrorResponse(w, MissingParamsName, http.StatusBadRequest)
 		return
 	}
-	partition := vars.ByName("partition")
-	appState := vars.ByName("state")
+	partition := vars.ByName(strings.ToLower("partition"))
+	appState := vars.ByName(strings.ToLower("state"))
 
 	partitionContext := schedulerContext.GetPartitionWithoutClusterID(partition)
 	if partitionContext == nil {
@@ -693,6 +693,8 @@ func getPartitionApplicationsByState(w http.ResponseWriter, r *http.Request) {
 		appList = partitionContext.GetRejectedApplications()
 	case objects.Completed.String():
 		appList = partitionContext.GetCompletedApplications()
+	default:
+		buildJSONErrorResponse(w, "BUG: unknown state", http.StatusInternalServerError)
 	}
 	appsDao := make([]*dao.ApplicationDAOInfo, 0)
 	for _, app := range appList {

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -60,7 +60,7 @@ const (
 	NodeDoesNotExists        = "Node not found"
 )
 
-var allowedActiveStatesMsg string
+var allowedActiveStatusMsg string
 var allowedAppActiveStates map[string]bool
 
 func init() {
@@ -78,7 +78,7 @@ func init() {
 	for k := range allowedAppActiveStates {
 		activeStates = append(activeStates, k)
 	}
-	allowedActiveStatesMsg = fmt.Sprintf("Only following active states are allowed: %s", strings.Join(activeStates, ","))
+	allowedActiveStatusMsg = fmt.Sprintf("Only following active states are allowed: %s", strings.Join(activeStates, ","))
 }
 
 func getStackInfo(w http.ResponseWriter, r *http.Request) {
@@ -655,16 +655,12 @@ func getPartitionApplicationsByState(w http.ResponseWriter, r *http.Request) {
 		buildJSONErrorResponse(w, PartitionDoesNotExists, http.StatusNotFound)
 		return
 	}
-	if appState != "active" && appState != "rejected" && appState != "completed" {
-		buildJSONErrorResponse(w, "Only following application states are allowed: active, rejected, completed", http.StatusBadRequest)
-		return
-	}
 	var appList []*objects.Application
 	switch appState {
 	case "active":
 		if status := strings.ToLower(r.URL.Query().Get("status")); status != "" {
 			if !allowedAppActiveStates[status] {
-				buildJSONErrorResponse(w, allowedActiveStatesMsg, http.StatusBadRequest)
+				buildJSONErrorResponse(w, allowedActiveStatusMsg, http.StatusBadRequest)
 				return
 			}
 			for _, app := range partitionContext.GetApplications() {
@@ -680,7 +676,7 @@ func getPartitionApplicationsByState(w http.ResponseWriter, r *http.Request) {
 	case "completed":
 		appList = partitionContext.GetCompletedApplications()
 	default:
-		buildJSONErrorResponse(w, "BUG: unknown state", http.StatusInternalServerError)
+		buildJSONErrorResponse(w, "Only following application states are allowed: active, rejected, completed", http.StatusBadRequest)
 		return
 	}
 	appsDao := make([]*dao.ApplicationDAOInfo, 0, len(appList))

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1486,7 +1486,7 @@ func assertAppStateAllow(t *testing.T, resp *MockResponseWriter) {
 	err := json.Unmarshal(resp.outputBytes, &errInfo)
 	assert.NilError(t, err, unmarshalError)
 	assert.Equal(t, http.StatusBadRequest, resp.statusCode, statusCodeError)
-	assert.Equal(t, errInfo.Message, allowedStatesMsg, jsonMessageError)
+	assert.Equal(t, errInfo.Message, "Only following application states are allowed: active, rejected, completed", jsonMessageError)
 	assert.Equal(t, errInfo.StatusCode, http.StatusBadRequest)
 }
 

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1495,7 +1495,7 @@ func assertActiveStateAllow(t *testing.T, resp *MockResponseWriter) {
 	err := json.Unmarshal(resp.outputBytes, &errInfo)
 	assert.NilError(t, err, unmarshalError)
 	assert.Equal(t, http.StatusBadRequest, resp.statusCode, statusCodeError)
-	assert.Equal(t, errInfo.Message, allowedActiveStatesMsg, jsonMessageError)
+	assert.Equal(t, errInfo.Message, allowedActiveStatusMsg, jsonMessageError)
 	assert.Equal(t, errInfo.StatusCode, http.StatusBadRequest)
 }
 

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -125,6 +125,18 @@ var webRoutes = routes{
 	route{
 		"Scheduler",
 		"GET",
+		"/ws/v1/partition/:partition/application/:application",
+		getApplication,
+	},
+	route{
+		"Scheduler",
+		"GET",
+		"/ws/v1/partition/:partition/applications/:state",
+		getPartitionApplicationsByState,
+	},
+	route{
+		"Scheduler",
+		"GET",
 		"/ws/v1/partition/:partition/usage/users",
 		getUsersResourceUsage,
 	},


### PR DESCRIPTION
### What is this PR for?
This PR add 2 RESTful API. 
One for retrieving one application object directly via /ws/v1/partition/{partitionName}/application/{applicationID}.
The other for listing application IDs via /ws/v1/partition/{partitionName}/applications/{state}.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2235

### How should this be tested?
It's been locally tested using go test
### Screenshots (if appropriate)
N/A

### Questions:
N/A
