### PR TITLE
[YUNIKORN-2483] Core: Remove stateaware sort policy

### DIFF
--- a/pkg/common/configs/config_test.go
+++ b/pkg/common/configs/config_test.go
@@ -45,7 +45,7 @@ partitions:
       - name: root
         submitacl: '*'
         properties:
-          application.sort.policy: stateaware
+          application.sort.policy: fifo
           sample: value2
 `
 
@@ -1714,7 +1714,7 @@ partitions:
       - name: root
         submitacl: '*'
         properties:
-            application.sort.policy: stateaware
+            application.sort.policy: fifo
 `
 	testCases := []struct {
 		name          string

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -39,7 +39,6 @@ import (
 	"github.com/apache/yunikorn-core/pkg/metrics"
 	"github.com/apache/yunikorn-core/pkg/rmproxy/rmevent"
 	"github.com/apache/yunikorn-core/pkg/scheduler/ugm"
-	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
@@ -185,11 +184,7 @@ func NewApplication(siApp *si.AddApplicationRequest, ugi security.UserGroup, eve
 	}
 	app.gangSchedulingStyle = gangSchedStyle
 	app.execTimeout = placeholderTimeout
-	if app.GetTag(siCommon.AppTagStateAwareDisable) != "" {
-		app.startTimeout = 0 // transition immediately to Running
-	} else {
-		app.startTimeout = startingTimeout
-	}
+	app.startTimeout = startingTimeout
 	app.user = ugi
 	app.rmEventHandler = eventHandler
 	app.rmID = rmID

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -1013,26 +1013,6 @@ func TestStateTimeOut(t *testing.T) {
 	if !app.stateMachine.Is(Running.String()) || app.stateTimer != nil {
 		t.Fatalf("State is not running or timer was not cleared, state: %s, timer %v", app.stateMachine.Current(), app.stateTimer)
 	}
-
-	startingTimeout = time.Minute * 5
-	app = newApplicationWithTags(appID2, "default", "root.a", map[string]string{siCommon.AppTagStateAwareDisable: "true"})
-	err = app.handleApplicationEventWithLocking(RunApplication)
-	assert.NilError(t, err, "no error expected new to accepted (timeout test)")
-	err = app.handleApplicationEventWithLocking(RunApplication)
-	assert.NilError(t, err, "no error expected accepted to starting (timeout test)")
-	// give it some time to run and progress
-	time.Sleep(time.Millisecond * 100)
-	if app.IsStarting() {
-		t.Fatal("Starting state should have timed out")
-	}
-	if app.stateTimer != nil {
-		t.Fatalf("Startup timer has not be cleared on time out as expected, %v", app.stateTimer)
-	}
-	log := app.GetStateLog()
-	assert.Equal(t, len(log), 3, "wrong number of app events")
-	assert.Equal(t, log[0].ApplicationState, Accepted.String())
-	assert.Equal(t, log[1].ApplicationState, Starting.String())
-	assert.Equal(t, log[2].ApplicationState, Running.String())
 }
 
 func TestCompleted(t *testing.T) {

--- a/pkg/scheduler/objects/sorters_test.go
+++ b/pkg/scheduler/objects/sorters_test.go
@@ -174,11 +174,6 @@ func TestSortAppsNoPending(t *testing.T) {
 	list = sortApplications(input, policies.FifoSortPolicy, true, nil)
 	assertAppListLength(t, list, []string{}, "fifo no pending - priority")
 
-	list = sortApplications(input, policies.StateAwarePolicy, false, nil)
-	assertAppListLength(t, list, []string{}, "state no pending")
-	list = sortApplications(input, policies.StateAwarePolicy, true, nil)
-	assertAppListLength(t, list, []string{}, "state no pending - priority")
-
 	// set one app with pending
 	appID := "app-1"
 	input[appID].pending = res
@@ -191,11 +186,6 @@ func TestSortAppsNoPending(t *testing.T) {
 	assertAppListLength(t, list, []string{appID}, "fifo one pending")
 	list = sortApplications(input, policies.FifoSortPolicy, true, nil)
 	assertAppListLength(t, list, []string{appID}, "fifo one pending - priority")
-
-	list = sortApplications(input, policies.StateAwarePolicy, false, nil)
-	assertAppListLength(t, list, []string{appID}, "state one pending")
-	list = sortApplications(input, policies.StateAwarePolicy, true, nil)
-	assertAppListLength(t, list, []string{appID}, "state one pending - priority")
 }
 
 func TestSortAppsFifo(t *testing.T) {
@@ -330,61 +320,6 @@ func TestSortAppsPriorityFair(t *testing.T) {
 	// apps should come back in order: 1, 3, 0, 2
 	list = sortApplications(input, policies.FairSortPolicy, true, resources.Multiply(res, 5))
 	assertAppList(t, list, []int{2, 0, 3, 1}, "app-1 & app-3 allocated")
-}
-
-func TestSortAppsStateAware(t *testing.T) {
-	// stable sort is used so equal values stay where they were
-	res := resources.NewResourceFromMap(map[string]resources.Quantity{
-		"vcore": resources.Quantity(100)})
-	// setup all apps with pending resources, all accepted state
-	input := make(map[string]*Application, 4)
-	for i := 0; i < 4; i++ {
-		num := strconv.Itoa(i)
-		appID := "app-" + num
-		app := newApplication(appID, "partition", "queue")
-		app.pending = res
-		input[appID] = app
-		err := app.HandleApplicationEvent(RunApplication)
-		assert.NilError(t, err, "state change failed for app %v", appID)
-		// make sure the time stamps differ at least a bit (tracking in nano seconds)
-		time.Sleep(time.Nanosecond * 5)
-	}
-	// only first app should be returned (all in accepted)
-	list := sortApplications(input, policies.StateAwarePolicy, false, nil)
-	appID0 := "app-0"
-	assertAppListLength(t, list, []string{appID0}, "state all accepted")
-
-	// set first app pending to zero, should get 2nd app back
-	input[appID0].pending = resources.NewResource()
-	list = sortApplications(input, policies.StateAwarePolicy, false, nil)
-	appID1 := "app-1"
-	assertAppListLength(t, list, []string{appID1}, "state no pending")
-
-	// move the first app to starting no pending resource should get nothing
-	err := input[appID0].HandleApplicationEvent(RunApplication)
-	assert.NilError(t, err, "state change failed for app-0")
-	list = sortApplications(input, policies.StateAwarePolicy, false, nil)
-	assertAppListLength(t, list, []string{}, "state starting no pending")
-
-	// move first app to running (no pending resource) and 4th app to starting should get starting app
-	err = input[appID0].HandleApplicationEvent(RunApplication)
-	assert.NilError(t, err, "state change failed for app-0")
-	appID3 := "app-3"
-	err = input[appID3].HandleApplicationEvent(RunApplication)
-	assert.NilError(t, err, "state change failed for app-3")
-	list = sortApplications(input, policies.StateAwarePolicy, false, nil)
-	assertAppListLength(t, list, []string{appID3}, "state starting")
-
-	// set pending for first app, should get back 1st and 4th in that order
-	input[appID0].pending = res
-	list = sortApplications(input, policies.StateAwarePolicy, false, nil)
-	assertAppListLength(t, list, []string{appID0, appID3}, "state first pending")
-
-	// move 4th to running should get back: 1st, 2nd and 4th in that order
-	err = input[appID3].HandleApplicationEvent(RunApplication)
-	assert.NilError(t, err, "state change failed for app-3")
-	list = sortApplications(input, policies.StateAwarePolicy, false, nil)
-	assertAppListLength(t, list, []string{appID0, appID1, appID3}, "state not app-2")
 }
 
 func queueNames(list []*Queue) string {

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -345,7 +345,7 @@ func (pc *PartitionContext) AddApplication(app *objects.Application) error {
 	queue.AddApplication(app)
 	// check only for gang request
 	// - make sure the taskgroup request fits in the maximum set for the queue hierarchy
-	// - task groups should only be used in FIFO or StateAware queues
+	// - task groups should only be used in FIFO queues
 	// if the check fails remove the app from the queue again
 	if placeHolder := app.GetPlaceholderAsk(); !resources.IsZero(placeHolder) {
 		// check the queue sorting

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1064,32 +1064,6 @@ func TestAddAppTaskGroup(t *testing.T) {
 	if err == nil || partition.getApplication(appID2) != nil {
 		t.Errorf("add application should have failed due to queue sort policy but did not")
 	}
-
-	// queue with stateaware as sort policy, with a max set smaller than placeholder ask: app add should fail
-	err = queue.ApplyConf(configs.QueueConfig{
-		Name:       "default",
-		Parent:     false,
-		Queues:     nil,
-		Properties: map[string]string{configs.ApplicationSortPolicy: "stateaware"},
-		Resources:  configs.Resources{Max: map[string]string{"vcore": "5"}},
-	})
-	assert.NilError(t, err, "updating queue should not have failed (stateaware & max)")
-	queue.UpdateQueueProperties()
-	err = partition.AddApplication(app)
-	if err == nil || partition.getApplication(appID2) != nil {
-		t.Errorf("add application should have failed due to max queue resource but did not")
-	}
-
-	// queue with stateaware as sort policy, with a max set larger than placeholder ask: app add works
-	err = queue.ApplyConf(configs.QueueConfig{
-		Name:      "default",
-		Parent:    false,
-		Queues:    nil,
-		Resources: configs.Resources{Max: map[string]string{"vcore": "20"}},
-	})
-	assert.NilError(t, err, "updating queue should not have failed (max resource)")
-	err = partition.AddApplication(app)
-	assert.NilError(t, err, "add application to partition should not have failed")
 }
 
 func TestRemoveApp(t *testing.T) {

--- a/pkg/scheduler/policies/sorting_policy.go
+++ b/pkg/scheduler/policies/sorting_policy.go
@@ -20,16 +20,18 @@ package policies
 
 import (
 	"fmt"
+
+	"github.com/apache/yunikorn-core/pkg/log"
 )
 
 // Sort type for queues & apps.
 type SortPolicy int
 
 const (
-	FifoSortPolicy   SortPolicy = iota // first in first out, submit time
-	FairSortPolicy                     // fair based on usage
-	StateAwarePolicy                   // only 1 app in starting state
-	Undefined                          // not initialised or parsing failed
+	FifoSortPolicy             SortPolicy = iota // first in first out, submit time
+	FairSortPolicy                               // fair based on usage
+	deprecatedStateAwarePolicy                   // deprecated: now alias for FIFO
+	Undefined                                    // not initialised or parsing failed
 )
 
 func (s SortPolicy) String() string {
@@ -43,8 +45,9 @@ func SortPolicyFromString(str string) (SortPolicy, error) {
 		return FifoSortPolicy, nil
 	case FairSortPolicy.String():
 		return FairSortPolicy, nil
-	case StateAwarePolicy.String():
-		return StateAwarePolicy, nil
+	case deprecatedStateAwarePolicy.String():
+		log.Log(log.Deprecation).Warn("Sort policy 'stateaware' is deprecated; using 'fifo' instead")
+		return FifoSortPolicy, nil
 	default:
 		return Undefined, fmt.Errorf("undefined policy: %s", str)
 	}

--- a/pkg/scheduler/policies/sorting_policy_test.go
+++ b/pkg/scheduler/policies/sorting_policy_test.go
@@ -32,7 +32,7 @@ func TestAppFromString(t *testing.T) {
 		{"EmptyString", "", FifoSortPolicy, false},
 		{"FifoString", "fifo", FifoSortPolicy, false},
 		{"FairString", "fair", FairSortPolicy, false},
-		{"StatusString", "stateaware", StateAwarePolicy, false},
+		{"StatusString", "stateaware", FifoSortPolicy, false},
 		{"UnknownString", "unknown", Undefined, true},
 	}
 	for _, tt := range tests {
@@ -56,7 +56,7 @@ func TestAppToString(t *testing.T) {
 	}{
 		{"FifoString", FifoSortPolicy, "fifo"},
 		{"FairString", FairSortPolicy, "fair"},
-		{"StatusString", StateAwarePolicy, "stateaware"},
+		{"StatusString", deprecatedStateAwarePolicy, "stateaware"},
 		{"DefaultString", Undefined, "undefined"},
 		{"NoneString", someSP, "fifo"},
 	}

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -142,11 +142,11 @@ partitions:
       - 
         name: root
         properties:
-          application.sort.policy: stateaware
+          application.sort.policy: fifo
         childtemplate:
           maxapplications: 10
           properties:
-            application.sort.policy: stateaware
+            application.sort.policy: fifo
           resources:
             guaranteed:
               memory: 400000
@@ -1058,7 +1058,7 @@ func TestGetPartitionQueuesHandler(t *testing.T) {
 		MaxResource:        tMaxResource.DAOMap(),
 		GuaranteedResource: tGuaranteedResource.DAOMap(),
 		Properties: map[string]string{
-			configs.ApplicationSortPolicy: policies.StateAwarePolicy.String(),
+			configs.ApplicationSortPolicy: policies.FifoSortPolicy.String(),
 		},
 	}
 
@@ -1095,7 +1095,7 @@ func TestGetPartitionQueuesHandler(t *testing.T) {
 	assert.Equal(t, partitionQueuesDao.CurrentPriority, configs.MinPriority)
 	assert.Assert(t, partitionQueuesDao.AllocatingAcceptedApps == nil)
 	assert.Equal(t, len(partitionQueuesDao.Properties), 1)
-	assert.Equal(t, partitionQueuesDao.Properties[configs.ApplicationSortPolicy], policies.StateAwarePolicy.String())
+	assert.Equal(t, partitionQueuesDao.Properties[configs.ApplicationSortPolicy], policies.FifoSortPolicy.String())
 	assert.DeepEqual(t, partitionQueuesDao.TemplateInfo, &templateInfo)
 
 	// assert child root.a fields
@@ -1119,7 +1119,7 @@ func TestGetPartitionQueuesHandler(t *testing.T) {
 	assert.Equal(t, child.CurrentPriority, configs.MinPriority)
 	assert.Assert(t, child.AllocatingAcceptedApps == nil)
 	assert.Equal(t, len(child.Properties), 1)
-	assert.Equal(t, child.Properties[configs.ApplicationSortPolicy], policies.StateAwarePolicy.String())
+	assert.Equal(t, child.Properties[configs.ApplicationSortPolicy], policies.FifoSortPolicy.String())
 	assert.DeepEqual(t, child.TemplateInfo, &templateInfo)
 
 	// assert child root.a.a1 fields


### PR DESCRIPTION
### What is this PR for?
Remove the deprecated stateaware policy from the core. Logs a warning is stateaware is requested, and falls back to
FIFO instead as that is the closest logical policy.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2483

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
