### PR TITLE
[YUNIKORN-2507] Picking Victims should consider usage and max quota f…

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -1858,9 +1858,7 @@ func (sq *Queue) findPreemptionFenceRoot(priorityMap map[string]int64, currentPr
 	}
 	priorityMap[sq.QueuePath] = currentPriority
 
-	// Is FencePreemptionPolicy set on the queue?
-	// Does Queue's Usage already reached Max Res? If Yes, No use in picking up the victims outside this queue path, have to find the victim queue path with in this queue hierarchy.
-	// At last, root queue would be the fence if none met above
+	// Return this queue as fence root if: 1. FencePreemptionPolicy is set 2. root queue 3. allocations in the queue reached maximum resources
 	if sq.parent == nil || sq.GetPreemptionPolicy() == policies.FencePreemptionPolicy || resources.Equals(sq.allocatedResource, sq.maxResource) {
 		return sq
 	}

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -1858,7 +1858,10 @@ func (sq *Queue) findPreemptionFenceRoot(priorityMap map[string]int64, currentPr
 	}
 	priorityMap[sq.QueuePath] = currentPriority
 
-	if sq.parent == nil || sq.GetPreemptionPolicy() == policies.FencePreemptionPolicy {
+	// Is FencePreemptionPolicy set on the queue?
+	// Does Queue's Usage already reached Max Res? If Yes, No use in picking up the victims outside this queue path, have to find the victim queue path with in this queue hierarchy.
+	// At last, root queue would be the fence if none met above
+	if sq.parent == nil || sq.GetPreemptionPolicy() == policies.FencePreemptionPolicy || resources.Equals(sq.allocatedResource, sq.maxResource) {
 		return sq
 	}
 	return sq.parent.findPreemptionFenceRoot(priorityMap, currentPriority)


### PR DESCRIPTION
…or queues at each level

### What is this PR for?

Given the ask queue path, Choosing fence depends on whether queue at any level has FencePreemptionPolicy set or not. Otherwise, root would be used. 

In addition, max resources and usage also needs to be checked for queues at different levels in ask's queue path hierarchy. If queue is already full at any level in the queue hierarchy, need to choose that queue as fence because there is no use in going up the tree further and considering other queue paths into victims queue path's list.

### What type of PR is it?
* [ ] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2507

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
