### PR TITLE
[YUNIKORN-2376] Remove dummy state dump plugin

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -26,19 +26,11 @@ import (
 var plugins SchedulerPlugins
 
 func init() {
-	plugins = SchedulerPlugins{
-		StateDumpPlugin: dummyStateDumpPlugin{},
-	}
+	plugins = SchedulerPlugins{}
 }
 
-type dummyStateDumpPlugin struct{}
-
-var _ api.StateDumpPlugin = dummyStateDumpPlugin{}
-
-func (d dummyStateDumpPlugin) GetStateDump() (string, error) {
-	return "{}", nil
-}
-
+// RegisterSchedulerPlugin registers the plugin based on the interfaces(s) it implements.
+// The known interfaces are defined in yunikorn-scheduler-interface/lib/go/api
 func RegisterSchedulerPlugin(plugin interface{}) {
 	plugins.Lock()
 	defer plugins.Unlock()
@@ -52,7 +44,8 @@ func RegisterSchedulerPlugin(plugin interface{}) {
 	}
 }
 
-// visible for testing
+// UnregisterSchedulerPlugins removes all earlier set plugins
+// visible for testing only
 func UnregisterSchedulerPlugins() {
 	plugins.Lock()
 	defer plugins.Unlock()
@@ -60,12 +53,14 @@ func UnregisterSchedulerPlugins() {
 	plugins.StateDumpPlugin = nil
 }
 
+// GetResourceManagerCallbackPlugin returns the registered callback plugin or nil if none was registered.
 func GetResourceManagerCallbackPlugin() api.ResourceManagerCallback {
 	plugins.RLock()
 	defer plugins.RUnlock()
 	return plugins.ResourceManagerCallbackPlugin
 }
 
+// GetStateDumpPlugin returns the registered state dump plugin or nil if none was registered.
 func GetStateDumpPlugin() api.StateDumpPlugin {
 	plugins.RLock()
 	defer plugins.RUnlock()

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -944,9 +944,14 @@ func getRMBuildInformation(lists map[string]*scheduler.RMInformation) []map[stri
 }
 
 func getResourceManagerDiagnostics() map[string]interface{} {
-	result := make(map[string]interface{}, 0)
+	result := make(map[string]interface{})
 
+	// if the RM has not registered state dump the plugin will be nil
 	plugin := plugins.GetStateDumpPlugin()
+	if plugin == nil {
+		result["empty"] = "Resource Manager did not register callback"
+		return result
+	}
 
 	// get state dump from RM
 	dumpStr, err := plugin.GetStateDump()


### PR DESCRIPTION
### What is this PR for?
Do not register a dummy state dump plugin during init. Handle the fact that a resource manager does not have to register a state dump plugin in the state dump creation.

### What type of PR is it?
* [X] - Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-2376

### How should this be tested?
TestFullStateDumpPath covers the case as it never sets a state dump plugin