### PR TITLE
[YUNIKORN-2285] Don't re-calculate reservationKey

### DIFF
--- a/pkg/scheduler/objects/allocation_ask.go
+++ b/pkg/scheduler/objects/allocation_ask.go
@@ -48,12 +48,14 @@ type AllocationAsk struct {
 	originator        bool
 	tags              map[string]string
 	allocatedResource *resources.Resource
+	resKeyWithoutNode string // the reservation key without node
 
 	// Mutable fields which need protection
 	pendingAskRepeat    int32
 	allocLog            map[string]*AllocationLogEntry
 	preemptionTriggered bool
 	preemptCheckTime    time.Time
+	resKeyPerNode       map[string]string // reservation key for a given node
 
 	sync.RWMutex
 }
@@ -65,12 +67,15 @@ type AllocationLogEntry struct {
 }
 
 func NewAllocationAsk(allocationKey string, applicationID string, allocatedResource *resources.Resource) *AllocationAsk {
-	return &AllocationAsk{
+	aa := &AllocationAsk{
 		allocationKey:     allocationKey,
 		applicationID:     applicationID,
 		allocatedResource: allocatedResource,
 		allocLog:          make(map[string]*AllocationLogEntry),
+		resKeyPerNode:     make(map[string]string),
 	}
+	aa.resKeyWithoutNode = reservationKeyWithoutNode(applicationID, allocationKey)
+	return aa
 }
 
 func NewAllocationAskFromSI(ask *si.AllocationAsk) *AllocationAsk {
@@ -93,6 +98,7 @@ func NewAllocationAskFromSI(ask *si.AllocationAsk) *AllocationAsk {
 		allowPreemptOther: common.IsAllowPreemptOther(ask.PreemptionPolicy),
 		originator:        ask.Originator,
 		allocLog:          make(map[string]*AllocationLogEntry),
+		resKeyPerNode:     make(map[string]string),
 	}
 	// this is a safety check placeholder and task group name must be set as a combo
 	// order is important as task group can be set without placeholder but not the other way around
@@ -101,6 +107,7 @@ func NewAllocationAskFromSI(ask *si.AllocationAsk) *AllocationAsk {
 			zap.Stringer("SI ask", ask))
 		return nil
 	}
+	saa.resKeyWithoutNode = reservationKeyWithoutNode(ask.ApplicationID, ask.AllocationKey)
 	return saa
 }
 
@@ -297,4 +304,16 @@ func (aa *AllocationAsk) completedPendingAsk() int {
 	aa.RLock()
 	defer aa.RUnlock()
 	return int(aa.maxAllocations - aa.pendingAskRepeat)
+}
+
+func (aa *AllocationAsk) setReservationKeyForNode(node, resKey string) {
+	aa.Lock()
+	defer aa.Unlock()
+	aa.resKeyPerNode[node] = resKey
+}
+
+func (aa *AllocationAsk) getReservationKeyForNode(node string) string {
+	aa.RLock()
+	defer aa.RUnlock()
+	return aa.resKeyPerNode[node]
 }

--- a/pkg/scheduler/objects/allocation_ask_test.go
+++ b/pkg/scheduler/objects/allocation_ask_test.go
@@ -57,6 +57,7 @@ func TestNewAsk(t *testing.T) {
 	askStr := ask.String()
 	expected := "allocationKey ask-1, applicationID app-1, Resource map[first:10], PendingRepeats 1"
 	assert.Equal(t, askStr, expected, "Strings should have been equal")
+	assert.Equal(t, "app-1|ask-1", ask.resKeyWithoutNode) //nolint:staticcheck
 }
 
 func TestPendingAskRepeat(t *testing.T) {

--- a/pkg/scheduler/objects/reservation.go
+++ b/pkg/scheduler/objects/reservation.go
@@ -21,6 +21,7 @@ package objects
 import (
 	"go.uber.org/zap"
 
+	"github.com/apache/yunikorn-core/pkg/common"
 	"github.com/apache/yunikorn-core/pkg/log"
 )
 
@@ -69,9 +70,20 @@ func reservationKey(node *Node, app *Application, ask *AllocationAsk) string {
 		return ""
 	}
 	if node == nil {
-		return app.ApplicationID + "|" + ask.GetAllocationKey()
+		return ask.resKeyWithoutNode
 	}
-	return node.NodeID + "|" + ask.GetAllocationKey()
+	key := ask.getReservationKeyForNode(node.NodeID)
+	if key != common.Empty {
+		return key
+	}
+
+	key = node.NodeID + "|" + ask.GetAllocationKey()
+	ask.setReservationKeyForNode(node.NodeID, key)
+	return key
+}
+
+func reservationKeyWithoutNode(appID, allocKey string) string {
+	return appID + "|" + allocKey
 }
 
 // Return the reservation key

--- a/pkg/scheduler/objects/reservation_test.go
+++ b/pkg/scheduler/objects/reservation_test.go
@@ -85,6 +85,8 @@ func TestReservationKey(t *testing.T) {
 	// other cases
 	reserve = reservationKey(node, nil, ask)
 	assert.Equal(t, reserve, "node-1|alloc-1", "incorrect node reservation key")
+	assert.Equal(t, "node-1|alloc-1", ask.resKeyPerNode["node-1"])
+	assert.Equal(t, 1, len(ask.resKeyPerNode))
 	reserve = reservationKey(nil, app, ask)
 	assert.Equal(t, reserve, "app-1|alloc-1", "incorrect app reservation key")
 }


### PR DESCRIPTION
### What is this PR for?
Don't constantly re-calculate reservationKey in case of reserved allocations. We keep generating this string if the cluster is busy.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2285

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
