### PR TITLE
[YUNIKORN-2326] get apps by Internal state

### DIFF
--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1070,7 +1070,7 @@ func (pc *PartitionContext) GetRejectedApplications() []*objects.Application {
 	return appList
 }
 
-func (pc *PartitionContext) getAppsByInternalState(appMap map[string]*objects.Application, state string) []string {
+func (pc *PartitionContext) getAppsState(appMap map[string]*objects.Application, state string) []string {
 	pc.RLock()
 	defer pc.RUnlock()
 	var apps []string
@@ -1085,17 +1085,17 @@ func (pc *PartitionContext) getAppsByInternalState(appMap map[string]*objects.Ap
 // getAppsByState returns a slice of applicationIDs for the current applications filtered by state
 // Completed and Rejected applications are tracked in a separate map and will never be included.
 func (pc *PartitionContext) getAppsByState(state string) []string {
-	return pc.getAppsByInternalState(pc.applications, state)
+	return pc.getAppsState(pc.applications, state)
 }
 
 // getRejectedAppsByState returns a slice of applicationIDs for the rejected applications filtered by state.
 func (pc *PartitionContext) getRejectedAppsByState(state string) []string {
-	return pc.getAppsByInternalState(pc.rejectedApplications, state)
+	return pc.getAppsState(pc.rejectedApplications, state)
 }
 
 // getCompletedAppsByState returns a slice of applicationIDs for the completed applicationIDs filtered by state.
 func (pc *PartitionContext) getCompletedAppsByState(state string) []string {
-	return pc.getAppsByInternalState(pc.completedApplications, state)
+	return pc.getAppsState(pc.completedApplications, state)
 }
 
 // cleanupExpiredApps cleans up applications in the Expired state from the three tracking maps

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1073,7 +1073,7 @@ func (pc *PartitionContext) GetRejectedApplications() []*objects.Application {
 func (pc *PartitionContext) getAppsState(appMap map[string]*objects.Application, state string) []string {
 	pc.RLock()
 	defer pc.RUnlock()
-	var apps []string
+	apps := []string{}
 	for appID, app := range appMap {
 		if app.CurrentState() == state {
 			apps = append(apps, appID)

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1070,44 +1070,32 @@ func (pc *PartitionContext) GetRejectedApplications() []*objects.Application {
 	return appList
 }
 
-// getAppsByState returns a slice of applicationIDs for the current applications filtered by state
-// Completed and Rejected applications are tracked in a separate map and will never be included.
-func (pc *PartitionContext) getAppsByState(state string) []string {
+func (pc *PartitionContext) getAppsByInternalState(appMap map[string]*objects.Application, state string) []string {
 	pc.RLock()
 	defer pc.RUnlock()
 	var apps []string
-	for appID, app := range pc.applications {
+	for appID, app := range appMap {
 		if app.CurrentState() == state {
 			apps = append(apps, appID)
 		}
 	}
 	return apps
+}
+
+// getAppsByState returns a slice of applicationIDs for the current applications filtered by state
+// Completed and Rejected applications are tracked in a separate map and will never be included.
+func (pc *PartitionContext) getAppsByState(state string) []string {
+	return pc.getAppsByInternalState(pc.applications, state)
 }
 
 // getRejectedAppsByState returns a slice of applicationIDs for the rejected applications filtered by state.
 func (pc *PartitionContext) getRejectedAppsByState(state string) []string {
-	pc.RLock()
-	defer pc.RUnlock()
-	var apps []string
-	for appID, app := range pc.rejectedApplications {
-		if app.CurrentState() == state {
-			apps = append(apps, appID)
-		}
-	}
-	return apps
+	return pc.getAppsByInternalState(pc.rejectedApplications, state)
 }
 
 // getCompletedAppsByState returns a slice of applicationIDs for the completed applicationIDs filtered by state.
 func (pc *PartitionContext) getCompletedAppsByState(state string) []string {
-	pc.RLock()
-	defer pc.RUnlock()
-	var apps []string
-	for appID, app := range pc.completedApplications {
-		if app.CurrentState() == state {
-			apps = append(apps, appID)
-		}
-	}
-	return apps
+	return pc.getAppsByInternalState(pc.completedApplications, state)
 }
 
 // cleanupExpiredApps cleans up applications in the Expired state from the three tracking maps


### PR DESCRIPTION
### What is this PR for?
`getAppsByState`, `getRejectedAppsByState`, and `getCompletedAppsByState` do the similar job that get apps according to specific state. Hence, it would be better to have a helper method and then these three methods can reuse the code.


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [x] - Refactoring


### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2326

### How should this be tested?
The same older tests should work for this.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
