### PR TITLE
[YUNIKORN-2406] Ensure shim is notified of existing allocations being added

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ module github.com/apache/yunikorn-core
 go 1.21
 
 require (
-	github.com/apache/yunikorn-scheduler-interface v0.0.0-20231211235204-ec7bfad7d00e
+	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240213122907-834ff5c1f36c
 	github.com/google/btree v1.1.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bEn0jTI6LJU0mpw=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnloDp7xxV0YvstAE7nKTaM=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20231211235204-ec7bfad7d00e h1:WiDns+JSNrp1jUfTkwtTwVyfxAhe3vPMtxJxs2CRseE=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20231211235204-ec7bfad7d00e/go.mod h1:zDWV5y9Zh9DM1C65RCVXT1nhNNO8kykVW7bzPFamNYw=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240213122907-834ff5c1f36c h1:u4ckUfYqKfrRGUyvGcyS5lMu1eVOsiMQZafjCcE/tNw=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240213122907-834ff5c1f36c/go.mod h1:Ga7qJusiW9E/dRokVGB50sUycR9Oc/yooixJWS0K7ZY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -788,7 +788,9 @@ func (cc *ClusterContext) processAllocations(request *si.AllocationRequest) {
 				zap.String("applicationID", siAlloc.ApplicationID),
 				zap.String("allocationKey", siAlloc.AllocationKey),
 				zap.Error(err))
+			continue
 		}
+		cc.notifyRMNewAllocation(request.RmID, alloc)
 	}
 
 	// Reject allocs returned to RM proxy for the apps and partitions not found


### PR DESCRIPTION
### What is this PR for?

When existing allocations are registered from the shim to the core, they are added to the partition, but the shim is never notified that the allocations were successfully registered. This manifests in the core as missing history for container allocations, and in the shim by tasks not transitioning to a bound state.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2406

### How should this be tested?
E2e testing only; this code is deeply tied to the shim implementation.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
