### PR TITLE
[YUNIKORN-2209] Remove limit checks in QueueTracker

### DIFF
--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -75,7 +75,7 @@ func (gt *GroupTracker) getTrackedApplications() map[string]string {
 func (gt *GroupTracker) setLimits(hierarchy []string, resource *resources.Resource, maxApps uint64) {
 	gt.Lock()
 	defer gt.Unlock()
-	gt.queueTracker.setLimit(hierarchy, resource, maxApps)
+	gt.queueTracker.setLimit(hierarchy, resource, maxApps, false)
 }
 
 func (gt *GroupTracker) headroom(hierarchy []string) *resources.Resource {

--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -34,10 +34,10 @@ type GroupTracker struct {
 	sync.RWMutex
 }
 
-func newGroupTracker(group string) *GroupTracker {
-	queueTracker := newRootQueueTracker()
+func newGroupTracker(groupName string) *GroupTracker {
+	queueTracker := newRootQueueTracker(group)
 	groupTracker := &GroupTracker{
-		groupName:    group,
+		groupName:    groupName,
 		applications: make(map[string]string),
 		queueTracker: queueTracker,
 	}
@@ -75,7 +75,7 @@ func (gt *GroupTracker) getTrackedApplications() map[string]string {
 func (gt *GroupTracker) setLimits(hierarchy []string, resource *resources.Resource, maxApps uint64) {
 	gt.Lock()
 	defer gt.Unlock()
-	gt.queueTracker.setLimit(hierarchy, resource, maxApps, false)
+	gt.queueTracker.setLimit(hierarchy, resource, maxApps, false, group, false)
 }
 
 func (gt *GroupTracker) headroom(hierarchy []string) *resources.Resource {

--- a/pkg/scheduler/ugm/group_tracker_test.go
+++ b/pkg/scheduler/ugm/group_tracker_test.go
@@ -32,7 +32,7 @@ func TestGTIncreaseTrackedResource(t *testing.T) {
 	// root->parent->child1->child12
 	// root->parent->child2
 	// root->parent->child12 (similar name like above leaf queue, but it is being treated differently as similar names are allowed)
-	GetUserManager()
+	manager := GetUserManager()
 	user := &security.UserGroup{User: "test", Groups: []string{"test"}}
 	groupTracker := newGroupTracker(user.User)
 
@@ -40,6 +40,8 @@ func TestGTIncreaseTrackedResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
 	}
+
+	manager.Headroom(queuePath1, TestApp1, *user)
 	result := groupTracker.increaseTrackedResource(hierarchy1, TestApp1, usage1, user.User)
 	if !result {
 		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy1, TestApp1, usage1)

--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -281,20 +281,6 @@ func (m *Manager) ensureGroupInternal(userGroups []string, queuePath string) str
 	return m.ensureGroupInternal(userGroups, parentPath)
 }
 
-func (m *Manager) isUserRemovable(ut *UserTracker) bool {
-	if len(ut.getTrackedApplications()) == 0 && resources.IsZero(ut.queueTracker.resourceUsage) {
-		return true
-	}
-	return false
-}
-
-func (m *Manager) isGroupRemovable(gt *GroupTracker) bool {
-	if len(gt.getTrackedApplications()) == 0 && resources.IsZero(gt.queueTracker.resourceUsage) {
-		return true
-	}
-	return false
-}
-
 func (m *Manager) UpdateConfig(config configs.QueueConfig, queuePath string) error {
 	userWildCardLimitsConfig := make(map[string]*LimitConfig)
 	groupWildCardLimitsConfig := make(map[string]*LimitConfig)

--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -406,7 +406,7 @@ func (m *Manager) clearEarlierSetUserWildCardLimits(newUserWildCardLimits map[st
 		_, currentQPExists := m.userLimits[queuePath]
 		_, newQPExists := newUserLimits[queuePath]
 
-		// Is queue path exists? In case wild card user limit not exists, reset limit settings, useWildCard flag etc for all those users
+		// Does queue path exist? In case wild limit does not exist, reset limit settings and useWildCard flag for all those users
 		if newLimitConfig, ok := newUserWildCardLimits[queuePath]; !ok && (!currentQPExists || !newQPExists) {
 			for _, ut := range m.userTrackers {
 				_, exists := m.userLimits[queuePath][ut.userName]

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -1568,6 +1568,7 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 			conf.Queues[0].Queues[0].Limits = tc.newLimits
 			assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
+			manager.Headroom(queuePathParent, TestApp2, tc.user)
 			increased = manager.IncreaseTrackedResource(queuePathParent, TestApp2, usage, tc.user)
 			assert.Equal(t, increased, false, "should not increase tracked resource: queuepath "+queuePathParent+", app "+TestApp2+", res "+usage.String())
 		})

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -1029,6 +1029,8 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 		conf                          configs.PartitionConfig
 		initExpectedHeadroomResource  map[string]string
 		finalExpectedHeadroomResource map[string]string
+		canRunApp                     bool
+		isHeadroomAvailable           bool
 	}{
 		// unmixed user and group limit
 		{
@@ -1039,6 +1041,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  mediumResource,
 			finalExpectedHeadroomResource: nil,
+			canRunApp:                     true,
 		},
 		{
 			name: "maxapplications with a specific user limit",
@@ -1048,6 +1051,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  largeResource,
 			finalExpectedHeadroomResource: mediumResource,
+			isHeadroomAvailable:           true,
 		},
 		{
 			name: "maxresources with a specific user limit and a wildcard user limit for a not specific user",
@@ -1058,6 +1062,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  mediumResource,
 			finalExpectedHeadroomResource: nil,
+			canRunApp:                     true,
 		},
 		{
 			name: "maxapplications with a specific user limit and a wildcard user limit for a not specific user",
@@ -1068,6 +1073,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  largeResource,
 			finalExpectedHeadroomResource: mediumResource,
+			isHeadroomAvailable:           true,
 		},
 		{
 			name: "maxresources with a specific user limit and a wildcard user limit for a specific user",
@@ -1078,6 +1084,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  mediumResource,
 			finalExpectedHeadroomResource: nil,
+			canRunApp:                     true,
 		},
 		{
 			name: "maxapplications with a specific user limit and a wildcard user limit for a specific user",
@@ -1088,6 +1095,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  largeResource,
 			finalExpectedHeadroomResource: mediumResource,
+			isHeadroomAvailable:           true,
 		},
 		{
 			name: "maxresources with a wildcard user limit",
@@ -1097,6 +1105,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  mediumResource,
 			finalExpectedHeadroomResource: nil,
+			canRunApp:                     true,
 		},
 		{
 			name: "maxapplications with a wildcard user limit",
@@ -1106,6 +1115,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  largeResource,
 			finalExpectedHeadroomResource: mediumResource,
+			isHeadroomAvailable:           true,
 		},
 		{
 			name: "maxresources with a specific group limit",
@@ -1115,6 +1125,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  mediumResource,
 			finalExpectedHeadroomResource: nil,
+			canRunApp:                     true,
 		},
 		{
 			name: "maxapplications with a specific group limit",
@@ -1124,6 +1135,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  largeResource,
 			finalExpectedHeadroomResource: mediumResource,
+			isHeadroomAvailable:           true,
 		},
 		{
 			name: "maxresources with a specific group limit and a wildcard group limit for a not specific group user",
@@ -1134,6 +1146,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  mediumResource,
 			finalExpectedHeadroomResource: nil,
+			canRunApp:                     true,
 		},
 		{
 			name: "maxapplications with a specific group limit and a wildcard group limit for a not specific group user",
@@ -1144,6 +1157,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  largeResource,
 			finalExpectedHeadroomResource: mediumResource,
+			isHeadroomAvailable:           true,
 		},
 		{
 			name: "maxresources with a specific group limit and a wildcard group limit for a specific group user",
@@ -1154,6 +1168,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  mediumResource,
 			finalExpectedHeadroomResource: nil,
+			canRunApp:                     true,
 		},
 		{
 			name: "maxapplications with a specific group limit and a wildcard group limit for a specific group user",
@@ -1164,6 +1179,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  largeResource,
 			finalExpectedHeadroomResource: mediumResource,
+			isHeadroomAvailable:           true,
 		},
 		// mixed user and group limit
 		{
@@ -1175,6 +1191,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  mediumResource,
 			finalExpectedHeadroomResource: nil,
+			canRunApp:                     true,
 		},
 		{
 			name: "maxapplications with user limit lower than group limit",
@@ -1185,6 +1202,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  largeResource,
 			finalExpectedHeadroomResource: mediumResource,
+			isHeadroomAvailable:           true,
 		},
 		{
 			name: "maxresources with gorup limit lower than user limit",
@@ -1195,6 +1213,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  mediumResource,
 			finalExpectedHeadroomResource: nil,
+			canRunApp:                     true,
 		},
 		{
 			name: "maxapplications with group limit lower than user limit",
@@ -1205,6 +1224,7 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			}),
 			initExpectedHeadroomResource:  largeResource,
 			finalExpectedHeadroomResource: mediumResource,
+			isHeadroomAvailable:           true,
 		},
 	}
 
@@ -1238,10 +1258,9 @@ func TestUserGroupLimit(t *testing.T) { //nolint:funlen
 			assert.NilError(t, err, fmt.Sprintf("can't create resource from %v", tc.finalExpectedHeadroomResource))
 			headroom = manager.Headroom(queuePathParent, TestApp1, tc.user)
 			assert.Equal(t, resources.Equals(headroom, finalExpectedHeadroom), true, "final headroom is not expected")
-			if manager.CanRunApp(queuePathParent, TestApp2, tc.user) {
-				headroom = manager.Headroom(queuePathParent, TestApp2, tc.user)
-				assert.Equal(t, headroom.FitInMaxUndef(usage), false)
-			}
+			assert.Equal(t, manager.CanRunApp(queuePathParent, TestApp2, tc.user), tc.canRunApp)
+			headroom = manager.Headroom(queuePathParent, TestApp2, tc.user)
+			assert.Equal(t, headroom.FitInMaxUndef(usage), tc.isHeadroomAvailable)
 		})
 	}
 }
@@ -1335,14 +1354,15 @@ func TestUserGroupMaxResourcesChange(t *testing.T) { //nolint:funlen
 
 func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 	testCases := []struct {
-		name      string
-		user      security.UserGroup
-		limits    []configs.Limit
-		newLimits []configs.Limit
+		name                 string
+		user                 security.UserGroup
+		limits               []configs.Limit
+		newLimits            []configs.Limit
+		maxAppsExceeded      bool
+		maxResourcesExceeded bool
 	}{
 		// user limit only
 		{
-
 			name: "maxresources with an updated specific user limit",
 			user: security.UserGroup{User: "user1", Groups: []string{"group1"}},
 			limits: []configs.Limit{
@@ -1351,6 +1371,7 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 			newLimits: []configs.Limit{
 				createLimit([]string{"user1"}, nil, mediumResource, 2),
 			},
+			maxResourcesExceeded: true,
 		},
 		{
 			name: "maxapplications with an updated specific user limit",
@@ -1361,6 +1382,7 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 			newLimits: []configs.Limit{
 				createLimit([]string{"user1"}, nil, largeResource, 1),
 			},
+			maxAppsExceeded: true,
 		},
 
 		// group limit only
@@ -1374,6 +1396,7 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 			newLimits: []configs.Limit{
 				createLimit(nil, []string{"group1"}, mediumResource, 2),
 			},
+			maxResourcesExceeded: true,
 		},
 		{
 			name: "maxapplications with an updated specific group limit",
@@ -1384,6 +1407,7 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 			newLimits: []configs.Limit{
 				createLimit(nil, []string{"group1"}, largeResource, 1),
 			},
+			maxAppsExceeded: true,
 		},
 
 		// user wilcard limit
@@ -1398,6 +1422,7 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 				createLimit([]string{"user1"}, nil, largeResource, 2),
 				createLimit([]string{"*"}, nil, mediumResource, 2),
 			},
+			maxResourcesExceeded: true,
 		},
 		{
 			name: "maxapplications with an updated wildcard user limit",
@@ -1410,6 +1435,7 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 				createLimit([]string{"user1"}, nil, largeResource, 2),
 				createLimit([]string{"*"}, nil, largeResource, 1),
 			},
+			maxAppsExceeded: true,
 		},
 
 		// group wilcard limit
@@ -1425,6 +1451,7 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 				createLimit(nil, []string{"group1"}, largeResource, 2),
 				createLimit(nil, []string{"*"}, mediumResource, 2),
 			},
+			maxResourcesExceeded: true,
 		},
 		{
 			name: "maxapplications with an updated wildcard group limit",
@@ -1437,6 +1464,7 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 				createLimit(nil, []string{"group1"}, largeResource, 2),
 				createLimit(nil, []string{"*"}, largeResource, 1),
 			},
+			maxAppsExceeded: true,
 		},
 
 		// in a different limit
@@ -1459,6 +1487,7 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 					MaxApplications: 2,
 				},
 			},
+			maxResourcesExceeded: true,
 		},
 		{
 			name: "maxapplications with a new specific user limit",
@@ -1479,6 +1508,7 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 					MaxApplications: 1,
 				},
 			},
+			maxAppsExceeded: true,
 		},
 		{
 			name: "maxresources with a new specific group limit",
@@ -1499,6 +1529,7 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 					MaxApplications: 2,
 				},
 			},
+			maxResourcesExceeded: true,
 		},
 		{
 			name: "maxapplications with a new specific group limit",
@@ -1519,6 +1550,7 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 					MaxApplications: 1,
 				},
 			},
+			maxAppsExceeded: true,
 		},
 	}
 
@@ -1548,10 +1580,9 @@ func TestUserGroupLimitChange(t *testing.T) { //nolint:funlen
 			conf.Queues[0].Queues[0].Limits = tc.newLimits
 			assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
 
-			if manager.CanRunApp(queuePathParent, TestApp2, tc.user) {
-				headroom := manager.Headroom(queuePathParent, TestApp2, tc.user)
-				assert.Equal(t, headroom.FitInMaxUndef(usage), false)
-			}
+			assert.Equal(t, manager.CanRunApp(queuePathParent, TestApp2, tc.user), !tc.maxAppsExceeded)
+			headroom := manager.Headroom(queuePathParent, TestApp2, tc.user)
+			assert.Equal(t, headroom.FitInMaxUndef(usage), !tc.maxResourcesExceeded)
 		})
 	}
 }

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -343,6 +343,91 @@ func TestUpdateConfig(t *testing.T) {
 	}
 }
 
+func TestUseWildCard(t *testing.T) {
+	setupUGM()
+	manager := GetUserManager()
+	user := security.UserGroup{User: "user1", Groups: []string{"group1"}}
+
+	expectedResource, err := resources.NewResourceFromConf(map[string]string{"memory": "50", "vcores": "50"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, expectedResource)
+	}
+	usage, err := resources.NewResourceFromConf(map[string]string{"memory": "10", "vcores": "10"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage)
+	}
+
+	expectedHeadroom, err := resources.NewResourceFromConf(map[string]string{"memory": "50", "vcores": "50"})
+	if err != nil {
+		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, expectedHeadroom)
+	}
+
+	user1 := security.UserGroup{User: "user2", Groups: []string{"group2"}}
+	conf := createUpdateConfigWithWildCardUsersAndGroups(user1.User, user1.Groups[0], "*", "*", "50", "50")
+	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+
+	// user1 fallback on wild card user limit. user1 max resources and max applications would be overwritten with wild card user limit settings
+	headroom := manager.Headroom(queuePath1, TestApp1, user)
+	assert.Equal(t, resources.Equals(headroom, expectedHeadroom), true)
+
+	// user2 has its own settings, so doesn't fallback on wild card user limit.
+	headroom = manager.Headroom(queuePath1, TestApp1, user1)
+	assert.Equal(t, resources.Equals(headroom, resources.Multiply(usage, 7)), true)
+
+	// user1 uses wild card user limit settings.
+	assert.Equal(t, manager.GetUserTracker(user.User).queueTracker.maxRunningApps, uint64(0))
+	assert.Equal(t, manager.GetUserTracker(user.User).queueTracker.childQueueTrackers["parent"].maxRunningApps, uint64(10))
+	assert.Equal(t, manager.GetUserTracker(user.User).queueTracker.childQueueTrackers["parent"].childQueueTrackers["child1"].maxRunningApps, uint64(0))
+	assert.Equal(t, resources.Equals(manager.GetUserTracker(user.User).queueTracker.maxResources, nil), true)
+	assert.Equal(t, resources.Equals(manager.GetUserTracker(user.User).queueTracker.childQueueTrackers["parent"].maxResources, expectedHeadroom), true)
+	assert.Equal(t, resources.Equals(manager.GetUserTracker(user.User).queueTracker.childQueueTrackers["parent"].childQueueTrackers["child1"].maxResources, nil), true)
+	assert.Equal(t, manager.GetUserTracker(user.User).queueTracker.useWildCard, false)
+	assert.Equal(t, manager.GetUserTracker(user.User).queueTracker.childQueueTrackers["parent"].useWildCard, true)
+	assert.Equal(t, manager.GetUserTracker(user.User).queueTracker.childQueueTrackers["parent"].childQueueTrackers["child1"].useWildCard, false)
+
+	// user2 uses its own settings.
+	assert.Equal(t, manager.GetUserTracker(user1.User).queueTracker.maxRunningApps, uint64(20))
+	assert.Equal(t, manager.GetUserTracker(user1.User).queueTracker.childQueueTrackers["parent"].maxRunningApps, uint64(10))
+	assert.Equal(t, manager.GetUserTracker(user1.User).queueTracker.childQueueTrackers["parent"].childQueueTrackers["child1"].maxRunningApps, uint64(0))
+	assert.Equal(t, resources.Equals(manager.GetUserTracker(user1.User).queueTracker.maxResources, resources.Multiply(usage, 14)), true)
+	assert.Equal(t, resources.Equals(manager.GetUserTracker(user1.User).queueTracker.childQueueTrackers["parent"].maxResources, resources.Multiply(usage, 7)), true)
+	assert.Equal(t, resources.Equals(manager.GetUserTracker(user1.User).queueTracker.childQueueTrackers["parent"].childQueueTrackers["child1"].maxResources, nil), true)
+
+	for i := 0; i < 5; i++ {
+		// should run as user has already fallen back on wild card user limit set on "root.parent" map[memory:50 vcores:50]
+		increased := manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, user)
+		assert.Equal(t, increased, true)
+	}
+
+	// should not run as user has exceeded wild card user limit set on "root.parent" map[memory:50 vcores:50]
+	increased := manager.IncreaseTrackedResource(queuePath1, TestApp3, usage, user)
+	assert.Equal(t, increased, false)
+
+	// clear all configs. Since wild card user limit is not there, all users used its settings earlier under the same queue path should start using its own value
+	conf = createConfigWithoutLimits()
+	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"), err)
+
+	headroom = manager.Headroom(queuePath1, TestApp1, user)
+	assert.Equal(t, resources.Equals(headroom, nil), true)
+
+	assert.Equal(t, manager.GetUserTracker(user.User).queueTracker.maxRunningApps, uint64(0))
+	assert.Equal(t, manager.GetUserTracker(user.User).queueTracker.childQueueTrackers["parent"].maxRunningApps, uint64(0))
+	assert.Equal(t, manager.GetUserTracker(user.User).queueTracker.childQueueTrackers["parent"].childQueueTrackers["child1"].maxRunningApps, uint64(0))
+	assert.Equal(t, resources.Equals(manager.GetUserTracker(user.User).queueTracker.maxResources, nil), true)
+	assert.Equal(t, resources.Equals(manager.GetUserTracker(user.User).queueTracker.childQueueTrackers["parent"].maxResources, nil), true)
+	assert.Equal(t, resources.Equals(manager.GetUserTracker(user.User).queueTracker.childQueueTrackers["parent"].childQueueTrackers["child1"].maxResources, nil), true)
+
+	// set limit for user1 explicitly. New limit should precede the wild card user limit
+	conf = createUpdateConfigWithWildCardUsersAndGroups(user.User, user.Groups[0], "", "", "50", "50")
+	assert.NilError(t, manager.UpdateConfig(conf.Queues[0], "root"))
+
+	headroom = manager.Headroom(queuePath1, TestApp1, user)
+	assert.Equal(t, resources.Equals(headroom, resources.Multiply(usage, 2)), true)
+	assert.Equal(t, manager.GetUserTracker(user.User).queueTracker.useWildCard, false)
+	assert.Equal(t, manager.GetUserTracker(user.User).queueTracker.childQueueTrackers["parent"].useWildCard, false)
+	assert.Equal(t, manager.GetUserTracker(user.User).queueTracker.childQueueTrackers["parent"].childQueueTrackers["child1"].useWildCard, false)
+}
+
 func TestUpdateConfigWithWildCardUsersAndGroups(t *testing.T) {
 	setupUGM()
 	// Queue setup:
@@ -390,6 +475,9 @@ func TestUpdateConfigWithWildCardUsersAndGroups(t *testing.T) {
 	// ensure both user1 & group1 has not been removed from local maps
 	assert.Equal(t, manager.GetUserTracker(user.User) != nil, true)
 	assert.Equal(t, manager.GetGroupTracker(user.Groups[0]) != nil, true)
+
+	headroom := manager.Headroom(queuePath1, TestApp2, user)
+	assert.Equal(t, resources.Equals(headroom, usage), true)
 
 	// user1 still should be able to run app as wild card user '*' setting is map[memory:70 vcores:70] for "root.parent" and
 	// total usage of "root.parent" is map[memory:60 vcores:60]

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -816,10 +816,10 @@ func TestUserGroupLimitWithMultipleApps(t *testing.T) {
 	assert.Equal(t, resources.Equals(gt2.queueTracker.resourceUsage, usage), true)
 
 	// limit has reached for both the groups
-	increased = manager.IncreaseTrackedResource(queuePath1, TestApp1, usage, userGroup)
-	assert.Equal(t, increased, false)
-	increased = manager.IncreaseTrackedResource(queuePath2, TestApp2, usage, userGroup)
-	assert.Equal(t, increased, false)
+	headroom := manager.Headroom(queuePath1, TestApp1, userGroup)
+	assert.Equal(t, resources.Equals(headroom, resources.Zero), true, "init headroom is not expected")
+	headroom = manager.Headroom(queuePath2, TestApp2, userGroup)
+	assert.Equal(t, resources.Equals(headroom, resources.Zero), true, "init headroom is not expected")
 
 	// remove the apps
 	decreased := manager.DecreaseTrackedResource(queuePath1, TestApp1, usage, userGroup, true)

--- a/pkg/scheduler/ugm/queue_tracker.go
+++ b/pkg/scheduler/ugm/queue_tracker.go
@@ -91,36 +91,8 @@ func (qt *QueueTracker) increaseTrackedResource(hierarchy []string, applicationI
 			return false
 		}
 	}
-
 	if qt.resourceUsage == nil {
 		qt.resourceUsage = resources.NewResource()
-	}
-	finalResourceUsage := qt.resourceUsage.Clone()
-	finalResourceUsage.AddTo(usage)
-	existingApp := qt.runningApplications[applicationID]
-
-	// apply user/group specific limit settings set if configured, otherwise use wild card limit settings
-	if qt.maxRunningApps != 0 && !resources.IsZero(qt.maxResources) {
-		log.Log(log.SchedUGM).Debug("applying enforcement checks using limit settings",
-			zap.Int("tracking type", int(trackType)),
-			zap.String("queue path", qt.queuePath),
-			zap.Bool("existing app", existingApp),
-			zap.Uint64("max running apps", qt.maxRunningApps),
-			zap.Stringer("max resources", qt.maxResources),
-			zap.Bool("use wild card", qt.useWildCard))
-		if (!existingApp && len(qt.runningApplications)+1 > int(qt.maxRunningApps)) ||
-			resources.StrictlyGreaterThan(finalResourceUsage, qt.maxResources) {
-			log.Log(log.SchedUGM).Warn("Unable to increase resource usage as allowing new application to run would exceed either configured max applications or max resources limit",
-				zap.Int("tracking type", int(trackType)),
-				zap.String("queue path", qt.queuePath),
-				zap.Bool("existing app", existingApp),
-				zap.Int("current running applications", len(qt.runningApplications)),
-				zap.Uint64("max running applications", qt.maxRunningApps),
-				zap.Stringer("current resource usage", qt.resourceUsage),
-				zap.Stringer("max resources", qt.maxResources),
-				zap.Bool("use wild card", qt.useWildCard))
-			return false
-		}
 	}
 	qt.resourceUsage.AddTo(usage)
 	qt.runningApplications[applicationID] = true
@@ -128,7 +100,6 @@ func (qt *QueueTracker) increaseTrackedResource(hierarchy []string, applicationI
 		zap.Int("tracking type", int(trackType)),
 		zap.String("queue path", qt.queuePath),
 		zap.String("application", applicationID),
-		zap.Bool("existing app", existingApp),
 		zap.Stringer("resource", usage),
 		zap.Uint64("max running applications", qt.maxRunningApps),
 		zap.Stringer("max resource usage", qt.maxResources),

--- a/pkg/scheduler/ugm/queue_tracker_test.go
+++ b/pkg/scheduler/ugm/queue_tracker_test.go
@@ -231,10 +231,8 @@ func TestQTQuotaEnforcement(t *testing.T) {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath2, TestApp2, usage1)
 	}
 
-	result = queueTracker.increaseTrackedResource(strings.Split(queuePath2, configs.DOT), TestApp3, user, usage1)
-	if result {
-		t.Fatalf("Increasing resource usage should fail as child2's resource usage exceeded configured max resources limit. queuepath %s, app %s, res %v", queuePath2, TestApp3, usage1)
-	}
+	headroom := queueTracker.headroom(strings.Split(queuePath2, configs.DOT), user)
+	assert.Equal(t, headroom.FitInMaxUndef(usage1), false)
 
 	result = queueTracker.increaseTrackedResource(strings.Split(queuePath3, configs.DOT), TestApp3, user, usage1)
 	if !result {
@@ -246,10 +244,8 @@ func TestQTQuotaEnforcement(t *testing.T) {
 		t.Fatalf("unable to increase tracked resource: queuepath %s, app %s, res %v", queuePath4, TestApp4, usage1)
 	}
 
-	result = queueTracker.increaseTrackedResource(strings.Split(queuePath4, configs.DOT), TestApp4, user, usage1)
-	if result {
-		t.Fatalf("Increasing resource usage should fail as parent's resource usage exceeded configured max resources limit. queuepath %s, app %s, res %v", queuePath4, TestApp4, usage1)
-	}
+	headroom = queueTracker.headroom(strings.Split(queuePath4, configs.DOT), user)
+	assert.Equal(t, headroom.FitInMaxUndef(usage1), false)
 }
 
 func TestHeadroom(t *testing.T) {

--- a/pkg/scheduler/ugm/queue_tracker_test.go
+++ b/pkg/scheduler/ugm/queue_tracker_test.go
@@ -34,7 +34,7 @@ func TestQTIncreaseTrackedResource(t *testing.T) {
 	// root->parent->child2
 	// root->parent->child12 (similar name like above leaf queue, but it is being treated differently as similar names are allowed)
 	GetUserManager()
-	queueTracker := newQueueTracker("", "root")
+	queueTracker := newQueueTracker("", "root", user)
 	usage1, err := resources.NewResourceFromConf(map[string]string{"mem": "10M", "vcore": "10"})
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
@@ -87,7 +87,7 @@ func TestQTDecreaseTrackedResource(t *testing.T) {
 	// root->parent->child1
 	// root->parent->child2
 	GetUserManager()
-	queueTracker := newQueueTracker("", "root")
+	queueTracker := newQueueTracker("", "root", user)
 	usage1, err := resources.NewResourceFromConf(map[string]string{"mem": "70M", "vcore": "70"})
 	if err != nil {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage1)
@@ -191,7 +191,7 @@ func TestQTQuotaEnforcement(t *testing.T) {
 	// root->parent->child2. max apps - 2 , max res - 20M, 20cores
 	// root->parent->child12 (similar name like above leaf queue, but it is being treated differently as similar names are allowed). config not set
 	GetUserManager()
-	queueTracker := newQueueTracker("", "root")
+	queueTracker := newQueueTracker("", "root", user)
 
 	usage1, err := resources.NewResourceFromConf(map[string]string{"mem": "10M", "vcore": "10"})
 	if err != nil {
@@ -201,17 +201,17 @@ func TestQTQuotaEnforcement(t *testing.T) {
 	queueTracker.maxResources = resources.Multiply(usage1, 6)
 	queueTracker.maxRunningApps = 6
 
-	parentQueueTracker := newQueueTracker("root", "parent")
+	parentQueueTracker := newQueueTracker("root", "parent", user)
 	parentQueueTracker.maxResources = resources.Multiply(usage1, 5)
 	parentQueueTracker.maxRunningApps = 5
 	queueTracker.childQueueTrackers["parent"] = parentQueueTracker
 
-	child1QueueTracker := newQueueTracker("root.parent", "child1")
+	child1QueueTracker := newQueueTracker("root.parent", "child1", user)
 	child1QueueTracker.maxResources = resources.Multiply(usage1, 2)
 	child1QueueTracker.maxRunningApps = 2
 	parentQueueTracker.childQueueTrackers["child1"] = child1QueueTracker
 
-	child2QueueTracker := newQueueTracker("root.parent.child2", "child2")
+	child2QueueTracker := newQueueTracker("root.parent.child2", "child2", user)
 	child2QueueTracker.maxResources = resources.Multiply(usage1, 2)
 	child2QueueTracker.maxRunningApps = 2
 	parentQueueTracker.childQueueTrackers["child2"] = child2QueueTracker
@@ -254,11 +254,11 @@ func TestHeadroom(t *testing.T) {
 	hierarchy := strings.Split(path, configs.DOT)
 
 	// nothing exists make sure the hierarchy gets created
-	root := newRootQueueTracker()
-	root.childQueueTrackers["parent"] = newQueueTracker("root", "parent")
+	root := newRootQueueTracker(user)
+	root.childQueueTrackers["parent"] = newQueueTracker("root", "parent", user)
 	parent := root.childQueueTrackers["parent"]
 	assert.Assert(t, parent != nil, "parent queue tracker should have been created")
-	parent.childQueueTrackers["leaf"] = newQueueTracker("root.parent", "leaf")
+	parent.childQueueTrackers["leaf"] = newQueueTracker("root.parent", "leaf", user)
 	leaf := parent.childQueueTrackers["leaf"]
 	assert.Assert(t, leaf != nil, "leaf queue tracker should have been created")
 

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -118,7 +118,7 @@ func (ut *UserTracker) getTrackedApplications() map[string]*GroupTracker {
 func (ut *UserTracker) setLimits(hierarchy []string, resource *resources.Resource, maxApps uint64) {
 	ut.Lock()
 	defer ut.Unlock()
-	ut.queueTracker.setLimit(hierarchy, resource, maxApps)
+	ut.queueTracker.setLimit(hierarchy, resource, maxApps, false)
 }
 
 func (ut *UserTracker) headroom(hierarchy []string) *resources.Resource {
@@ -171,4 +171,10 @@ func (ut *UserTracker) canRunApp(hierarchy []string, applicationID string) bool 
 	ut.Lock()
 	defer ut.Unlock()
 	return ut.queueTracker.canRunApp(hierarchy, applicationID, user)
+}
+
+func (ut *UserTracker) hasWildCardApplied(hierarchy []string) bool {
+	ut.RLock()
+	defer ut.RUnlock()
+	return ut.queueTracker.hasWildCardApplied(hierarchy)
 }

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -42,10 +42,10 @@ type UserTracker struct {
 	sync.RWMutex
 }
 
-func newUserTracker(user string) *UserTracker {
-	queueTracker := newRootQueueTracker()
+func newUserTracker(userName string) *UserTracker {
+	queueTracker := newRootQueueTracker(user)
 	userTracker := &UserTracker{
-		userName:         user,
+		userName:         userName,
 		appGroupTrackers: make(map[string]*GroupTracker),
 		queueTracker:     queueTracker,
 	}
@@ -115,10 +115,10 @@ func (ut *UserTracker) getTrackedApplications() map[string]*GroupTracker {
 	return ut.appGroupTrackers
 }
 
-func (ut *UserTracker) setLimits(hierarchy []string, resource *resources.Resource, maxApps uint64) {
+func (ut *UserTracker) setLimits(hierarchy []string, resource *resources.Resource, maxApps uint64, useWildCard bool, doWildCardCheck bool) {
 	ut.Lock()
 	defer ut.Unlock()
-	ut.queueTracker.setLimit(hierarchy, resource, maxApps, false)
+	ut.queueTracker.setLimit(hierarchy, resource, maxApps, useWildCard, user, doWildCardCheck)
 }
 
 func (ut *UserTracker) headroom(hierarchy []string) *resources.Resource {
@@ -171,10 +171,4 @@ func (ut *UserTracker) canRunApp(hierarchy []string, applicationID string) bool 
 	ut.Lock()
 	defer ut.Unlock()
 	return ut.queueTracker.canRunApp(hierarchy, applicationID, user)
-}
-
-func (ut *UserTracker) hasWildCardApplied(hierarchy []string) bool {
-	ut.RLock()
-	defer ut.RUnlock()
-	return ut.queueTracker.hasWildCardApplied(hierarchy)
 }

--- a/pkg/scheduler/ugm/user_tracker_test.go
+++ b/pkg/scheduler/ugm/user_tracker_test.go
@@ -206,8 +206,8 @@ func TestSetMaxLimits(t *testing.T) {
 		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v, error %t", hierarchy1, TestApp1, usage1, err)
 	}
 
-	userTracker.setLimits(hierarchy1, resources.Multiply(usage1, 5), 5)
-	userTracker.setLimits(hierarchy5, resources.Multiply(usage1, 10), 10)
+	userTracker.setLimits(hierarchy1, resources.Multiply(usage1, 5), 5, false, false)
+	userTracker.setLimits(hierarchy5, resources.Multiply(usage1, 10), 10, false, false)
 
 	result = userTracker.increaseTrackedResource(hierarchy1, TestApp1, usage1)
 	if !result {
@@ -218,8 +218,8 @@ func TestSetMaxLimits(t *testing.T) {
 	if !result {
 		t.Fatalf("unable to increase tracked resource: queuepath %+q, app %s, res %v", hierarchy1, TestApp2, usage1)
 	}
-	userTracker.setLimits(hierarchy1, usage1, 1)
-	userTracker.setLimits(hierarchy5, usage1, 1)
+	userTracker.setLimits(hierarchy1, usage1, 1, false, false)
+	userTracker.setLimits(hierarchy5, usage1, 1, false, false)
 }
 
 func getUserResource(ut *UserTracker) map[string]*resources.Resource {


### PR DESCRIPTION
### What is this PR for?
If there is no limit configured for user but wild card has some limit, then use that limit for all users permanently till next config change. Since limit has been defined in corresponding user queue tracker object, there is no need to wild card checks during headroom, canrunapp and increase calls etc thereby increases the performance of critical path. While clearing old configs, in case wild card user limit has been removed, ensure all users used that wild card user limit settings has reset to its original value. Introduced "useWildCard" bool flag in queue tracker to handle this.

### What type of PR is it?
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2209

### How should this be tested?
Existing unit tests should continue to run as usual without any failures.
Added new unit test to cover this change.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
