### PR TITLE
[YUNIKORN-2416] [ADDENDUM] Cleanup replace directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,3 +52,11 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 )
+
+replace (
+	golang.org/x/crypto => golang.org/x/crypto v0.19.0
+	golang.org/x/net => golang.org/x/net v0.21.0
+	golang.org/x/sys => golang.org/x/sys v0.17.0
+	golang.org/x/text => golang.org/x/text v0.14.0
+	golang.org/x/tools => golang.org/x/tools v0.17.0
+)

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ module github.com/apache/yunikorn-core
 go 1.21
 
 require (
-	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240222100805-e404c64334d2
+	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240222194711-770b7b60b5c6
 	github.com/google/btree v1.1.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240222100805-e404c64334d2 h1:4HWzXCGqBIWPBrUHhOGHBsvSf3ruY/mgWn5M9gR9zoA=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240222100805-e404c64334d2/go.mod h1:S1aH1vTdYFySHoB/pO1KwH0nUkbE/7jCmlauBK7vMp0=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240222194711-770b7b60b5c6 h1:Uwvq+660rtbpeyoU22jmKPdOpMyl8C/AA2gmC0PgFEQ=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240222194711-770b7b60b5c6/go.mod h1:O1eabhTkamZupM07mYbzoZ4TRS1pOnJKohOFnHpHcFs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=


### PR DESCRIPTION
### What is this PR for?
Base on the discussion under https://github.com/apache/yunikorn-k8shim/pull/794
and reference to the original Jira https://issues.apache.org/jira/browse/YUNIKORN-2416 
(If this PR got merged, I will modify the Jira content)


Move deps back to replace entry
- golang.org/x/crypto to v0.18.0 => v0.19.0 (Indrect require have higer verion)
- golang.org/x/net v0.20.0 => v0.21.0
- golang.org/x/sys v0.16.0 => v0.17.0(Indrect require have higer verion)
- golang.org/x/text v0.14.0
- golang.org/x/tools v0.17.0

Won't remove back
- golang.org/x/lint (We don't use it actually)

Once this change got approval, I should also add a ADDENDUM commit in scheduler-interface(Copy past the replace dependencies)

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2416

### How should this be tested?
go test

### Screenshots (if appropriate)
NA

### Questions:
NA
