### PR TITLE
[YUNIKORN-2190] Using empty array to replace null response from /ws/v1/partition/{partitionName}/usage/users

### DIFF
--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -823,7 +823,7 @@ func getUsersResourceUsage(w http.ResponseWriter, _ *http.Request) {
 	writeHeaders(w)
 	userManager := ugm.GetUserManager()
 	usersResources := userManager.GetUsersResources()
-	var result []*dao.UserResourceUsageDAOInfo
+	result := []*dao.UserResourceUsageDAOInfo{}
 	for _, tracker := range usersResources {
 		result = append(result, tracker.GetUserResourceUsageDAOInfo())
 	}
@@ -859,7 +859,7 @@ func getGroupsResourceUsage(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
 	userManager := ugm.GetUserManager()
 	groupsResources := userManager.GetGroupsResources()
-	var result []*dao.GroupResourceUsageDAOInfo
+	result := []*dao.GroupResourceUsageDAOInfo{}
 	for _, tracker := range groupsResources {
 		result = append(result, tracker.GetGroupResourceUsageDAOInfo())
 	}

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -823,9 +823,9 @@ func getUsersResourceUsage(w http.ResponseWriter, _ *http.Request) {
 	writeHeaders(w)
 	userManager := ugm.GetUserManager()
 	usersResources := userManager.GetUsersResources()
-	result := []*dao.UserResourceUsageDAOInfo{}
-	for _, tracker := range usersResources {
-		result = append(result, tracker.GetUserResourceUsageDAOInfo())
+	result := make([]*dao.UserResourceUsageDAOInfo, len(usersResources))
+	for i, tracker := range usersResources {
+		result[i] = tracker.GetUserResourceUsageDAOInfo()
 	}
 	if err := json.NewEncoder(w).Encode(result); err != nil {
 		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
@@ -859,9 +859,9 @@ func getGroupsResourceUsage(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
 	userManager := ugm.GetUserManager()
 	groupsResources := userManager.GetGroupsResources()
-	result := []*dao.GroupResourceUsageDAOInfo{}
-	for _, tracker := range groupsResources {
-		result = append(result, tracker.GetGroupResourceUsageDAOInfo())
+	result := make([]*dao.GroupResourceUsageDAOInfo, len(groupsResources))
+	for i, tracker := range groupsResources {
+		result[i] = tracker.GetGroupResourceUsageDAOInfo()
 	}
 	if err := json.NewEncoder(w).Encode(result); err != nil {
 		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
### What is this PR for?
The endpoint `/ws/v1/partition/{partitionName}/usage/users` and `/ws/v1/partition/{partitionName}/usage/groups`
will return nil when user / group usages are nonexistent. The return type is expected to be array, so it seems to me the empty array is more suitable to be returned.

### What type of PR is it?
* [x] - Improvement

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2190

### How should this be tested?
covered by unit tests

### Screenshots (if appropriate)
N/A

### Questions:
N/A