### PR TITLE
[YUNIKORN-2284] ERROR message when stopping Service context

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -1847,7 +1847,9 @@ func (sa *Application) RemoveAllAllocations() []*Allocation {
 		sa.appEvents.sendRemoveAllocationEvent(alloc, si.TerminationType_STOPPED_BY_RM)
 	}
 
-	if resources.IsZero(sa.pending) {
+	// if an app doesn't have any allocations and the user doesn't have other applications,
+	// the user tracker is nonexistent. We don't want to decrease resource usage in this case.
+	if ugm.GetUserManager().GetUserTracker(sa.user.User) != nil && resources.IsZero(sa.pending) {
 		sa.decUserResourceUsage(resources.Add(sa.allocatedResource, sa.allocatedPlaceholder), true)
 	}
 	// cleanup allocated resource for app (placeholders and normal)


### PR DESCRIPTION
### What is this PR for?
The tracker object no longer exist when `PartitionContext.removeApplication()` is called. At this point the app is also in Completed state, so it's not necessary to decrement any resource.

### What type of PR is it?
* [X] - Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2284

### How should this be tested?
Run `go test ./... -tags deadlock -v` and check there is no error message like `user tracker must be available`.
