### PR TITLE
[YUNIKORN-2329] Remove goroutine in RMProxy.UpdateNode after benchmark

### DIFF
--- a/pkg/rmproxy/rmproxy.go
+++ b/pkg/rmproxy/rmproxy.go
@@ -314,37 +314,26 @@ func (rmp *RMProxy) UpdateAllocation(request *si.AllocationRequest) error {
 	if rmp.GetResourceManagerCallback(request.RmID) == nil {
 		return fmt.Errorf("received AllocationRequest, but RmID=\"%s\" not registered", request.RmID)
 	}
-	go func() {
-		// Update allocations
-		if len(request.Allocations) > 0 {
-			for _, alloc := range request.Allocations {
-				alloc.PartitionName = common.GetNormalizedPartitionName(alloc.PartitionName, request.RmID)
-			}
-		}
+	// Update allocations
+	for _, alloc := range request.Allocations {
+		alloc.PartitionName = common.GetNormalizedPartitionName(alloc.PartitionName, request.RmID)
+	}
 
-		// Update asks
-		if len(request.Asks) > 0 {
-			for _, ask := range request.Asks {
-				ask.PartitionName = common.GetNormalizedPartitionName(ask.PartitionName, request.RmID)
-			}
-		}
+	// Update asks
+	for _, ask := range request.Asks {
+		ask.PartitionName = common.GetNormalizedPartitionName(ask.PartitionName, request.RmID)
+	}
 
-		// Update releases
-		if request.Releases != nil {
-			if len(request.Releases.AllocationsToRelease) > 0 {
-				for _, rel := range request.Releases.AllocationsToRelease {
-					rel.PartitionName = common.GetNormalizedPartitionName(rel.PartitionName, request.RmID)
-				}
-			}
-
-			if len(request.Releases.AllocationAsksToRelease) > 0 {
-				for _, rel := range request.Releases.AllocationAsksToRelease {
-					rel.PartitionName = common.GetNormalizedPartitionName(rel.PartitionName, request.RmID)
-				}
-			}
+	// Update releases
+	if request.Releases != nil {
+		for _, rel := range request.Releases.AllocationsToRelease {
+			rel.PartitionName = common.GetNormalizedPartitionName(rel.PartitionName, request.RmID)
 		}
-		rmp.EventHandlers.SchedulerEventHandler.HandleEvent(&rmevent.RMUpdateAllocationEvent{Request: request})
-	}()
+		for _, rel := range request.Releases.AllocationAsksToRelease {
+			rel.PartitionName = common.GetNormalizedPartitionName(rel.PartitionName, request.RmID)
+		}
+	}
+	rmp.EventHandlers.SchedulerEventHandler.HandleEvent(&rmevent.RMUpdateAllocationEvent{Request: request})
 	return nil
 }
 
@@ -353,21 +342,17 @@ func (rmp *RMProxy) UpdateApplication(request *si.ApplicationRequest) error {
 		return fmt.Errorf("received ApplicationRequest, but RmID=\"%s\" not registered", request.RmID)
 	}
 
-	go func() {
-		// Update New apps
-		if len(request.New) > 0 {
-			for _, app := range request.New {
-				app.PartitionName = common.GetNormalizedPartitionName(app.PartitionName, request.RmID)
-			}
-		}
-		// Update Remove apps
-		if len(request.Remove) > 0 {
-			for _, app := range request.Remove {
-				app.PartitionName = common.GetNormalizedPartitionName(app.PartitionName, request.RmID)
-			}
-		}
-		rmp.EventHandlers.SchedulerEventHandler.HandleEvent(&rmevent.RMUpdateApplicationEvent{Request: request})
-	}()
+	// Update New apps
+	for _, app := range request.New {
+		app.PartitionName = common.GetNormalizedPartitionName(app.PartitionName, request.RmID)
+	}
+
+	// Update Remove apps
+	for _, app := range request.Remove {
+		app.PartitionName = common.GetNormalizedPartitionName(app.PartitionName, request.RmID)
+	}
+
+	rmp.EventHandlers.SchedulerEventHandler.HandleEvent(&rmevent.RMUpdateApplicationEvent{Request: request})
 	return nil
 }
 
@@ -376,17 +361,15 @@ func (rmp *RMProxy) UpdateNode(request *si.NodeRequest) error {
 		return fmt.Errorf("received NodeRequest, but RmID=\"%s\" not registered", request.RmID)
 	}
 
-	if len(request.Nodes) > 0 {
-		for _, node := range request.Nodes {
-			if len(node.GetAttributes()) == 0 {
-				node.Attributes = map[string]string{}
-			}
-			partition := node.Attributes[siCommon.NodePartition]
-			node.Attributes[siCommon.NodePartition] = common.GetNormalizedPartitionName(partition, request.RmID)
+	for _, node := range request.Nodes {
+		if len(node.GetAttributes()) == 0 {
+			node.Attributes = map[string]string{}
 		}
+		partition := node.Attributes[siCommon.NodePartition]
+		node.Attributes[siCommon.NodePartition] = common.GetNormalizedPartitionName(partition, request.RmID)
 	}
-	rmp.EventHandlers.SchedulerEventHandler.HandleEvent(&rmevent.RMUpdateNodeEvent{Request: request})
 
+	rmp.EventHandlers.SchedulerEventHandler.HandleEvent(&rmevent.RMUpdateNodeEvent{Request: request})
 	return nil
 }
 

--- a/pkg/rmproxy/rmproxy.go
+++ b/pkg/rmproxy/rmproxy.go
@@ -375,18 +375,18 @@ func (rmp *RMProxy) UpdateNode(request *si.NodeRequest) error {
 	if rmp.GetResourceManagerCallback(request.RmID) == nil {
 		return fmt.Errorf("received NodeRequest, but RmID=\"%s\" not registered", request.RmID)
 	}
-	go func() {
-		if len(request.Nodes) > 0 {
-			for _, node := range request.Nodes {
-				if len(node.GetAttributes()) == 0 {
-					node.Attributes = map[string]string{}
-				}
-				partition := node.Attributes[siCommon.NodePartition]
-				node.Attributes[siCommon.NodePartition] = common.GetNormalizedPartitionName(partition, request.RmID)
+
+	if len(request.Nodes) > 0 {
+		for _, node := range request.Nodes {
+			if len(node.GetAttributes()) == 0 {
+				node.Attributes = map[string]string{}
 			}
+			partition := node.Attributes[siCommon.NodePartition]
+			node.Attributes[siCommon.NodePartition] = common.GetNormalizedPartitionName(partition, request.RmID)
 		}
-		rmp.EventHandlers.SchedulerEventHandler.HandleEvent(&rmevent.RMUpdateNodeEvent{Request: request})
-	}()
+	}
+	rmp.EventHandlers.SchedulerEventHandler.HandleEvent(&rmevent.RMUpdateNodeEvent{Request: request})
+
 	return nil
 }
 


### PR DESCRIPTION
### What is this PR for?
[2024-01-20 Update version 2]
As a solution for [YUNIKORN-2327](https://issues.apache.org/jira/browse/YUNIKORN-2327). Remove goroutine in [RMProxy.UpdateNode()](https://github.com/apache/yunikorn-core/blob/master/pkg/rmproxy/rmproxy.go#L378-L389) could make sure the function put si.NodeRequest in channel in the same order from shim.

Also, remove some trivial parallelism in RMProxy.go because it is considered "premature optimization." The parallelism is not really necessary. Remove goroutine in below functions:
1. func (rmp *RMProxy) UpdateApplication(request *si.ApplicationRequest)
2. func (rmp *RMProxy) UpdateAllocation(request *si.AllocationRequest)
3. func (rmp *RMProxy) UpdateNode(request *si.NodeRequest)

Also remove unnecessary empty list checks.

Once this PR is merged, I'll trigger another PR for shim to upgrade go.mod version.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
Update yunikorn-core version in shim

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2329

### How should this be tested?
Rebuild shim with this core version, all existing e2e test should pass.
The e2e test passed in my forked shim:
https://github.com/chenyulin0719/yunikorn-k8shim/actions/runs/7587158325

### Screenshots (if appropriate)
NA

### Questions:
NA
