### PR TITLE
[YUNIKORN-2340] Upgrade actions versions in Github Action workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,11 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: .go_version
       - name: Check license


### PR DESCRIPTION
### What is this PR for?
Bump below actions verions to surpress the "Node.js 16 actions are deprecated." warning message:

1. actions/checkout (v3 -> v4)
2. actions/setup-go (v3 -> v5)   ([Only support node js 20 in v5](https://github.com/actions/setup-go/releases))

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
Update below repo's actions version:
1. yunikorn-k8shim

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2340

### How should this be tested?
Tested in Github action.  Create a pull request to master branch and check the Actions result.
ex: https://github.com/chenyulin0719/yunikorn-core/actions/runs/7694334424

### Screenshots (if appropriate)
After:
<img width="1448" alt="image" src="https://github.com/apache/yunikorn-core/assets/26764036/d1bc48a2-ba44-47c2-89a7-aeae1e6da197">

Before:
<img width="1451" alt="image" src="https://github.com/apache/yunikorn-core/assets/26764036/e51ca4ab-f1e2-4584-9c7a-6cb5694cf2c0">


### Questions:
NA
