### PR TITLE
[YUNIKORN-2303] Data race during queue sorting

### DIFF
--- a/pkg/scheduler/objects/sorters.go
+++ b/pkg/scheduler/objects/sorters.go
@@ -68,7 +68,7 @@ func sortQueuesByPriorityAndFairness(queues []*Queue) {
 		comp := resources.CompUsageRatioSeparately(l.GetAllocatedResource(), l.GetGuaranteedResource(),
 			r.GetAllocatedResource(), r.GetGuaranteedResource())
 		if comp == 0 {
-			return resources.StrictlyGreaterThan(resources.Sub(l.pending, r.pending), resources.Zero)
+			return resources.StrictlyGreaterThan(resources.Sub(l.GetPendingResource(), r.GetPendingResource()), resources.Zero)
 		}
 		return comp < 0
 	})
@@ -89,7 +89,7 @@ func sortQueuesByFairnessAndPriority(queues []*Queue) {
 			if lPriority < rPriority {
 				return false
 			}
-			return resources.StrictlyGreaterThan(resources.Sub(l.pending, r.pending), resources.Zero)
+			return resources.StrictlyGreaterThan(resources.Sub(l.GetPendingResource(), r.GetPendingResource()), resources.Zero)
 		}
 		return comp < 0
 	})


### PR DESCRIPTION
### What is this PR for?
We must not access `Queue.pending` directly.  Use `GetPendingResource()` because it can be modified from different goroutines.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2303

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
