### PR TITLE
[YUNIKORN-2270] GPU Preemption is not triggered as expected when all available GPUs are used.

### DIFF
--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -1871,7 +1871,7 @@ func TestTryAllocatePreemptQueue(t *testing.T) {
 	// pass the time and try again
 	ask3.createTime = ask3.createTime.Add(-30 * time.Second)
 	alloc3 = app2.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
-	assert.Assert(t, alloc3 == nil, "alloc3 not expected")
+	assert.Assert(t, alloc3 != nil && alloc3.result == Reserved, "alloc3 should be a reservation")
 	assert.Assert(t, alloc2.IsPreempted(), "alloc2 should have been preempted")
 }
 

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -573,20 +573,11 @@ func (p *Preemptor) TryPreemption() (*Allocation, bool) {
 		"preempting allocations to free up resources to run ask: "+p.ask.GetAllocationKey())
 
 	// reserve the selected node for the new allocation if it will fit
-	if p.headRoom.FitInMaxUndef(p.ask.GetAllocatedResource()) {
-		log.Log(log.SchedPreemption).Info("Reserving node for ask after preemption",
-			zap.String("allocationKey", p.ask.GetAllocationKey()),
-			zap.String("nodeID", nodeID),
-			zap.Int("victimCount", len(victims)))
-		return newReservedAllocation(nodeID, p.ask), true
-	}
-
-	// can't reserve as queue is still too full, but scheduling should succeed after preemption occurs
-	log.Log(log.SchedPreemption).Info("Preempting allocations for ask, but not reserving yet as queue is still above capacity",
+	log.Log(log.SchedPreemption).Info("Reserving node for ask after preemption",
 		zap.String("allocationKey", p.ask.GetAllocationKey()),
+		zap.String("nodeID", nodeID),
 		zap.Int("victimCount", len(victims)))
-
-	return nil, true
+	return newReservedAllocation(nodeID, p.ask), true
 }
 
 type predicateCheckResult struct {

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1908,6 +1908,7 @@ func TestPreemption(t *testing.T) {
 	assert.Assert(t, alloc2.IsPreempted(), "alloc-2 is not preempted")
 
 	// allocation should still not do anything as we have not yet released the preempted allocation
+	// but the ask should have a reservation
 	alloc = partition.tryAllocate()
 	if alloc != nil {
 		t.Fatal("unexpected allocation")
@@ -1937,7 +1938,7 @@ func TestPreemption(t *testing.T) {
 		t.Fatal("missing allocation")
 	}
 	assert.Equal(t, 0, len(app2.GetReservations()), "ask should not be reserved")
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result should be allocated")
+	assert.Equal(t, alloc.GetResult(), objects.AllocatedReserved, "result should be allocated from reservation")
 	assert.Equal(t, alloc.GetAllocationKey(), allocID3, "expected ask alloc-3 to be allocated")
 	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 10000}), getExpectedQueuesLimitsForPreemption())
 


### PR DESCRIPTION
### What is this PR for?
I am testing GPU preemption scenarios, and in the following scenario, the preemption isn't happening as expected. 

queue structure is pretty simple:

```
root
 - a
   min=100
   max=300
 - b
   min=0
   max=300
```
the cluster has a total of 300 GPUs available, no autoscaling. Reproducing steps:

1. Create 600 pods in `root.b queue`, each needs 1 GPU. This will consume all 300 GPUs available in the cluster, and 300 pods pending
2. Create 100 pods in `root.a` queue, each needs 1 GPU. The expectation is queue `a` will preempt 100 GPU from queue `b` reach the guarantee.

observation: a small number of pods preempted resources from queue `b` got started on queue `a`, the result is not stable. it could not reach guaranteed resources.

When I debug, I found in these lines: https://github.com/apache/yunikorn-core/blob/620687afe10638d3e191edffbc81959985abbbb4/pkg/scheduler/objects/preemption.go#L576-L587. When it marks an ask as triggered preemption, when the next time doing `tryPreemption()`, it will be skipped. However, when the queue headroom is enough, in my case, because all GPUs are utilized, the headroom for GPU is 0, it skipped to create the reservation. Then even one pod gets evicted, the pod initiated this preemption cannot get the spot.

Not sure why we need the check here, when I removed it and always return a reservation, it works much better and much stable now.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
N/A

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-2270

