### PR TITLE
[YUNIKORN-2257] Add rest API to retrieve node utilization for multiple resource types

### DIFF
--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -259,4 +259,10 @@ var webRoutes = routes{
 		"/ws/v1/scheduler/node-utilization",
 		getNodeUtilisation,
 	},
+	route{
+		"Scheduler",
+		"GET",
+		"/ws/v1/partition/:partition/node-utilization",
+		getPartitionNodeUtilisation,
+	},
 }


### PR DESCRIPTION
### What is this PR for?
Add new rest endpoint to return multiple resource types. ([]*dao.NodesUtilDAOInfo)
- /ws/v1/partition/:partition/node-utilization


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
Add api document.

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2257

### How should this be tested?
1. make e2e test should passed.
2. deploy yunikorn-core and call http://localhost:9889/ws/v1/partition/default/node-utilization

### Screenshots (if appropriate)
![YUNIKORN-2257 API Result](https://github.com/apache/yunikorn-core/assets/26764036/65abfd75-a9b5-4b53-94c7-94e1747c1cd5)

### Questions:
NA
