### PR TITLE
[YUNIKORN-2233] Scheduler core cannot be stopped properly

### DIFF
--- a/pkg/common/security/usergroup_no_resolver.go
+++ b/pkg/common/security/usergroup_no_resolver.go
@@ -33,6 +33,7 @@ func GetUserGroupNoResolve() *UserGroupCache {
 		lookup:        noLookupUser,
 		lookupGroupID: noLookupGroupID,
 		groupIds:      noLookupGroupIds,
+		stop:          make(chan struct{}),
 	}
 }
 

--- a/pkg/common/security/usergroup_os_resolver.go
+++ b/pkg/common/security/usergroup_os_resolver.go
@@ -31,6 +31,7 @@ func GetUserGroupCacheOS() *UserGroupCache {
 		lookup:        user.Lookup,
 		lookupGroupID: user.LookupGroupId,
 		groupIds:      wrappedGroupIds,
+		stop:          make(chan struct{}),
 	}
 }
 

--- a/pkg/common/security/usergroup_test_resolver.go
+++ b/pkg/common/security/usergroup_test_resolver.go
@@ -34,6 +34,7 @@ func GetUserGroupCacheTest() *UserGroupCache {
 		lookup:        lookup,
 		lookupGroupID: lookupGroupID,
 		groupIds:      groupIds,
+		stop:          make(chan struct{}),
 	}
 }
 

--- a/pkg/entrypoint/entrypoint.go
+++ b/pkg/entrypoint/entrypoint.go
@@ -103,6 +103,7 @@ func startAllServicesWithParameters(opts startupOptions) *ServiceContext {
 		imHistory = history.NewInternalMetricsHistory(opts.metricsHistorySize)
 		metricsCollector := metrics.NewInternalMetricsCollector(imHistory)
 		metricsCollector.StartService()
+		context.MetricsCollector = metricsCollector
 	}
 
 	if opts.startWebAppFlag {

--- a/pkg/events/event_system.go
+++ b/pkg/events/event_system.go
@@ -122,6 +122,7 @@ func (ec *EventSystemImpl) StartServiceWithPublisher(withPublisher bool) {
 	ec.requestCapacity = ec.readRequestCapacity()
 
 	go func() {
+		log.Log(log.Events).Info("Starting event system handler")
 		for {
 			select {
 			case <-ec.stop:

--- a/pkg/events/event_system_test.go
+++ b/pkg/events/event_system_test.go
@@ -122,7 +122,6 @@ func TestConfigUpdate(t *testing.T) {
 	assert.Equal(t, eventSystem.GetRingBufferCapacity(), uint64(configs.DefaultEventRingBufferCapacity))
 	assert.Equal(t, eventSystem.GetRequestCapacity(), configs.DefaultEventRequestCapacity)
 	assert.Equal(t, eventSystem.eventBuffer.capacity, uint64(configs.DefaultEventRingBufferCapacity))
-	assert.Assert(t, !eventSystem.publisher.stop.Load())
 
 	// update config and wait for refresh
 	var newRingBufferCapacity uint64 = 123
@@ -141,5 +140,4 @@ func TestConfigUpdate(t *testing.T) {
 	assert.Equal(t, eventSystem.GetRingBufferCapacity(), newRingBufferCapacity)
 	assert.Equal(t, eventSystem.GetRequestCapacity(), newRequestCapacity)
 	assert.Equal(t, eventSystem.eventBuffer.capacity, newRingBufferCapacity)
-	assert.Assert(t, eventSystem.publisher.stop.Load())
 }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -79,15 +79,16 @@ var (
 	SchedQueue       = &LoggerHandle{id: 22, name: "core.scheduler.queue"}
 	SchedReservation = &LoggerHandle{id: 23, name: "core.scheduler.reservation"}
 	SchedUGM         = &LoggerHandle{id: 24, name: "core.scheduler.ugm"}
-	Security         = &LoggerHandle{id: 25, name: "core.security"}
-	Utils            = &LoggerHandle{id: 26, name: "core.utils"}
+	SchedNodesUsage  = &LoggerHandle{id: 25, name: "core.scheduler.nodesusage"}
+	Security         = &LoggerHandle{id: 26, name: "core.security"}
+	Utils            = &LoggerHandle{id: 27, name: "core.utils"}
 )
 
 // this tracks all the known logger handles, used to preallocate the real logger instances when configuration changes
 var loggers = []*LoggerHandle{
 	Core, Test, Deprecation, Config, Entrypoint, Events, OpenTracing, Resources, REST, RMProxy, RPC, Metrics,
 	Scheduler, SchedAllocation, SchedApplication, SchedAppUsage, SchedContext, SchedFSM, SchedHealth, SchedNode,
-	SchedPartition, SchedPreemption, SchedQueue, SchedReservation, SchedUGM, Security, Utils,
+	SchedPartition, SchedPreemption, SchedQueue, SchedReservation, SchedUGM, SchedNodesUsage, Security, Utils,
 }
 
 // structure to hold all current logger configuration state

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -39,7 +39,7 @@ func TestLoggerIds(t *testing.T) {
 	_ = Log(Test)
 
 	// validate logger count
-	assert.Equal(t, 27, len(loggers), "wrong logger count")
+	assert.Equal(t, 28, len(loggers), "wrong logger count")
 
 	// validate that all loggers are populated and have sequential ids
 	for i := 0; i < len(loggers); i++ {

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -984,3 +984,11 @@ func (cc *ClusterContext) SetLastHealthCheckResult(c *dao.SchedulerHealthDAOInfo
 func (cc *ClusterContext) GetUUID() string {
 	return cc.uuid
 }
+
+func (cc *ClusterContext) Stop() {
+	log.Log(log.SchedContext).Info("Stopping background services of partitions")
+	for _, part := range cc.GetPartitionMapClone() {
+		part.partitionManager.Stop()
+		part.userGroupCache.Stop()
+	}
+}

--- a/pkg/scheduler/nodes_usage_monitor.go
+++ b/pkg/scheduler/nodes_usage_monitor.go
@@ -21,24 +21,26 @@ package scheduler
 import (
 	"time"
 
+	"github.com/apache/yunikorn-core/pkg/log"
 	"github.com/apache/yunikorn-core/pkg/metrics"
 )
 
 type nodesResourceUsageMonitor struct {
-	done   chan bool
+	done   chan struct{}
 	ticker *time.Ticker
 	cc     *ClusterContext
 }
 
 func newNodesResourceUsageMonitor(scheduler *ClusterContext) *nodesResourceUsageMonitor {
 	return &nodesResourceUsageMonitor{
-		done:   make(chan bool),
+		done:   make(chan struct{}),
 		ticker: time.NewTicker(1 * time.Second),
 		cc:     scheduler,
 	}
 }
 
 func (m *nodesResourceUsageMonitor) start() {
+	log.Log(log.SchedNodesUsage).Info("Starting node resource monitor")
 	go func() {
 		for {
 			select {
@@ -66,7 +68,7 @@ func (m *nodesResourceUsageMonitor) runOnce() {
 }
 
 // Stop the node usage monitor.
-//nolint:unused
 func (m *nodesResourceUsageMonitor) stop() {
-	m.done <- true
+	log.Log(log.SchedNodesUsage).Info("Stopping node resource usage monitor")
+	close(m.done)
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -36,6 +36,9 @@ type Scheduler struct {
 	clusterContext  *ClusterContext  // main context
 	pendingEvents   chan interface{} // queue for events
 	activityPending chan bool        // activity pending channel
+	stop            chan struct{}    // channel to signal stop request
+	healthChecker   *HealthChecker
+	nodesMonitor    *nodesResourceUsageMonitor
 }
 
 func NewScheduler() *Scheduler {
@@ -43,6 +46,7 @@ func NewScheduler() *Scheduler {
 	m.clusterContext = newClusterContext()
 	m.pendingEvents = make(chan interface{}, 1024*1024)
 	m.activityPending = make(chan bool, 1)
+	m.stop = make(chan struct{})
 	return m
 }
 
@@ -55,12 +59,12 @@ func (s *Scheduler) StartService(handlers handler.EventHandlers, manualSchedule 
 	go s.handleRMEvent()
 
 	// Start resource monitor if necessary (majorly for testing)
-	monitor := newNodesResourceUsageMonitor(s.clusterContext)
-	monitor.start()
+	s.nodesMonitor = newNodesResourceUsageMonitor(s.clusterContext)
+	s.nodesMonitor.start()
 
 	// Start health check periodically
-	c := NewHealthChecker(s.clusterContext)
-	c.Start()
+	s.healthChecker = NewHealthChecker(s.clusterContext)
+	s.healthChecker.Start()
 
 	if !manualSchedule {
 		go s.internalSchedule()
@@ -71,7 +75,15 @@ func (s *Scheduler) StartService(handlers handler.EventHandlers, manualSchedule 
 // Internal start scheduling service
 func (s *Scheduler) internalSchedule() {
 	for {
-		s.awaitActivity()
+		select {
+		case <-s.stop:
+			return
+		case <-s.activityPending:
+			// activity pending
+		case <-time.After(100 * time.Millisecond):
+			// timeout, run scheduler anyway
+		}
+
 		if s.clusterContext.schedule() {
 			s.registerActivity()
 		}
@@ -80,8 +92,12 @@ func (s *Scheduler) internalSchedule() {
 
 func (s *Scheduler) internalInspectOutstandingRequests() {
 	for {
-		time.Sleep(1000 * time.Millisecond)
-		s.inspectOutstandingRequests()
+		select {
+		case <-s.stop:
+			return
+		case <-time.After(time.Second):
+			s.inspectOutstandingRequests()
+		}
 	}
 }
 
@@ -105,25 +121,29 @@ func enqueueAndCheckFull(queue chan interface{}, ev interface{}) {
 
 func (s *Scheduler) handleRMEvent() {
 	for {
-		ev := <-s.pendingEvents
-		switch v := ev.(type) {
-		case *rmevent.RMUpdateAllocationEvent:
-			s.clusterContext.handleRMUpdateAllocationEvent(v)
-		case *rmevent.RMUpdateApplicationEvent:
-			s.clusterContext.handleRMUpdateApplicationEvent(v)
-		case *rmevent.RMUpdateNodeEvent:
-			s.clusterContext.handleRMUpdateNodeEvent(v)
-		case *rmevent.RMPartitionsRemoveEvent:
-			s.clusterContext.removePartitionsByRMID(v)
-		case *rmevent.RMRegistrationEvent:
-			s.clusterContext.processRMRegistrationEvent(v)
-		case *rmevent.RMConfigUpdateEvent:
-			s.clusterContext.processRMConfigUpdateEvent(v)
-		default:
-			log.Log(log.Scheduler).Error("Received type is not an acceptable type for RM event.",
-				zap.Stringer("received type", reflect.TypeOf(v)))
+		select {
+		case ev := <-s.pendingEvents:
+			switch v := ev.(type) {
+			case *rmevent.RMUpdateAllocationEvent:
+				s.clusterContext.handleRMUpdateAllocationEvent(v)
+			case *rmevent.RMUpdateApplicationEvent:
+				s.clusterContext.handleRMUpdateApplicationEvent(v)
+			case *rmevent.RMUpdateNodeEvent:
+				s.clusterContext.handleRMUpdateNodeEvent(v)
+			case *rmevent.RMPartitionsRemoveEvent:
+				s.clusterContext.removePartitionsByRMID(v)
+			case *rmevent.RMRegistrationEvent:
+				s.clusterContext.processRMRegistrationEvent(v)
+			case *rmevent.RMConfigUpdateEvent:
+				s.clusterContext.processRMConfigUpdateEvent(v)
+			default:
+				log.Log(log.Scheduler).Error("Received type is not an acceptable type for RM event.",
+					zap.Stringer("received type", reflect.TypeOf(v)))
+			}
+			s.registerActivity()
+		case <-s.stop:
+			return
 		}
-		s.registerActivity()
 	}
 }
 
@@ -134,16 +154,6 @@ func (s *Scheduler) registerActivity() {
 		// activity registered
 	default:
 		// buffer is full, activity will be processed at the next available opportunity
-	}
-}
-
-// awaitActivity waits for scheduler activity to occur.
-func (s *Scheduler) awaitActivity() {
-	select {
-	case <-s.activityPending:
-		// activity pending
-	case <-time.After(100 * time.Millisecond):
-		// timeout, run scheduler anyway
 	}
 }
 
@@ -198,4 +208,12 @@ func (s *Scheduler) MultiStepSchedule(nAlloc int) {
 		// Note, this sleep only works in tests.
 		time.Sleep(100 * time.Millisecond)
 	}
+}
+
+func (s *Scheduler) Stop() {
+	log.Log(log.Scheduler).Info("Stopping scheduler & background services")
+	s.healthChecker.Stop()
+	s.nodesMonitor.stop()
+	s.clusterContext.Stop()
+	close(s.stop)
 }


### PR DESCRIPTION
### What is this PR for?
After calling `MockScheduler.Stop()`, we still have a bunch of goroutines running. This is not a problem on a real cluster, because a restart means a complete shutdown of the Yunikorn process. During testing, this leaves garbage behind and generates possible unwanted interactions between test cases.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2233

### How should this be tested?
Insert a breakpoint after `ms.Stop()` in a test which uses the Mock scheduler. Check the running goroutines with the debugger.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
