### PR TITLE
[YUNIKORN-2265] Populate Originator and PreemptionPolicy fields in SI Allocation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ module github.com/apache/yunikorn-core
 go 1.20
 
 require (
-	github.com/apache/yunikorn-scheduler-interface v0.0.0-20231201001639-c81397b31653
+	github.com/apache/yunikorn-scheduler-interface v0.0.0-20231211235204-ec7bfad7d00e
 	github.com/google/btree v1.1.2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20231201001639-c81397b31653 h1:pUbVmmR+LWuy0L8dGCZNue9UNpWKsY7yFYcCtPtWAic=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20231201001639-c81397b31653/go.mod h1:zDWV5y9Zh9DM1C65RCVXT1nhNNO8kykVW7bzPFamNYw=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20231211235204-ec7bfad7d00e h1:WiDns+JSNrp1jUfTkwtTwVyfxAhe3vPMtxJxs2CRseE=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20231211235204-ec7bfad7d00e/go.mod h1:zDWV5y9Zh9DM1C65RCVXT1nhNNO8kykVW7bzPFamNYw=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -153,6 +153,9 @@ func NewAllocationFromSI(alloc *si.Allocation) *Allocation {
 		placeholder:       alloc.Placeholder,
 		createTime:        time.Unix(creationTime, 0),
 		allocLog:          make(map[string]*AllocationLogEntry),
+		originator:        alloc.Originator,
+		allowPreemptSelf:  alloc.PreemptionPolicy.GetAllowPreemptSelf(),
+		allowPreemptOther: alloc.PreemptionPolicy.GetAllowPreemptOther(),
 	}
 	newAlloc := NewAllocation(alloc.NodeID, ask)
 	newAlloc.allocationID = alloc.AllocationID
@@ -175,6 +178,11 @@ func (a *Allocation) NewSIFromAllocation() *si.Allocation {
 		ResourcePerAlloc: a.GetAllocatedResource().ToProto(), // needed in tests for restore
 		TaskGroupName:    a.GetTaskGroup(),
 		Placeholder:      a.IsPlaceholder(),
+		Originator:       a.GetAsk().IsOriginator(),
+		PreemptionPolicy: &si.PreemptionPolicy{
+			AllowPreemptSelf:  a.GetAsk().IsAllowPreemptSelf(),
+			AllowPreemptOther: a.GetAsk().IsAllowPreemptOther(),
+		},
 	}
 }
 

--- a/pkg/scheduler/objects/allocation_test.go
+++ b/pkg/scheduler/objects/allocation_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 
 	"github.com/apache/yunikorn-core/pkg/common/resources"
@@ -136,14 +135,37 @@ func TestSIFromAlloc(t *testing.T) {
 		NodeID:           "node-1",
 		ApplicationID:    "app-1",
 		ResourcePerAlloc: res.ToProto(),
+		Originator:       true,
+		PreemptionPolicy: &si.PreemptionPolicy{
+			AllowPreemptSelf:  true,
+			AllowPreemptOther: false,
+		},
 	}
 	ask := newAllocationAsk("ask-1", "app-1", res)
 	alloc := NewAllocation("node-1", ask)
+	ask.originator = true
+	ask.allowPreemptSelf = false
+	ask.allowPreemptOther = true
 	if alloc == nil {
 		t.Fatal("NewAllocation create failed while it should not")
 	}
+
 	allocSI := alloc.NewSIFromAllocation()
-	assert.DeepEqual(t, allocSI, expectedSI, cmpopts.IgnoreUnexported(si.Allocation{}, si.Resource{}, si.Quantity{}))
+	assert.Equal(t, expectedSI.AllocationKey, allocSI.AllocationKey, "wrong AllocationKey")
+	assert.Equal(t, expectedSI.AllocationID, allocSI.AllocationID, "wrong AllocationID")
+	assert.Equal(t, expectedSI.NodeID, allocSI.NodeID, "wrong NodeID")
+	assert.Equal(t, expectedSI.ApplicationID, allocSI.ApplicationID, "wrong ApplicationID")
+	assert.Check(t, allocSI.Originator, "originator flag should be set")
+	assert.Check(t, !allocSI.PreemptionPolicy.AllowPreemptSelf, "allowPreemptSelf flag should not be set")
+	assert.Check(t, allocSI.PreemptionPolicy.AllowPreemptOther, "aloowPreemptOther flag should be set")
+
+	alloc.ask.originator = false
+	alloc.ask.allowPreemptSelf = true
+	alloc.ask.allowPreemptOther = false
+	allocSI = alloc.NewSIFromAllocation()
+	assert.Check(t, !allocSI.Originator, "originator flag should not be set")
+	assert.Check(t, allocSI.PreemptionPolicy.AllowPreemptSelf, "allowPreemptSelf flag should be set")
+	assert.Check(t, !allocSI.PreemptionPolicy.AllowPreemptOther, "aloowPreemptOther flag should not be set")
 }
 
 func TestNewAllocFromNilSI(t *testing.T) {
@@ -171,6 +193,11 @@ func TestNewAllocFromSI(t *testing.T) {
 		TaskGroupName:    "",
 		Placeholder:      true,
 		AllocationTags:   tags,
+		Originator:       true,
+		PreemptionPolicy: &si.PreemptionPolicy{
+			AllowPreemptSelf:  false,
+			AllowPreemptOther: true,
+		},
 	}
 	var nilAlloc *Allocation
 	alloc := NewAllocationFromSI(allocSI)
@@ -181,8 +208,22 @@ func TestNewAllocFromSI(t *testing.T) {
 	assert.Assert(t, alloc.IsPlaceholder(), "ask should have been a placeholder")
 	assert.Equal(t, alloc.GetTaskGroup(), "testgroup", "TaskGroupName not set as expected")
 	assert.Equal(t, alloc.GetAsk().GetCreateTime(), time.Unix(past, 0)) //nolint:staticcheck
+	assert.Assert(t, alloc.GetAsk().IsOriginator(), "ask should have been an originator")
+	assert.Assert(t, !alloc.GetAsk().IsAllowPreemptSelf(), "ask should not have allow-preempt-self set")
+	assert.Assert(t, alloc.GetAsk().IsAllowPreemptOther(), "ask should have allow-preempt-other set")
 
+	allocSI.Originator = false
+	allocSI.PreemptionPolicy.AllowPreemptSelf = true
+	allocSI.PreemptionPolicy.AllowPreemptOther = false
 	allocSI.AllocationTags[siCommon.CreationTime] = "xyz"
 	alloc = NewAllocationFromSI(allocSI)
 	assert.Equal(t, alloc.GetAsk().GetCreateTime().Unix(), int64(-1)) //nolint:staticcheck
+	assert.Assert(t, !alloc.GetAsk().IsOriginator(), "ask should not have been an originator")
+	assert.Assert(t, alloc.GetAsk().IsAllowPreemptSelf(), "ask should have allow-preempt-self set")
+	assert.Assert(t, !alloc.GetAsk().IsAllowPreemptOther(), "ask should not have allow-preempt-other set")
+
+	allocSI.PreemptionPolicy = nil
+	alloc = NewAllocationFromSI(allocSI)
+	assert.Assert(t, !alloc.GetAsk().IsAllowPreemptSelf(), "ask should not have allow-preempt-self set")
+	assert.Assert(t, !alloc.GetAsk().IsAllowPreemptOther(), "ask should not have allow-preempt-other set")
 }


### PR DESCRIPTION
### What is this PR for?
Use and populate the new Originator and PreemptionPolicy fields in the SI Allocation object.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2265

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
