### PR TITLE
[YUNIKORN-2527] Reset state of configured queue on re-add

### DIFF
--- a/pkg/scheduler/objects/object_state.go
+++ b/pkg/scheduler/objects/object_state.go
@@ -68,7 +68,7 @@ func NewObjectState() *fsm.FSM {
 				Dst:  Draining.String(),
 			}, {
 				Name: Start.String(),
-				Src:  []string{Active.String(), Stopped.String()},
+				Src:  []string{Active.String(), Stopped.String(), Draining.String()},
 				Dst:  Active.String(),
 			}, {
 				Name: Stop.String(),

--- a/pkg/scheduler/objects/object_state_test.go
+++ b/pkg/scheduler/objects/object_state_test.go
@@ -50,15 +50,15 @@ func TestStateTransition(t *testing.T) {
 	assert.Assert(t, err == nil)
 	assert.Equal(t, stateMachine.Current(), Draining.String())
 
-	// start on draining not allowed
-	err = stateMachine.Event(context.Background(), Start.String(), "test_object")
-	assert.Assert(t, err != nil)
-	assert.Equal(t, stateMachine.Current(), Draining.String())
-
 	// stop on draining not allowed
 	err = stateMachine.Event(context.Background(), Stop.String(), "test_object")
 	assert.Assert(t, err != nil)
 	assert.Equal(t, stateMachine.Current(), Draining.String())
+
+	// draining to active
+	err = stateMachine.Event(context.Background(), Start.String(), "test_object")
+	assert.Assert(t, err == nil)
+	assert.Equal(t, stateMachine.Current(), Active.String())
 }
 
 func TestTransitionToSelf(t *testing.T) {

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -328,6 +328,14 @@ func (sq *Queue) applyConf(conf configs.QueueConfig) error {
 		sq.isManaged = true
 	}
 
+	// if the queue is marked for removal reverse that state
+	if !sq.IsRunning() {
+		err = sq.handleQueueEvent(Start)
+		if err != nil {
+			log.Log(log.SchedQueue).Info("managed queue state change failed",
+				zap.String("queue", sq.QueuePath))
+		}
+	}
 	prevLeaf := sq.isLeaf
 	sq.isLeaf = !conf.Parent
 	// Make sure the parent flag is set correctly: config might expect auto parent type creation


### PR DESCRIPTION
### What is this PR for?
When a queue is removed and re-added the configured queue status is not reset. If that happens within the cleanup cycle, the cleanup still gets triggered. The queue is removed causing an inconsistency between the config and the queues available in the core.

The object state needs to allow for moving from Draining back to Active. Updated tests to cover the new state transition.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-2527

### How should this be tested?
unit tests included
