### PR TITLE
[YUNIKORN-2427] Use r-lock instead of rw-lock in user_tracker.go#getGroupForApp

### DIFF
--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -111,8 +111,8 @@ func (gt *GroupTracker) IsUnlinkRequired(hierarchy []string) bool {
 }
 
 func (gt *GroupTracker) UnlinkQT(hierarchy []string) bool {
-	gt.RLock()
-	defer gt.RUnlock()
+	gt.Lock()
+	defer gt.Unlock()
 	return gt.queueTracker.UnlinkQT(hierarchy)
 }
 

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -101,8 +101,8 @@ func (ut *UserTracker) setGroupForApp(applicationID string, groupTrack *GroupTra
 }
 
 func (ut *UserTracker) getGroupForApp(applicationID string) string {
-	ut.Lock()
-	defer ut.Unlock()
+	ut.RLock()
+	defer ut.RUnlock()
 	if ut.appGroupTrackers[applicationID] != nil {
 		return ut.appGroupTrackers[applicationID].groupName
 	}

--- a/pkg/scheduler/ugm/user_tracker.go
+++ b/pkg/scheduler/ugm/user_tracker.go
@@ -156,8 +156,8 @@ func (ut *UserTracker) IsUnlinkRequired(hierarchy []string) bool {
 }
 
 func (ut *UserTracker) UnlinkQT(hierarchy []string) bool {
-	ut.RLock()
-	defer ut.RUnlock()
+	ut.Lock()
+	defer ut.Unlock()
 	return ut.queueTracker.UnlinkQT(hierarchy)
 }
 


### PR DESCRIPTION
### What is this PR for?
Use r-lock instead of rw-lock in user_tracker.go#getGroupForApp.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2427

### How should this be tested?
Run e2e test, it passed in my forked repo
- https://github.com/chenyulin0719/yunikorn-k8shim/pull/36

### Screenshots (if appropriate)
NA

### Questions:
NA
