### PR TITLE
[YUNIKORN-2453] Add `EventRecord_APP_NEW` to event of created/submitted application

### DIFF
--- a/pkg/scheduler/objects/application_events.go
+++ b/pkg/scheduler/objects/application_events.go
@@ -91,7 +91,7 @@ func (evt *applicationEvents) sendNewApplicationEvent() {
 	if !evt.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-	event := events.CreateAppEventRecord(evt.app.ApplicationID, common.Empty, common.Empty, si.EventRecord_ADD, si.EventRecord_DETAILS_NONE, evt.app.allocatedResource)
+	event := events.CreateAppEventRecord(evt.app.ApplicationID, common.Empty, common.Empty, si.EventRecord_ADD, si.EventRecord_APP_NEW, evt.app.allocatedResource)
 	evt.eventSystem.AddEvent(event)
 }
 

--- a/pkg/scheduler/objects/application_events_test.go
+++ b/pkg/scheduler/objects/application_events_test.go
@@ -31,7 +31,7 @@ func isNewApplicationEvent(t *testing.T, app *Application, record *si.EventRecor
 	assert.Equal(t, si.EventRecord_APP, record.Type, "incorrect event type, expect app")
 	assert.Equal(t, app.ApplicationID, record.ObjectID, "incorrect object ID, expected application ID")
 	assert.Equal(t, si.EventRecord_ADD, record.EventChangeType, "incorrect change type, expected add")
-	assert.Equal(t, si.EventRecord_DETAILS_NONE, record.EventChangeDetail, "incorrect change detail, expected none")
+	assert.Equal(t, si.EventRecord_APP_NEW, record.EventChangeDetail, "incorrect change detail, expected none")
 }
 
 func isRemoveApplicationEvent(t *testing.T, app *Application, record *si.EventRecord) {
@@ -277,7 +277,7 @@ func TestSendNewApplicationEvent(t *testing.T) {
 	event := mockEvents.Events[0]
 	assert.Equal(t, si.EventRecord_APP, event.Type)
 	assert.Equal(t, si.EventRecord_ADD, event.EventChangeType)
-	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
+	assert.Equal(t, si.EventRecord_APP_NEW, event.EventChangeDetail)
 	assert.Equal(t, "app-0", event.ObjectID)
 	assert.Equal(t, "", event.ReferenceID)
 	assert.Equal(t, "", event.Message)

--- a/pkg/scheduler/tests/application_tracking_test.go
+++ b/pkg/scheduler/tests/application_tracking_test.go
@@ -271,7 +271,7 @@ func verifyAppAddedEvents(t *testing.T, events []*si.EventRecord) {
 	assert.Equal(t, "", events[0].ReferenceID)
 	assert.Equal(t, si.EventRecord_APP, events[0].Type)
 	assert.Equal(t, si.EventRecord_ADD, events[0].EventChangeType)
-	assert.Equal(t, si.EventRecord_DETAILS_NONE, events[0].EventChangeDetail)
+	assert.Equal(t, si.EventRecord_APP_NEW, events[0].EventChangeDetail)
 
 	assert.Equal(t, "root.singleleaf", events[1].ObjectID)
 	assert.Equal(t, "", events[1].Message)


### PR DESCRIPTION
### What is this PR for?
the event detail of new application is "EventRecord_DETAILS_NONE" (see https://github.com/apache/yunikorn-core/blob/master/pkg/scheduler/objects/application_events.go#L94), and it seems the "EventRecord_APP_NEW" is more acceptable (see https://github.com/apache/yunikorn-scheduler-interface/blob/master/lib/go/si/si.pb.go#L350)

### What type of PR is it?
* [x] - Improvement

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2453

### How should this be tested?
covered by existed unit tests

### Screenshots (if appropriate)
N/A

### Questions:
N/A