### PR TITLE
[YUNIKORN-2242] Fix incorrect help message of queue metrics

### DIFF
--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -65,7 +65,7 @@ func InitQueueMetrics(name string) *QueueMetrics {
 			Namespace:   Namespace,
 			Name:        "queue_app",
 			ConstLabels: prometheus.Labels{"queue": name},
-			Help:        "Queue application metrics. State of the application includes `running`.",
+			Help:        "Queue application metrics. State of the application includes `running`, `accepted`, `failed`, `completed`.",
 		}, []string{"state"})
 
 	q.appMetricsSubsystem = prometheus.NewGaugeVec(

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -65,7 +65,7 @@ func InitQueueMetrics(name string) *QueueMetrics {
 			Namespace:   Namespace,
 			Name:        "queue_app",
 			ConstLabels: prometheus.Labels{"queue": name},
-			Help:        "Queue application metrics. State of the application includes `running`, `accepted`, `rejected`, `failed`, `completed`.",
+			Help:        "Queue application metrics. State of the application includes `accepted`, `rejected`, `running`, `failed`, `completed`.",
 		}, []string{"state"})
 
 	q.appMetricsSubsystem = prometheus.NewGaugeVec(

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -65,7 +65,7 @@ func InitQueueMetrics(name string) *QueueMetrics {
 			Namespace:   Namespace,
 			Name:        "queue_app",
 			ConstLabels: prometheus.Labels{"queue": name},
-			Help:        "Queue application metrics. State of the application includes `running`, `accepted`, `failed`, `completed`.",
+			Help:        "Queue application metrics. State of the application includes `running`, `accepted`, `rejected`, `failed`, `completed`.",
 		}, []string{"state"})
 
 	q.appMetricsSubsystem = prometheus.NewGaugeVec(


### PR DESCRIPTION
### What is this PR for?
Add the missing states in the help message of `appMetricsLabel`


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2242
