### PR TITLE
[YUNIKORN-2543] Fix locking in RMProxy

### DIFF
--- a/pkg/entrypoint/entrypoint.go
+++ b/pkg/entrypoint/entrypoint.go
@@ -80,8 +80,7 @@ func startAllServicesWithParameters(opts startupOptions) *ServiceContext {
 	events.GetEventSystem().StartService()
 
 	sched := scheduler.NewScheduler()
-	proxy := rmproxy.NewRMProxy()
-
+	proxy := rmproxy.NewRMProxy(sched)
 	eventHandler := handler.EventHandlers{
 		SchedulerEventHandler: sched,
 		RMProxyEventHandler:   proxy,
@@ -90,7 +89,7 @@ func startAllServicesWithParameters(opts startupOptions) *ServiceContext {
 	// start services
 	log.Log(log.Entrypoint).Info("ServiceContext start scheduling services")
 	sched.StartService(eventHandler, opts.manualScheduleFlag)
-	proxy.StartService(eventHandler)
+	proxy.StartService()
 
 	context := &ServiceContext{
 		RMProxy:   proxy,


### PR DESCRIPTION
### What is this PR for?
Reduce the scopes of read locks in RMProxy to avoid potential deadlocks which can be caused by an interference with `cache.Context`.

Also simplify the event handler references, we only need `schedulerEventHandler` which is now set once during creation.

### What type of PR is it?
* [x] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2543

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
