### PR TITLE
[YUNIKORN-2547] Queue: clean up logic when adding application

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -2120,12 +2120,12 @@ func (sa *Application) updateRunnableStatus(runnableInQueue, runnableByUserLimit
 	sa.runnableByUserLimit = runnableByUserLimit
 }
 
-// GetGuaranteedResource returns the guaranteed resource that was set in the application tags
+// GetGuaranteedResource returns the guaranteed resource that is set in the application tags
 func (sa *Application) GetGuaranteedResource() *resources.Resource {
 	return sa.getResourceFromTags(siCommon.AppTagNamespaceResourceGuaranteed)
 }
 
-// GetMaxResource returns the max resource that was set in the application tags
+// GetMaxResource returns the max resource that is set in the application tags
 func (sa *Application) GetMaxResource() *resources.Resource {
 	return sa.getResourceFromTags(siCommon.AppTagNamespaceResourceQuota)
 }
@@ -2144,7 +2144,7 @@ func (sa *Application) getResourceFromTags(tag string) *resources.Resource {
 			zap.Error(err))
 	} else if !resources.StrictlyGreaterThanZero(resource) {
 		log.Log(log.SchedQueue).Warn("resource quantities should be greater than zero",
-			zap.Stringer("maxResource", resource))
+			zap.Stringer("resource", resource))
 		resource = nil
 	}
 

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -1529,7 +1529,6 @@ func (sa *Application) SetQueue(queue *Queue) {
 	defer sa.Unlock()
 	sa.queuePath = queue.QueuePath
 	sa.queue = queue
-	sa.queue.UpdateApplicationPriority(sa.ApplicationID, sa.askMaxPriority)
 }
 
 // remove the leaf queue the application runs in, used when completing the app

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -361,11 +361,10 @@ func (pc *PartitionContext) AddApplication(app *objects.Application) error {
 			}
 		}
 	}
-	queue.AddApplication(app)
-
 	// all is OK update the app and add it to the partition
 	app.SetQueue(queue)
 	app.SetTerminatedCallback(pc.moveTerminatedApp)
+	queue.AddApplication(app)
 	pc.applications[appID] = app
 
 	return nil

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -339,8 +339,11 @@ func (pc *PartitionContext) AddApplication(app *objects.Application) error {
 		return fmt.Errorf("failed to find queue %s for application %s", queueName, appID)
 	}
 
-	// set resources based on tags, but only if the queue is dynamic
-	if !queue.IsManaged() {
+	// set resources based on tags, but only if the queue is dynamic (unmanaged)
+	if queue.IsManaged() {
+		log.Log(log.SchedQueue).Warn("Trying to set resources on a queue that is not an unmanaged leaf",
+			zap.String("queueName", queue.QueuePath))
+	} else {
 		queue.SetResources(app.GetGuaranteedResource(), app.GetMaxResource())
 	}
 	// check only for gang request
@@ -358,7 +361,6 @@ func (pc *PartitionContext) AddApplication(app *objects.Application) error {
 			}
 		}
 	}
-	// add the app to the queue to set the quota on the queue if needed
 	queue.AddApplication(app)
 
 	// all is OK update the app and add it to the partition

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -339,8 +339,6 @@ func (pc *PartitionContext) AddApplication(app *objects.Application) error {
 		return fmt.Errorf("failed to find queue %s for application %s", queueName, appID)
 	}
 
-	// add the app to the queue to set the quota on the queue if needed
-	queue.AddApplication(app)
 	// check only for gang request
 	// - make sure the taskgroup request fits in the maximum set for the queue hierarchy
 	// - task groups should only be used in FIFO queues
@@ -348,17 +346,21 @@ func (pc *PartitionContext) AddApplication(app *objects.Application) error {
 	if placeHolder := app.GetPlaceholderAsk(); !resources.IsZero(placeHolder) {
 		// check the queue sorting
 		if !queue.SupportTaskGroup() {
-			queue.RemoveApplication(app)
 			return fmt.Errorf("queue %s cannot run application %s with task group request: unsupported sort type", queueName, appID)
 		}
-		// retrieve the max set
-		if maxQueue := queue.GetMaxQueueSet(); maxQueue != nil {
+		// the new maxResource is going to be either app.GetMaxResource() from the tags or the maxResource which already set on the queue
+		maxRes := queue.GetMaxResource()
+		if app.GetMaxResource() != nil {
+			maxRes = app.GetMaxResource()
+		}
+		if maxQueue := queue.GetProposedMaxQueueResource(maxRes); maxQueue != nil {
 			if !maxQueue.FitInMaxUndef(placeHolder) {
-				queue.RemoveApplication(app)
 				return fmt.Errorf("queue %s cannot fit application %s: task group request %s larger than max queue allocation %s", queueName, appID, placeHolder.String(), maxQueue.String())
 			}
 		}
 	}
+	// add the app to the queue to set the quota on the queue if needed
+	queue.AddApplication(app)
 
 	// all is OK update the app and add it to the partition
 	app.SetQueue(queue)

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -2804,7 +2804,8 @@ func TestAddTGApplication(t *testing.T) {
 	partition, err := newLimitedPartition(limit)
 	assert.NilError(t, err, "partition create failed")
 	// add a app with TG that does not fit in the queue
-	tgRes, err := resources.NewResourceFromConf(map[string]string{"vcore": "10"})
+	var tgRes *resources.Resource
+	tgRes, err = resources.NewResourceFromConf(map[string]string{"vcore": "10"})
 	assert.NilError(t, err, "failed to create resource")
 	tags := map[string]string{
 		siCommon.AppTagNamespaceResourceGuaranteed: "{\"resources\":{\"vcore\":{\"value\":111}}}",

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -2804,14 +2804,22 @@ func TestAddTGApplication(t *testing.T) {
 	partition, err := newLimitedPartition(limit)
 	assert.NilError(t, err, "partition create failed")
 	// add a app with TG that does not fit in the queue
-	var tgRes *resources.Resource
-	tgRes, err = resources.NewResourceFromConf(map[string]string{"vcore": "10"})
+	tgRes, err := resources.NewResourceFromConf(map[string]string{"vcore": "10"})
 	assert.NilError(t, err, "failed to create resource")
-	app := newApplicationTG(appID1, "default", "root.limited", tgRes)
+	tags := map[string]string{
+		siCommon.AppTagNamespaceResourceGuaranteed: "{\"resources\":{\"vcore\":{\"value\":111}}}",
+		siCommon.AppTagNamespaceResourceQuota:      "{\"resources\":{\"vcore\":{\"value\":2222}}}",
+	}
+	app := newApplicationTGTags(appID1, "default", "root.limited", tgRes, tags)
 	err = partition.AddApplication(app)
 	if err == nil {
 		t.Error("app-1 should be rejected due to TG request")
 	}
+	queue := partition.GetQueue("root.limited")
+	assert.Assert(t, resources.Equals(queue.GetMaxResource(), resources.NewResourceFromMap(map[string]resources.Quantity{
+		"vcore": 1000,
+	})), "max resource changed unexpectedly")
+	assert.Assert(t, queue.GetGuaranteedResource() == nil)
 
 	// add a app with TG that does fit in the queue
 	limit = map[string]string{"vcore": "100"}
@@ -2820,6 +2828,11 @@ func TestAddTGApplication(t *testing.T) {
 	err = partition.AddApplication(app)
 	assert.NilError(t, err, "app-1 should have been added to the partition")
 	assert.Equal(t, partition.getApplication(appID1), app, "partition failed to add app incorrect app returned")
+	queue = partition.GetQueue("root.limited")
+	assert.Assert(t, resources.Equals(queue.GetMaxResource(), resources.NewResourceFromMap(map[string]resources.Quantity{
+		"vcore": 100000,
+	})), "max resource changed unexpectedly")
+	assert.Assert(t, queue.GetGuaranteedResource() == nil)
 
 	// add a app with TG that does fit in the queue as the resource is not limited in the queue
 	limit = map[string]string{"second": "100"}
@@ -2828,6 +2841,11 @@ func TestAddTGApplication(t *testing.T) {
 	err = partition.AddApplication(app)
 	assert.NilError(t, err, "app-1 should have been added to the partition")
 	assert.Equal(t, partition.getApplication(appID1), app, "partition failed to add app incorrect app returned")
+	queue = partition.GetQueue("root.limited")
+	assert.Assert(t, resources.Equals(queue.GetMaxResource(), resources.NewResourceFromMap(map[string]resources.Quantity{
+		"second": 100,
+	})), "max resource changed unexpectedly")
+	assert.Assert(t, queue.GetGuaranteedResource() == nil)
 }
 
 func TestAddTGAppDynamic(t *testing.T) {
@@ -2843,16 +2861,24 @@ func TestAddTGAppDynamic(t *testing.T) {
 	assert.NilError(t, err, "app-1 should have been added to the partition")
 	assert.Equal(t, app.GetQueuePath(), "root.unlimited", "app-1 not placed in expected queue")
 
-	jsonRes := "{\"resources\":{\"vcore\":{\"value\":10000}}}"
-	tags = map[string]string{"taskqueue": "same", siCommon.AppTagNamespaceResourceQuota: jsonRes}
+	jsonMaxRes := "{\"resources\":{\"vcore\":{\"value\":10000}}}"
+	tags = map[string]string{"taskqueue": "same", siCommon.AppTagNamespaceResourceQuota: jsonMaxRes}
 	app = newApplicationTGTags(appID2, "default", "unknown", tgRes, tags)
 	err = partition.AddApplication(app)
 	assert.NilError(t, err, "app-2 should have been added to the partition")
 	assert.Equal(t, partition.getApplication(appID2), app, "partition failed to add app incorrect app returned")
 	assert.Equal(t, app.GetQueuePath(), "root.same", "app-2 not placed in expected queue")
+	queue := partition.GetQueue("root.same")
+	assert.Assert(t, queue.GetGuaranteedResource() == nil, "guaranteed resource should be unset")
+	maxRes := queue.GetMaxResource()
+	assert.Assert(t, maxRes != nil, "maximum resource should have been set")
+	assert.Assert(t, resources.Equals(maxRes, resources.NewResourceFromMap(map[string]resources.Quantity{
+		"vcore": 10000,
+	})), "max resource set on the queue does not match the JSON tag")
 
-	jsonRes = "{\"resources\":{\"vcore\":{\"value\":1000}}}"
-	tags = map[string]string{"taskqueue": "smaller", siCommon.AppTagNamespaceResourceQuota: jsonRes}
+	jsonMaxRes = "{\"resources\":{\"vcore\":{\"value\":1000}}}"
+	jsonGuaranteedRes := "{\"resources\":{\"vcore\":{\"value\":111}}}"
+	tags = map[string]string{"taskqueue": "smaller", siCommon.AppTagNamespaceResourceQuota: jsonMaxRes, siCommon.AppTagNamespaceResourceGuaranteed: jsonGuaranteedRes}
 	app = newApplicationTGTags(appID3, "default", "unknown", tgRes, tags)
 	err = partition.AddApplication(app)
 	if err == nil {
@@ -2861,10 +2887,20 @@ func TestAddTGAppDynamic(t *testing.T) {
 	if partition.getApplication(appID3) != nil {
 		t.Fatal("partition added app incorrectly should have failed")
 	}
-	queue := partition.GetQueue("root.smaller")
+	queue = partition.GetQueue("root.smaller")
 	if queue == nil {
 		t.Fatal("queue should have been added, even if app failed")
 	}
+	maxRes = queue.GetMaxResource()
+	assert.Assert(t, maxRes != nil, "maximum resource should have been set")
+	assert.Assert(t, resources.Equals(maxRes, resources.NewResourceFromMap(map[string]resources.Quantity{
+		"vcore": 1000,
+	})), "max resource set on the queue does not match the JSON tag")
+	guaranteedRes := queue.GetGuaranteedResource()
+	assert.Assert(t, guaranteedRes != nil, "guaranteed resource should have been set")
+	assert.Assert(t, resources.Equals(guaranteedRes, resources.NewResourceFromMap(map[string]resources.Quantity{
+		"vcore": 111,
+	})), "guaranteed resource set on the queue does not match the JSON tag")
 }
 
 func TestPlaceholderSmallerThanReal(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
Clean up tag parsing logic in `Queue.AddApplication()` because that code belongs to `objects.NewApplication`.
Also, don't add the application to the queue then remove it if the placeholder doesn't fit, because it generates an unnecessary application event. Instead, calculate the new maximum resource without adding it.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2547

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
