### PR TITLE
[YUNIKORN-2472] REST API returns subtree by default

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -624,14 +624,14 @@ func (sq *Queue) CheckAdminAccess(user security.UserGroup) bool {
 }
 
 // GetPartitionQueueDAOInfo returns the queue hierarchy as an object for a REST call.
-// Exclude is true, which means that returns the specified queue object, but does not return the children of the specified queue.
-func (sq *Queue) GetPartitionQueueDAOInfo(exclude bool) dao.PartitionQueueDAOInfo {
+// Include is false, which means that returns the specified queue object, but does not return the children of the specified queue.
+func (sq *Queue) GetPartitionQueueDAOInfo(include bool) dao.PartitionQueueDAOInfo {
 	queueInfo := dao.PartitionQueueDAOInfo{}
 	children := sq.GetCopyOfChildren()
-	if !exclude {
+	if include {
 		queueInfo.Children = make([]dao.PartitionQueueDAOInfo, 0, len(children))
 		for _, child := range children {
-			queueInfo.Children = append(queueInfo.Children, child.GetPartitionQueueDAOInfo(false))
+			queueInfo.Children = append(queueInfo.Children, child.GetPartitionQueueDAOInfo(true))
 		}
 	}
 	// we have held the read lock so following method should not take lock again.
@@ -639,7 +639,7 @@ func (sq *Queue) GetPartitionQueueDAOInfo(exclude bool) dao.PartitionQueueDAOInf
 	defer sq.RUnlock()
 
 	for _, child := range children {
-		queueInfo.ChildrenNames = append(queueInfo.ChildrenNames, child.QueuePath)
+		queueInfo.ChildNames = append(queueInfo.ChildNames, child.QueuePath)
 	}
 	queueInfo.QueueName = sq.QueuePath
 	queueInfo.Status = sq.stateMachine.Current()

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1649,6 +1649,20 @@ func TestGetPartitionQueueDAOInfo(t *testing.T) {
 	assert.Equal(t, len(root.allocatingAcceptedApps), 2, "allocatingAcceptedApps size")
 	assert.Equal(t, len(root.GetPartitionQueueDAOInfo(true).AllocatingAcceptedApps), 1, "AllocatingAcceptedApps size")
 	assert.Equal(t, root.GetPartitionQueueDAOInfo(true).AllocatingAcceptedApps[0], appID1)
+
+	// Test specific queue
+	_, err = createManagedQueue(root, "leaf-queue", false, nil)
+	assert.NilError(t, err, "failed to create managed queue")
+	assert.Equal(t, root.GetPartitionQueueDAOInfo(false).QueueName, "root")
+	assert.Equal(t, len(root.GetPartitionQueueDAOInfo(false).Children), 0)
+	assert.Equal(t, len(root.GetPartitionQueueDAOInfo(false).ChildNames), 1)
+	assert.Equal(t, root.GetPartitionQueueDAOInfo(false).ChildNames[0], "root.leaf-queue")
+	// Test hierarchy queue
+	assert.Equal(t, root.GetPartitionQueueDAOInfo(true).QueueName, "root")
+	assert.Equal(t, len(root.GetPartitionQueueDAOInfo(true).Children), 1)
+	assert.Equal(t, len(root.GetPartitionQueueDAOInfo(true).ChildNames), 1)
+	assert.Equal(t, root.GetPartitionQueueDAOInfo(true).Children[0].QueueName, "root.leaf-queue")
+	assert.Equal(t, root.GetPartitionQueueDAOInfo(true).ChildNames[0], "root.leaf-queue")
 }
 
 func getAllocatingAcceptedApps() map[string]bool {

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1620,7 +1620,7 @@ func TestGetPartitionQueueDAOInfo(t *testing.T) {
 
 	// test properties
 	root.properties = getProperties()
-	assert.DeepEqual(t, root.properties, root.GetPartitionQueueDAOInfo(false).Properties)
+	assert.DeepEqual(t, root.properties, root.GetPartitionQueueDAOInfo(true).Properties)
 
 	// test template
 	root.template, err = template.FromConf(&configs.ChildTemplate{
@@ -1632,23 +1632,23 @@ func TestGetPartitionQueueDAOInfo(t *testing.T) {
 		},
 	})
 	assert.NilError(t, err)
-	assert.Equal(t, root.template.GetMaxApplications(), root.GetPartitionQueueDAOInfo(false).TemplateInfo.MaxApplications)
-	assert.DeepEqual(t, root.template.GetProperties(), root.GetPartitionQueueDAOInfo(false).TemplateInfo.Properties)
-	assert.DeepEqual(t, root.template.GetMaxResource().DAOMap(), root.GetPartitionQueueDAOInfo(false).TemplateInfo.MaxResource)
-	assert.DeepEqual(t, root.template.GetGuaranteedResource().DAOMap(), root.GetPartitionQueueDAOInfo(false).TemplateInfo.GuaranteedResource)
+	assert.Equal(t, root.template.GetMaxApplications(), root.GetPartitionQueueDAOInfo(true).TemplateInfo.MaxApplications)
+	assert.DeepEqual(t, root.template.GetProperties(), root.GetPartitionQueueDAOInfo(true).TemplateInfo.Properties)
+	assert.DeepEqual(t, root.template.GetMaxResource().DAOMap(), root.GetPartitionQueueDAOInfo(true).TemplateInfo.MaxResource)
+	assert.DeepEqual(t, root.template.GetGuaranteedResource().DAOMap(), root.GetPartitionQueueDAOInfo(true).TemplateInfo.GuaranteedResource)
 
 	// test resources
 	root.maxResource = getResource(t)
 	root.guaranteedResource = getResource(t)
-	assert.DeepEqual(t, root.GetMaxResource().DAOMap(), root.GetPartitionQueueDAOInfo(false).MaxResource)
-	assert.DeepEqual(t, root.GetGuaranteedResource().DAOMap(), root.GetPartitionQueueDAOInfo(false).GuaranteedResource)
-	assert.DeepEqual(t, root.getHeadRoom().DAOMap(), root.GetPartitionQueueDAOInfo(false).HeadRoom)
+	assert.DeepEqual(t, root.GetMaxResource().DAOMap(), root.GetPartitionQueueDAOInfo(true).MaxResource)
+	assert.DeepEqual(t, root.GetGuaranteedResource().DAOMap(), root.GetPartitionQueueDAOInfo(true).GuaranteedResource)
+	assert.DeepEqual(t, root.getHeadRoom().DAOMap(), root.GetPartitionQueueDAOInfo(true).HeadRoom)
 
 	// test allocatingAcceptedApps
 	root.allocatingAcceptedApps = getAllocatingAcceptedApps()
 	assert.Equal(t, len(root.allocatingAcceptedApps), 2, "allocatingAcceptedApps size")
-	assert.Equal(t, len(root.GetPartitionQueueDAOInfo(false).AllocatingAcceptedApps), 1, "AllocatingAcceptedApps size")
-	assert.Equal(t, root.GetPartitionQueueDAOInfo(false).AllocatingAcceptedApps[0], appID1)
+	assert.Equal(t, len(root.GetPartitionQueueDAOInfo(true).AllocatingAcceptedApps), 1, "AllocatingAcceptedApps size")
+	assert.Equal(t, root.GetPartitionQueueDAOInfo(true).AllocatingAcceptedApps[0], appID1)
 }
 
 func getAllocatingAcceptedApps() map[string]bool {

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -477,7 +477,7 @@ func (pc *PartitionContext) getQueueInternal(name string) *objects.Queue {
 
 // Get the queue info for the whole queue structure to pass to the webservice
 func (pc *PartitionContext) GetPartitionQueues() dao.PartitionQueueDAOInfo {
-	partitionQueueDAOInfo := pc.root.GetPartitionQueueDAOInfo(false)
+	partitionQueueDAOInfo := pc.root.GetPartitionQueueDAOInfo(true)
 	partitionQueueDAOInfo.Partition = common.GetPartitionNameWithoutClusterID(pc.Name)
 	return partitionQueueDAOInfo
 }

--- a/pkg/webservice/dao/queue_info.go
+++ b/pkg/webservice/dao/queue_info.go
@@ -40,7 +40,7 @@ type PartitionQueueDAOInfo struct {
 	Parent                 string                  `json:"parent,omitempty"`
 	TemplateInfo           *TemplateInfo           `json:"template,omitempty"`
 	Children               []PartitionQueueDAOInfo `json:"children,omitempty"`
-	ChildrenNames          []string                `json:"childrenNames,omitempty"`
+	ChildNames             []string                `json:"childNames,omitempty"`
 	AbsUsedCapacity        map[string]int64        `json:"absUsedCapacity,omitempty"`
 	MaxRunningApps         uint64                  `json:"maxRunningApps,omitempty"`
 	RunningApps            uint64                  `json:"runningApps,omitempty"`

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1163,7 +1163,7 @@ func TestGetPartitionQueuesHandler(t *testing.T) {
 
 	// test specific queue
 	var partitionQueueDao1 dao.PartitionQueueDAOInfo
-	req, err = http.NewRequest("GET", "/ws/v1/partition/default/queue/root.a?subtree", strings.NewReader(""))
+	req, err = http.NewRequest("GET", "/ws/v1/partition/default/queue/root.a", strings.NewReader(""))
 	req = req.WithContext(context.WithValue(req.Context(), httprouter.ParamsKey, httprouter.Params{httprouter.Param{Key: "partition", Value: "default"}, httprouter.Param{Key: "queue", Value: "root.a"}}))
 	assert.NilError(t, err)
 	resp = &MockResponseWriter{}
@@ -1172,12 +1172,12 @@ func TestGetPartitionQueuesHandler(t *testing.T) {
 	assert.NilError(t, err, unmarshalError)
 	assert.Equal(t, partitionQueueDao1.QueueName, "root.a")
 	assert.Equal(t, len(partitionQueueDao1.Children), 0)
-	assert.Equal(t, len(partitionQueueDao1.ChildrenNames), 1)
-	assert.Equal(t, partitionQueueDao1.ChildrenNames[0], "root.a.a1")
+	assert.Equal(t, len(partitionQueueDao1.ChildNames), 1)
+	assert.Equal(t, partitionQueueDao1.ChildNames[0], "root.a.a1")
 
 	// test hierarchy queue
 	var partitionQueueDao2 dao.PartitionQueueDAOInfo
-	req, err = http.NewRequest("GET", "/ws/v1/partition/default/queue/root.a", strings.NewReader(""))
+	req, err = http.NewRequest("GET", "/ws/v1/partition/default/queue/root.a?subtree", strings.NewReader(""))
 	req = req.WithContext(context.WithValue(req.Context(), httprouter.ParamsKey, httprouter.Params{httprouter.Param{Key: "partition", Value: "default"}, httprouter.Param{Key: "queue", Value: "root.a"}}))
 	assert.NilError(t, err)
 	resp = &MockResponseWriter{}
@@ -1186,9 +1186,9 @@ func TestGetPartitionQueuesHandler(t *testing.T) {
 	assert.NilError(t, err, unmarshalError)
 	assert.Equal(t, partitionQueueDao2.QueueName, "root.a")
 	assert.Equal(t, len(partitionQueueDao2.Children), 1)
-	assert.Equal(t, len(partitionQueueDao2.ChildrenNames), 1)
+	assert.Equal(t, len(partitionQueueDao2.ChildNames), 1)
 	assert.Equal(t, partitionQueueDao2.Children[0].QueueName, "root.a.a1")
-	assert.Equal(t, partitionQueueDao2.ChildrenNames[0], "root.a.a1")
+	assert.Equal(t, partitionQueueDao2.ChildNames[0], "root.a.a1")
 
 	// test partition not exists
 	req, err = http.NewRequest("GET", "/ws/v1/partition/default/queue/root.a", strings.NewReader(""))


### PR DESCRIPTION
### What is this PR for?
> subtree given(/ws/v1/partition/default/queue/root?subtree): return the whole tree
subtree missing(/ws/v1/partition/default/queue/root): return one level

- `GetPartitionQueueDAOInfo(include bool)` The default include is true, which means all subtrees are included.
`GetPartitionQueueDAOInfo(include bool)` include is false, which means that only the specified queue is included.

- `ChildrenNames` changes to `ChildNames`

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2472

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [x] - It needs documentation.
