### PR TITLE
[YUNIKORN-2320] Package-level logger triggers early log system initialization, preventing custom logging configuration

### DIFF
--- a/pkg/entrypoint/entrypoint_test.go
+++ b/pkg/entrypoint/entrypoint_test.go
@@ -35,7 +35,6 @@ import (
 const relTestDataDir = "build" // test data directory, relative to the project root
 const logFileName = "test.log"
 const logMessage = "log message sent via the core logger"
-const logMessage2 = "log message sent via the app logger"
 
 // TestCustomLoggingConfiguration ensures that custom logging configuration takes even in the presence of "objects"
 // package initialization. "objects" package initialization used to break custom logging configuration in the past,
@@ -58,7 +57,6 @@ func TestCustomLoggingConfiguration(t *testing.T) {
 	StartAllServices()
 	ykManagedLogger := log.Log(log.Core)
 	ykManagedLogger.Info(logMessage)
-	objects.GetRateLimitedAppLog().Info(logMessage2)
 	err = ykManagedLogger.Sync()
 	if err != nil {
 		// if it fails to sync, it may be because the logger is still using /dev/stderr
@@ -67,9 +65,7 @@ func TestCustomLoggingConfiguration(t *testing.T) {
 	// make sure the test log messages are in the log file
 	bs, err := os.ReadFile(logFile)
 	assert.NilError(t, err, "failed to read the log file", logFile)
-	for _, m := range []string{logMessage, logMessage2} {
-		assert.Equal(t, strings.Contains(string(bs), m), true, "'%s' not found in the log file %s", m, logFile)
-	}
+	assert.Equal(t, strings.Contains(string(bs), logMessage), true, "'%s' not found in the log file %s", logMessage, logFile)
 }
 
 // getWritableTestDataDir returns the absolute path of the validated (in that it ensures it exists in the file system)

--- a/pkg/entrypoint/entrypoint_test.go
+++ b/pkg/entrypoint/entrypoint_test.go
@@ -58,7 +58,7 @@ func TestCustomLoggingConfiguration(t *testing.T) {
 	StartAllServices()
 	ykManagedLogger := log.Log(log.Core)
 	ykManagedLogger.Info(logMessage)
-	objects.GetAppLog().Info(logMessage2)
+	objects.GetRateLimitedAppLog().Info(logMessage2)
 	err = ykManagedLogger.Sync()
 	if err != nil {
 		// if it fails to sync, it may be because the logger is still using /dev/stderr

--- a/pkg/entrypoint/entrypoint_test.go
+++ b/pkg/entrypoint/entrypoint_test.go
@@ -1,0 +1,104 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package entrypoint
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/apache/yunikorn-core/pkg/log"
+	"github.com/apache/yunikorn-core/pkg/scheduler/objects"
+
+	"go.uber.org/zap"
+	"gotest.tools/v3/assert"
+)
+
+const relTestDataDir = "build" // test data directory, relative to the project root
+const logFileName = "test.log"
+const logMessage = "log message sent via the core logger"
+const logMessage2 = "log message sent via the app logger"
+
+// TestCustomLoggingConfiguration ensures that custom logging configuration takes even in the presence of "objects"
+// package initialization. "objects" package initialization used to break custom logging configuration in the past,
+// by triggering rateLimitedLogger initialization in the package lexical scope, which did trigger in turn one-time
+// logging system initialization, preventing subsequent custom configuration. See YUNIKORN-2320.
+func TestCustomLoggingConfiguration(t *testing.T) {
+	defer cleanup()
+	// ensure that the "object" package initialization happens
+	app := objects.Application{}
+	assert.Equal(t, "", app.ApplicationID)
+	testDataDir, err := getWritableTestDataDir()
+	assert.NilError(t, err, "failed to get the test data directory")
+	logFile := filepath.Join(testDataDir, logFileName)
+	config := zap.NewDevelopmentConfig()
+	config.OutputPaths = []string{logFile}
+	config.ErrorOutputPaths = []string{logFile}
+	logger, err := config.Build()
+	assert.NilError(t, err, "zap Logger creation failed")
+	log.InitializeLogger(logger, &config)
+	StartAllServices()
+	ykManagedLogger := log.Log(log.Core)
+	ykManagedLogger.Info(logMessage)
+	objects.GetAppLog().Info(logMessage2)
+	err = ykManagedLogger.Sync()
+	if err != nil {
+		// if it fails to sync, it may be because the logger is still using /dev/stderr
+		fmt.Printf("%v\n", err)
+	}
+	// make sure the test log messages are in the log file
+	bs, err := os.ReadFile(logFile)
+	assert.NilError(t, err, "failed to read the log file", logFile)
+	for _, m := range []string{logMessage, logMessage2} {
+		assert.Equal(t, strings.Contains(string(bs), m), true, "'%s' not found in the log file %s", m, logFile)
+	}
+}
+
+// getWritableTestDataDir returns the absolute path of the validated (in that it ensures it exists in the file system)
+// directory where we can write test data on the local file system.
+func getWritableTestDataDir() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	buildDir := filepath.Join(dir, "../../", relTestDataDir)
+	_, err = os.Stat(buildDir)
+	if err != nil {
+		return "", err
+	}
+	return buildDir, nil
+}
+
+// cleanup removes the test log file, if created in the writable test data directory. Noop if the file is not present.
+func cleanup() {
+	testDataDir, err := getWritableTestDataDir()
+	if err != nil {
+		fmt.Printf("%v\n", err)
+	}
+	err = os.Remove(filepath.Join(testDataDir, logFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			// ignore
+			return
+		}
+		fmt.Printf("%v\n", err)
+	}
+}

--- a/pkg/log/rate_limited_logger.go
+++ b/pkg/log/rate_limited_logger.go
@@ -30,7 +30,7 @@ type RateLimitedLogger struct {
 	limiter *rate.Limiter
 }
 
-// RateLimitedLogger provides a logger that only logs once within a specified duration
+// RateLimitedLog provides a logger that only logs once within a specified duration.
 func RateLimitedLog(handle *LoggerHandle, every time.Duration) *RateLimitedLogger {
 	return &RateLimitedLogger{
 		logger:  Log(handle),

--- a/pkg/log/rate_limited_logger.go
+++ b/pkg/log/rate_limited_logger.go
@@ -25,56 +25,56 @@ import (
 	"golang.org/x/time/rate"
 )
 
-type rateLimitedLogger struct {
+type RateLimitedLogger struct {
 	logger  *zap.Logger
 	limiter *rate.Limiter
 }
 
 // RateLimitedLogger provides a logger that only logs once within a specified duration
-func RateLimitedLog(handle *LoggerHandle, every time.Duration) *rateLimitedLogger {
-	return &rateLimitedLogger{
+func RateLimitedLog(handle *LoggerHandle, every time.Duration) *RateLimitedLogger {
+	return &RateLimitedLogger{
 		logger:  Log(handle),
 		limiter: rate.NewLimiter(rate.Every(every), 1),
 	}
 }
 
-func (rl *rateLimitedLogger) Debug(msg string, fields ...zap.Field) {
+func (rl *RateLimitedLogger) Debug(msg string, fields ...zap.Field) {
 	if rl.limiter.Allow() {
 		rl.logger.Debug(msg, fields...)
 	}
 }
 
-func (rl *rateLimitedLogger) Info(msg string, fields ...zap.Field) {
+func (rl *RateLimitedLogger) Info(msg string, fields ...zap.Field) {
 	if rl.limiter.Allow() {
 		rl.logger.Info(msg, fields...)
 	}
 }
 
-func (rl *rateLimitedLogger) Warn(msg string, fields ...zap.Field) {
+func (rl *RateLimitedLogger) Warn(msg string, fields ...zap.Field) {
 	if rl.limiter.Allow() {
 		rl.logger.Warn(msg, fields...)
 	}
 }
 
-func (rl *rateLimitedLogger) Error(msg string, fields ...zap.Field) {
+func (rl *RateLimitedLogger) Error(msg string, fields ...zap.Field) {
 	if rl.limiter.Allow() {
 		rl.logger.Error(msg, fields...)
 	}
 }
 
-func (rl *rateLimitedLogger) DPanic(msg string, fields ...zap.Field) {
+func (rl *RateLimitedLogger) DPanic(msg string, fields ...zap.Field) {
 	if rl.limiter.Allow() {
 		rl.logger.DPanic(msg, fields...)
 	}
 }
 
-func (rl *rateLimitedLogger) Panic(msg string, fields ...zap.Field) {
+func (rl *RateLimitedLogger) Panic(msg string, fields ...zap.Field) {
 	if rl.limiter.Allow() {
 		rl.logger.Panic(msg, fields...)
 	}
 }
 
-func (rl *rateLimitedLogger) Fatal(msg string, fields ...zap.Field) {
+func (rl *RateLimitedLogger) Fatal(msg string, fields ...zap.Field) {
 	if rl.limiter.Allow() {
 		rl.logger.Fatal(msg, fields...)
 	}

--- a/pkg/log/rate_limited_logger.go
+++ b/pkg/log/rate_limited_logger.go
@@ -30,8 +30,8 @@ type RateLimitedLogger struct {
 	limiter *rate.Limiter
 }
 
-// RateLimitedLog provides a logger that only logs once within a specified duration.
-func RateLimitedLog(handle *LoggerHandle, every time.Duration) *RateLimitedLogger {
+// NewRateLimitedLogger provides a logger that only logs once within a specified duration.
+func NewRateLimitedLogger(handle *LoggerHandle, every time.Duration) *RateLimitedLogger {
 	return &RateLimitedLogger{
 		logger:  Log(handle),
 		limiter: rate.NewLimiter(rate.Every(every), 1),

--- a/pkg/log/rate_limited_logger_test.go
+++ b/pkg/log/rate_limited_logger_test.go
@@ -48,7 +48,7 @@ func TestRateLimitedLog(t *testing.T) {
 		),
 	)
 	// log once within one minute
-	logger := &rateLimitedLogger{
+	logger := &RateLimitedLogger{
 		logger:  zapLogger,
 		limiter: rate.NewLimiter(rate.Every(time.Minute), 1),
 	}

--- a/pkg/log/rate_limited_logger_test.go
+++ b/pkg/log/rate_limited_logger_test.go
@@ -22,12 +22,12 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"golang.org/x/time/rate"
 	"gotest.tools/v3/assert"
 )
 
@@ -37,6 +37,9 @@ type logMessage struct {
 }
 
 func TestRateLimitedLog(t *testing.T) {
+	defer resetTestLogger()
+	once = sync.Once{}
+	config := zap.NewDevelopmentConfig()
 	encoderConfig := zap.NewDevelopmentEncoderConfig()
 	buf := bytes.Buffer{}
 	writer := bufio.NewWriter(&buf)
@@ -47,12 +50,9 @@ func TestRateLimitedLog(t *testing.T) {
 			zap.NewAtomicLevelAt(zap.InfoLevel),
 		),
 	)
+	InitializeLogger(zapLogger, &config)
 	// log once within one minute
-	logger := &RateLimitedLogger{
-		logger:  zapLogger,
-		limiter: rate.NewLimiter(rate.Every(time.Minute), 1),
-	}
-
+	logger := NewRateLimitedLogger(Core, 1*time.Minute)
 	startTime := time.Now()
 	for {
 		elapsed := time.Since(startTime)
@@ -62,10 +62,10 @@ func TestRateLimitedLog(t *testing.T) {
 		logger.Info("YuniKorn")
 		time.Sleep(10 * time.Millisecond)
 	}
-	writer.Flush()
-
+	err := writer.Flush()
+	assert.NilError(t, err, "failed to flush writer")
 	var lm logMessage
-	err := json.Unmarshal(buf.Bytes(), &lm)
+	err = json.Unmarshal(buf.Bytes(), &lm)
 	assert.NilError(t, err, "failed to unmarshal logMessage from buffer: %s", buf.Bytes())
 	assert.Equal(t, "INFO", lm.Level)
 	assert.Equal(t, "YuniKorn", lm.Message)

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -974,7 +974,7 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption
 			// the iterator might not have the node we need as it could be reserved, or we have not added it yet
 			node := getNodeFn(requiredNode)
 			if node == nil {
-				GetRateLimitedAppLog().Info("required node is not found (could be transient)",
+				getRateLimitedAppLog().Info("required node is not found (could be transient)",
 					zap.String("application ID", sa.ApplicationID),
 					zap.String("allocationKey", request.GetAllocationKey()),
 					zap.String("required node", requiredNode))
@@ -2065,8 +2065,8 @@ func (sa *Application) SetTimedOutPlaceholder(taskGroupName string, timedOut int
 	}
 }
 
-// GetRateLimitedAppLog lazy initializes the application logger the first time is needed.
-func GetRateLimitedAppLog() *log.RateLimitedLogger {
+// getRateLimitedAppLog lazy initializes the application logger the first time is needed.
+func getRateLimitedAppLog() *log.RateLimitedLogger {
 	initAppLogOnce.Do(func() {
 		rateLimitedAppLog = log.RateLimitedLog(log.SchedApplication, time.Second)
 	})

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -2068,7 +2068,7 @@ func (sa *Application) SetTimedOutPlaceholder(taskGroupName string, timedOut int
 // getRateLimitedAppLog lazy initializes the application logger the first time is needed.
 func getRateLimitedAppLog() *log.RateLimitedLogger {
 	initAppLogOnce.Do(func() {
-		rateLimitedAppLog = log.RateLimitedLog(log.SchedApplication, time.Second)
+		rateLimitedAppLog = log.NewRateLimitedLogger(log.SchedApplication, time.Second)
 	})
 	return rateLimitedAppLog
 }

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -2065,7 +2065,7 @@ func (sa *Application) SetTimedOutPlaceholder(taskGroupName string, timedOut int
 	}
 }
 
-// GetAppLog lazy initializes the application logger the first time is needed. See YUNIKORN-2320.
+// GetAppLog lazy initializes the application logger the first time is needed.
 func GetAppLog() *log.RateLimitedLogger {
 	initAppLogOnce.Do(func() {
 		appLog = log.RateLimitedLog(log.SchedApplication, time.Second)

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -52,7 +52,7 @@ var (
 )
 
 var initAppLogOnce sync.Once
-var appLog *log.RateLimitedLogger
+var rateLimitedAppLog *log.RateLimitedLogger
 
 const (
 	Soft string = "Soft"
@@ -974,7 +974,7 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption
 			// the iterator might not have the node we need as it could be reserved, or we have not added it yet
 			node := getNodeFn(requiredNode)
 			if node == nil {
-				GetAppLog().Warn("required node is not found (could be transient)",
+				GetRateLimitedAppLog().Info("required node is not found (could be transient)",
 					zap.String("application ID", sa.ApplicationID),
 					zap.String("allocationKey", request.GetAllocationKey()),
 					zap.String("required node", requiredNode))
@@ -2065,10 +2065,10 @@ func (sa *Application) SetTimedOutPlaceholder(taskGroupName string, timedOut int
 	}
 }
 
-// GetAppLog lazy initializes the application logger the first time is needed.
-func GetAppLog() *log.RateLimitedLogger {
+// GetRateLimitedAppLog lazy initializes the application logger the first time is needed.
+func GetRateLimitedAppLog() *log.RateLimitedLogger {
 	initAppLogOnce.Do(func() {
-		appLog = log.RateLimitedLog(log.SchedApplication, time.Second)
+		rateLimitedAppLog = log.RateLimitedLog(log.SchedApplication, time.Second)
 	})
-	return appLog
+	return rateLimitedAppLog
 }

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -2357,6 +2357,11 @@ func TestGetOutstandingRequests(t *testing.T) {
 	assert.Equal(t, 0, len(total4), "expected no outstanding requests for TestCase 4")
 }
 
+func TestGetRateLimitedAppLog(t *testing.T) {
+	l := getRateLimitedAppLog()
+	assert.Check(t, l != nil)
+}
+
 func (sa *Application) addPlaceholderDataWithLocking(ask *AllocationAsk) {
 	sa.Lock()
 	defer sa.Unlock()


### PR DESCRIPTION
### What is this PR for?

Fix for YUNIKORN-2320 "Package-level logger triggers early log system initialization, preventing custom logging configuration". Early initialization at package lexical scope triggers one-time logging system initialization, preventing subsequent custom logging configuration. The fix introduces lazy initialization of the package variable.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-2320 

### How should this be tested?

endpoint.TestCustomLoggingConfiguration() fails in presence of the defect and start passing after the bug is fixed.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
