### PR TITLE
[YUNIKORN-2370] Proper event handling for failed headroom checks

### DIFF
--- a/pkg/scheduler/objects/allocation_ask.go
+++ b/pkg/scheduler/objects/allocation_ask.go
@@ -360,7 +360,7 @@ func (aa *AllocationAsk) setHeadroomCheckFailed(headroom *resources.Resource, qu
 	defer aa.Unlock()
 	if !aa.headroomCheckFailed {
 		aa.headroomCheckFailed = true
-		aa.askEvents.sendRequestDoesNotFitInQueue(headroom, queue)
+		aa.askEvents.sendRequestExceedsQueueHeadroom(headroom, queue)
 	}
 }
 

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -955,9 +955,10 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption
 		// as the preempted allocation must be for the same user in a different queue in the hierarchy...
 		if !userHeadroom.FitInMaxUndef(request.GetAllocatedResource()) {
 			request.LogAllocationFailure(NotEnoughUserQuota, true) // error message MUST be constant!
+			request.setUserQuotaCheckFailed(userHeadroom)
 			continue
 		}
-
+		request.setUserQuotaCheckPassed()
 		request.SetSchedulingAttempted(true)
 
 		// resource must fit in headroom otherwise skip the request (unless preemption could help)
@@ -973,10 +974,11 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption
 					}
 				}
 			}
-			sa.appEvents.sendAppDoesNotFitEvent(request, headRoom)
 			request.LogAllocationFailure(NotEnoughQueueQuota, true) // error message MUST be constant!
+			request.setHeadroomCheckFailed(headRoom, sa.queuePath)
 			continue
 		}
+		request.setHeadroomCheckPassed(sa.queuePath)
 
 		requiredNode := request.GetRequiredNode()
 		// does request have any constraint to run on specific node?

--- a/pkg/scheduler/objects/application_events.go
+++ b/pkg/scheduler/objects/application_events.go
@@ -25,7 +25,6 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/apache/yunikorn-core/pkg/common"
-	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/events"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
@@ -34,15 +33,6 @@ type applicationEvents struct {
 	eventSystem events.EventSystem
 	app         *Application
 	limiter     *rate.Limiter
-}
-
-func (evt *applicationEvents) sendAppDoesNotFitEvent(request *AllocationAsk, headroom *resources.Resource) {
-	if !evt.eventSystem.IsEventTrackingEnabled() || !evt.limiter.Allow() {
-		return
-	}
-	message := fmt.Sprintf("Application %s does not fit into %s queue (request resoure %s, headroom %s)", request.GetApplicationID(), evt.app.queuePath, request.GetAllocatedResource(), headroom)
-	event := events.CreateRequestEventRecord(request.GetAllocationKey(), request.GetApplicationID(), message, request.GetAllocatedResource())
-	evt.eventSystem.AddEvent(event)
 }
 
 func (evt *applicationEvents) sendPlaceholderLargerEvent(ph *Allocation, request *AllocationAsk) {

--- a/pkg/scheduler/objects/application_events_test.go
+++ b/pkg/scheduler/objects/application_events_test.go
@@ -19,13 +19,10 @@
 package objects
 
 import (
-	"testing"
-	"time"
-
 	"gotest.tools/v3/assert"
+	"testing"
 
 	"github.com/apache/yunikorn-core/pkg/common"
-	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
@@ -48,45 +45,6 @@ func isStateChangeEvent(t *testing.T, app *Application, changeDetail si.EventRec
 	assert.Equal(t, app.ApplicationID, record.ObjectID, "incorrect object ID, expected application ID")
 	assert.Equal(t, si.EventRecord_SET, record.EventChangeType, "incorrect change type, expected set")
 	assert.Equal(t, changeDetail, record.EventChangeDetail, "incorrect change detail")
-}
-
-func TestSendAppDoesNotFitEvent(t *testing.T) {
-	app := &Application{
-		queuePath: "root.test",
-	}
-	mock := newEventSystemMockDisabled()
-	appEvents := newApplicationEvents(app, mock)
-	appEvents.sendAppDoesNotFitEvent(&AllocationAsk{}, &resources.Resource{})
-	assert.Equal(t, 0, len(mock.events), "unexpected event")
-
-	mock = newEventSystemMock()
-	appEvents = newApplicationEvents(app, mock)
-	appEvents.sendAppDoesNotFitEvent(&AllocationAsk{
-		applicationID: appID0,
-		allocationKey: aKey,
-	}, &resources.Resource{})
-	assert.Equal(t, 1, len(mock.events), "event was not generated")
-}
-
-func TestSendAppDoesNotFitEventWithRateLimiter(t *testing.T) {
-	app := &Application{
-		queuePath: "root.test",
-	}
-	mock := newEventSystemMock()
-	appEvents := newApplicationEvents(app, mock)
-	startTime := time.Now()
-	for {
-		elapsed := time.Since(startTime)
-		if elapsed > 500*time.Millisecond {
-			break
-		}
-		appEvents.sendAppDoesNotFitEvent(&AllocationAsk{
-			applicationID: appID0,
-			allocationKey: aKey,
-		}, &resources.Resource{})
-		time.Sleep(10 * time.Millisecond)
-	}
-	assert.Equal(t, 1, len(mock.events), "event was not generated")
 }
 
 func TestSendPlaceholderLargerEvent(t *testing.T) {

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -2258,19 +2258,15 @@ func TestPlaceholderLargerEvent(t *testing.T) {
 	assert.Equal(t, "app-1", records[3].ReferenceID)
 }
 
-func TestAppDoesNotFitEvent(t *testing.T) {
-	resMap := map[string]string{"memory": "100", "vcores": "10"}
-	res, err := resources.NewResourceFromConf(resMap)
-	assert.NilError(t, err, "failed to create resource with error")
-	headroomMap := map[string]string{"memory": "0", "vcores": "0"}
-	headroom, err := resources.NewResourceFromConf(headroomMap)
-	assert.NilError(t, err, "failed to create resource with error")
+func TestRequestDoesNotFitQueueEvents(t *testing.T) {
+	res, err := resources.NewResourceFromConf(map[string]string{"memory": "100", "vcores": "10"})
+	assert.NilError(t, err)
+	headroom, err := resources.NewResourceFromConf(map[string]string{"memory": "0", "vcores": "0"})
+	assert.NilError(t, err)
 	ask := newAllocationAsk("alloc-0", "app-1", res)
 	app := newApplication(appID1, "default", "root.default")
-	// Create event system after new application to avoid new application event.
-	events.Init()
-	eventSystem := events.GetEventSystem().(*events.EventSystemImpl) //nolint:errcheck
-	eventSystem.StartServiceWithPublisher(false)
+	eventSystem := newEventSystemMock()
+	ask.askEvents = newAskEvents(ask, eventSystem)
 	app.disableStateChangeEvents()
 	app.resetAppEvents()
 	queue, err := createRootQueue(nil)
@@ -2281,20 +2277,106 @@ func TestAppDoesNotFitEvent(t *testing.T) {
 	app.sortedRequests = sr
 	attempts := 0
 
+	// try to allocate
 	app.tryAllocate(headroom, true, time.Second, &attempts, nilNodeIterator, nilNodeIterator, nilGetNode)
+	assert.Equal(t, 1, len(eventSystem.events))
+	event := eventSystem.events[0]
+	assert.Equal(t, si.EventRecord_REQUEST, event.Type)
+	assert.Equal(t, si.EventRecord_NONE, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
+	assert.Equal(t, "app-1", event.ReferenceID)
+	assert.Equal(t, "alloc-0", event.ObjectID)
+	assert.Equal(t, "Request 'alloc-0' does not fit in queue 'root.default' (requested map[memory:100 vcores:10], available map[memory:0 vcores:0])", event.Message)
 
-	noEvents := 0
-	err = common.WaitFor(10*time.Millisecond, time.Second, func() bool {
-		noEvents = eventSystem.Store.CountStoredEvents()
-		return noEvents == 2
-	})
-	assert.NilError(t, err, "expected 2 event, got %d", noEvents)
-	records := eventSystem.Store.CollectEvents()
-	assert.Equal(t, si.EventRecord_REQUEST, records[1].Type)
-	assert.Equal(t, si.EventRecord_NONE, records[1].EventChangeType)
-	assert.Equal(t, si.EventRecord_DETAILS_NONE, records[1].EventChangeDetail)
-	assert.Equal(t, "app-1", records[1].ReferenceID)
-	assert.Equal(t, "alloc-0", records[1].ObjectID)
+	// second attempt - no new event
+	app.tryAllocate(headroom, true, time.Second, &attempts, nilNodeIterator, nilNodeIterator, nilGetNode)
+	assert.Equal(t, 1, len(eventSystem.events))
+
+	// third attempt with enough headroom - new event
+	eventSystem.Reset()
+	headroom, err = resources.NewResourceFromConf(map[string]string{"memory": "1000", "vcores": "1000"})
+	assert.NilError(t, err)
+	app.tryAllocate(headroom, true, time.Second, &attempts, nilNodeIterator, nilNodeIterator, nilGetNode)
+	assert.Equal(t, 1, len(eventSystem.events))
+	event = eventSystem.events[0]
+	assert.Equal(t, si.EventRecord_REQUEST, event.Type)
+	assert.Equal(t, si.EventRecord_NONE, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
+	assert.Equal(t, "app-1", event.ReferenceID)
+	assert.Equal(t, "alloc-0", event.ObjectID)
+	assert.Equal(t, "Request 'alloc-0' has become schedulable in queue 'root.default'", event.Message)
+}
+
+func TestRequestDoesNotFitUserQuotaQueueEvents(t *testing.T) {
+	setupUGM()
+	// create config with resource limits for "testuser"
+	conf := configs.QueueConfig{
+		Name:      "root",
+		Parent:    true,
+		SubmitACL: "*",
+		Limits: []configs.Limit{
+			{
+				Limit: "leaf queue limit",
+				Users: []string{
+					"testuser",
+				},
+				MaxResources: map[string]string{
+					"memory": "1",
+					"vcores": "1",
+				},
+			},
+		},
+	}
+	err := ugm.GetUserManager().UpdateConfig(conf, "root")
+	assert.NilError(t, err)
+
+	res, err := resources.NewResourceFromConf(map[string]string{"memory": "100", "vcores": "10"})
+	assert.NilError(t, err)
+	headroom, err := resources.NewResourceFromConf(map[string]string{"memory": "1000", "vcores": "1000"})
+	assert.NilError(t, err)
+	ask := newAllocationAsk("alloc-0", "app-1", res)
+	app := newApplication(appID1, "default", "root")
+	eventSystem := newEventSystemMock()
+	ask.askEvents = newAskEvents(ask, eventSystem)
+	app.disableStateChangeEvents()
+	app.resetAppEvents()
+	queue, err := createRootQueue(nil)
+	assert.NilError(t, err, "queue create failed")
+	app.queue = queue
+	sr := sortedRequests{}
+	sr.insert(ask)
+	app.sortedRequests = sr
+	attempts := 0
+
+	// try to allocate
+	app.tryAllocate(headroom, true, time.Second, &attempts, nilNodeIterator, nilNodeIterator, nilGetNode)
+	assert.Equal(t, 1, len(eventSystem.events))
+	event := eventSystem.events[0]
+	assert.Equal(t, si.EventRecord_REQUEST, event.Type)
+	assert.Equal(t, si.EventRecord_NONE, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
+	assert.Equal(t, "app-1", event.ReferenceID)
+	assert.Equal(t, "alloc-0", event.ObjectID)
+	assert.Equal(t, "Request 'alloc-0' exceeds the available user quota (requested map[memory:100 vcores:10], available map[memory:1 vcores:1])", event.Message)
+
+	// second attempt - no new event
+	app.tryAllocate(headroom, true, time.Second, &attempts, nilNodeIterator, nilNodeIterator, nilGetNode)
+	assert.Equal(t, 1, len(eventSystem.events))
+
+	// third attempt with enough headroom - new event
+	eventSystem.Reset()
+	conf.Limits[0].MaxResources = nil
+	err = ugm.GetUserManager().UpdateConfig(conf, "root")
+	assert.NilError(t, err)
+	app.tryAllocate(headroom, true, time.Second, &attempts, nilNodeIterator, nilNodeIterator, nilGetNode)
+	assert.Equal(t, 1, len(eventSystem.events))
+	event = eventSystem.events[0]
+	assert.Equal(t, si.EventRecord_REQUEST, event.Type)
+	assert.Equal(t, si.EventRecord_NONE, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
+	assert.Equal(t, "app-1", event.ReferenceID)
+	assert.Equal(t, "alloc-0", event.ObjectID)
+	assert.Equal(t, "Request 'alloc-0' fits in the available user quota", event.Message)
 }
 
 func TestAllocationFailures(t *testing.T) {

--- a/pkg/scheduler/objects/ask_events.go
+++ b/pkg/scheduler/objects/ask_events.go
@@ -35,7 +35,7 @@ type askEvents struct {
 	limiter     *rate.Limiter
 }
 
-func (ae *askEvents) sendRequestDoesNotFitInQueue(headroom *resources.Resource, queuePath string) {
+func (ae *askEvents) sendRequestExceedsQueueHeadroom(headroom *resources.Resource, queuePath string) {
 	if !ae.eventSystem.IsEventTrackingEnabled() {
 		return
 	}

--- a/pkg/scheduler/objects/ask_events.go
+++ b/pkg/scheduler/objects/ask_events.go
@@ -1,0 +1,93 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package objects
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/apache/yunikorn-core/pkg/common/resources"
+	"github.com/apache/yunikorn-core/pkg/events"
+)
+
+// Ask-specific events. These events are of REQUEST type, so they are eventually sent to the respective pods in K8s.
+type askEvents struct {
+	eventSystem events.EventSystem
+	ask         *AllocationAsk
+	limiter     *rate.Limiter
+}
+
+func (ae *askEvents) sendRequestDoesNotFitInQueue(headroom *resources.Resource, queuePath string) {
+	if !ae.eventSystem.IsEventTrackingEnabled() {
+		return
+	}
+	message := fmt.Sprintf("Request '%s' does not fit in queue '%s' (requested %s, available %s)", ae.ask.allocationKey, queuePath, ae.ask.GetAllocatedResource(), headroom)
+	event := events.CreateRequestEventRecord(ae.ask.allocationKey, ae.ask.applicationID, message, ae.ask.GetAllocatedResource())
+	ae.eventSystem.AddEvent(event)
+}
+
+func (ae *askEvents) sendRequestFitsInQueue(queuePath string) {
+	if !ae.eventSystem.IsEventTrackingEnabled() {
+		return
+	}
+	message := fmt.Sprintf("Request '%s' has become schedulable in queue '%s'", ae.ask.allocationKey, queuePath)
+	event := events.CreateRequestEventRecord(ae.ask.allocationKey, ae.ask.applicationID, message, ae.ask.GetAllocatedResource())
+	ae.eventSystem.AddEvent(event)
+}
+
+func (ae *askEvents) sendRequestExceedsUserQuota(headroom *resources.Resource) {
+	if !ae.eventSystem.IsEventTrackingEnabled() {
+		return
+	}
+	message := fmt.Sprintf("Request '%s' exceeds the available user quota (requested %s, available %s)", ae.ask.allocationKey, ae.ask.GetAllocatedResource(), headroom)
+	event := events.CreateRequestEventRecord(ae.ask.allocationKey, ae.ask.applicationID, message, ae.ask.GetAllocatedResource())
+	ae.eventSystem.AddEvent(event)
+}
+
+func (ae *askEvents) sendRequestFitsInUserQuota() {
+	if !ae.eventSystem.IsEventTrackingEnabled() {
+		return
+	}
+	message := fmt.Sprintf("Request '%s' fits in the available user quota", ae.ask.allocationKey)
+	event := events.CreateRequestEventRecord(ae.ask.allocationKey, ae.ask.applicationID, message, ae.ask.GetAllocatedResource())
+	ae.eventSystem.AddEvent(event)
+}
+
+func (ae *askEvents) sendPredicateFailed(predicateMsg string) {
+	if !ae.eventSystem.IsEventTrackingEnabled() || !ae.limiter.Allow() {
+		return
+	}
+	message := fmt.Sprintf("Predicate failed for request '%s' with message: '%s'", ae.ask.allocationKey, predicateMsg)
+	event := events.CreateRequestEventRecord(ae.ask.allocationKey, ae.ask.applicationID, message, ae.ask.GetAllocatedResource())
+	ae.eventSystem.AddEvent(event)
+}
+
+func newAskEvents(ask *AllocationAsk, evt events.EventSystem) *askEvents {
+	return newAskEventsWithRate(ask, evt, 15*time.Second, 1)
+}
+
+func newAskEventsWithRate(ask *AllocationAsk, evt events.EventSystem, interval time.Duration, burst int) *askEvents {
+	return &askEvents{
+		eventSystem: evt,
+		ask:         ask,
+		limiter:     rate.NewLimiter(rate.Every(interval), burst),
+	}
+}

--- a/pkg/scheduler/objects/ask_events_test.go
+++ b/pkg/scheduler/objects/ask_events_test.go
@@ -1,0 +1,161 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package objects
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/apache/yunikorn-core/pkg/common/resources"
+	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
+)
+
+var requestResource = resources.NewResourceFromMap(map[string]resources.Quantity{
+	"memory": 100,
+	"cpu":    100,
+})
+
+func TestRequestDoesNotFitInQueueEvent(t *testing.T) {
+	ask := &AllocationAsk{
+		allocationKey:     "alloc-0",
+		applicationID:     "app-0",
+		allocatedResource: requestResource,
+	}
+	eventSystem := newEventSystemMockDisabled()
+	events := newAskEvents(ask, eventSystem)
+	events.sendRequestDoesNotFitInQueue(getTestResource(), "root.test")
+	assert.Equal(t, 0, len(eventSystem.events))
+
+	eventSystem = newEventSystemMock()
+	events = newAskEvents(ask, eventSystem)
+	events.sendRequestDoesNotFitInQueue(getTestResource(), "root.test")
+	assert.Equal(t, 1, len(eventSystem.events))
+	event := eventSystem.events[0]
+	assert.Equal(t, "alloc-0", event.ObjectID)
+	assert.Equal(t, "app-0", event.ReferenceID)
+	assert.Equal(t, si.EventRecord_REQUEST, event.Type)
+	assert.Equal(t, si.EventRecord_NONE, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
+	assert.Equal(t, "Request 'alloc-0' does not fit in queue 'root.test' (requested map[cpu:100 memory:100], available map[cpu:1])", event.Message)
+}
+
+func TestRequestFitsInQueueEvent(t *testing.T) {
+	ask := &AllocationAsk{
+		allocationKey:     "alloc-0",
+		applicationID:     "app-0",
+		allocatedResource: requestResource,
+	}
+	eventSystem := newEventSystemMockDisabled()
+	events := newAskEvents(ask, eventSystem)
+	events.sendRequestFitsInQueue("root.test")
+	assert.Equal(t, 0, len(eventSystem.events))
+
+	eventSystem = newEventSystemMock()
+	events = newAskEvents(ask, eventSystem)
+	events.sendRequestFitsInQueue("root.test")
+	assert.Equal(t, 1, len(eventSystem.events))
+	event := eventSystem.events[0]
+	assert.Equal(t, "alloc-0", event.ObjectID)
+	assert.Equal(t, "app-0", event.ReferenceID)
+	assert.Equal(t, si.EventRecord_REQUEST, event.Type)
+	assert.Equal(t, si.EventRecord_NONE, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
+	assert.Equal(t, "Request 'alloc-0' has become schedulable in queue 'root.test'", event.Message)
+}
+
+func TestRequestExceedsUserQuotaEvent(t *testing.T) {
+	ask := &AllocationAsk{
+		allocationKey:     "alloc-0",
+		applicationID:     "app-0",
+		allocatedResource: requestResource,
+	}
+	eventSystem := newEventSystemMockDisabled()
+	events := newAskEvents(ask, eventSystem)
+	events.sendRequestExceedsUserQuota(getTestResource())
+	assert.Equal(t, 0, len(eventSystem.events))
+
+	eventSystem = newEventSystemMock()
+	events = newAskEvents(ask, eventSystem)
+	events.sendRequestExceedsUserQuota(getTestResource())
+	assert.Equal(t, 1, len(eventSystem.events))
+	event := eventSystem.events[0]
+	assert.Equal(t, "alloc-0", event.ObjectID)
+	assert.Equal(t, "app-0", event.ReferenceID)
+	assert.Equal(t, si.EventRecord_REQUEST, event.Type)
+	assert.Equal(t, si.EventRecord_NONE, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
+	assert.Equal(t, "Request 'alloc-0' exceeds the available user quota (requested map[cpu:100 memory:100], available map[cpu:1])", event.Message)
+}
+
+func TestRequestFitsInUserQuotaEvent(t *testing.T) {
+	ask := &AllocationAsk{
+		allocationKey:     "alloc-0",
+		applicationID:     "app-0",
+		allocatedResource: requestResource,
+	}
+	eventSystem := newEventSystemMockDisabled()
+	events := newAskEvents(ask, eventSystem)
+	events.sendRequestFitsInUserQuota()
+	assert.Equal(t, 0, len(eventSystem.events))
+
+	eventSystem = newEventSystemMock()
+	events = newAskEvents(ask, eventSystem)
+	events.sendRequestFitsInUserQuota()
+	assert.Equal(t, 1, len(eventSystem.events))
+	event := eventSystem.events[0]
+	assert.Equal(t, "alloc-0", event.ObjectID)
+	assert.Equal(t, "app-0", event.ReferenceID)
+	assert.Equal(t, si.EventRecord_REQUEST, event.Type)
+	assert.Equal(t, si.EventRecord_NONE, event.EventChangeType)
+	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
+	assert.Equal(t, "Request 'alloc-0' fits in the available user quota", event.Message)
+}
+
+func TestPredicateFailedEvents(t *testing.T) {
+	ask := &AllocationAsk{
+		allocationKey:     "alloc-0",
+		applicationID:     "app-0",
+		allocatedResource: requestResource,
+	}
+	eventSystem := newEventSystemMockDisabled()
+	events := newAskEvents(ask, eventSystem)
+	events.sendPredicateFailed("failed")
+	assert.Equal(t, 0, len(eventSystem.events))
+
+	eventSystem = newEventSystemMock()
+	events = newAskEventsWithRate(ask, eventSystem, 50*time.Millisecond, 1)
+	// only the first event is expected to be emitted due to rate limiting
+	for i := 0; i < 200; i++ {
+		events.sendPredicateFailed("failure-" + strconv.FormatUint(uint64(i), 10))
+	}
+	assert.Equal(t, 1, len(eventSystem.events))
+	event := eventSystem.events[0]
+	assert.Equal(t, "Predicate failed for request 'alloc-0' with message: 'failure-0'", event.Message)
+
+	eventSystem.Reset()
+	// wait a bit, a new event is expected
+	time.Sleep(100 * time.Millisecond)
+	events.sendPredicateFailed("failed")
+	assert.Equal(t, 1, len(eventSystem.events))
+	event = eventSystem.events[0]
+	assert.Equal(t, "Predicate failed for request 'alloc-0' with message: 'failed'", event.Message)
+}

--- a/pkg/scheduler/objects/ask_events_test.go
+++ b/pkg/scheduler/objects/ask_events_test.go
@@ -42,12 +42,12 @@ func TestRequestDoesNotFitInQueueEvent(t *testing.T) {
 	}
 	eventSystem := newEventSystemMockDisabled()
 	events := newAskEvents(ask, eventSystem)
-	events.sendRequestDoesNotFitInQueue(getTestResource(), "root.test")
+	events.sendRequestExceedsQueueHeadroom(getTestResource(), "root.test")
 	assert.Equal(t, 0, len(eventSystem.events))
 
 	eventSystem = newEventSystemMock()
 	events = newAskEvents(ask, eventSystem)
-	events.sendRequestDoesNotFitInQueue(getTestResource(), "root.test")
+	events.sendRequestExceedsQueueHeadroom(getTestResource(), "root.test")
 	assert.Equal(t, 1, len(eventSystem.events))
 	event := eventSystem.events[0]
 	assert.Equal(t, "alloc-0", event.ObjectID)

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -406,7 +406,9 @@ func (sn *Node) preConditions(ask *AllocationAsk, allocate bool) bool {
 				zap.Bool("allocateFlag", allocate),
 				zap.Error(err))
 			// running predicates failed
-			ask.LogAllocationFailure(err.Error(), allocate)
+			msg := err.Error()
+			ask.LogAllocationFailure(msg, allocate)
+			ask.SendPredicateFailedEvent(msg)
 			return false
 		}
 	}


### PR DESCRIPTION
### What is this PR for?
Send proper events whenever a queue/user quota check fails. Currently, we send only one per application per second. So, in case of multiple pods, only the first one will be updated with a new event. The message is also incorrect, because it's a request that exceeds the quota, not the application.

New events:
- Queue headroom check failed (once per pod/ask)
- User quota check failed (once per pod/ask)
- Queue headroom check passed if previously failed (once per pod/ask) 
- User quota check passed if previously failed (once per pod/ask) 
- Predicate failed (once in every 15 seconds)

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2370

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
