### PR TITLE
[YUNIKORN-2548] Potential deadlock during concurrent bottom-up/top-down queue traversal

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -963,16 +963,22 @@ func (sq *Queue) MarkQueueForRemoval() {
 	if sq.IsManaged() {
 		log.Log(log.SchedQueue).Info("marking managed queue for deletion",
 			zap.String("queue", sq.QueuePath))
-		if err := sq.handleQueueEvent(Remove); err != nil {
-			log.Log(log.SchedQueue).Warn("failed to mark managed queue for deletion",
-				zap.String("queue", sq.QueuePath),
-				zap.Error(err))
-		}
+		sq.doRemoveQueue()
 		if len(sq.children) > 0 {
 			for _, child := range children {
 				child.MarkQueueForRemoval()
 			}
 		}
+	}
+}
+
+func (sq *Queue) doRemoveQueue() {
+	sq.Lock()
+	defer sq.Unlock()
+	if err := sq.handleQueueEvent(Remove); err != nil {
+		log.Log(log.SchedQueue).Warn("failed to mark managed queue for deletion",
+			zap.String("queue", sq.QueuePath),
+			zap.Error(err))
 	}
 }
 

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -957,17 +957,18 @@ func (sq *Queue) addChildQueue(child *Queue) error {
 // This can be executed multiple times and is only effective the first time.
 // This is a noop on an unmanaged queue.
 func (sq *Queue) MarkQueueForRemoval() {
+	if !sq.IsManaged() {
+		return
+	}
 	children := sq.GetCopyOfChildren()
 	// Mark the managed queue for deletion: it is removed from the config let it drain.
 	// Also mark all the managed children for deletion.
-	if sq.IsManaged() {
-		log.Log(log.SchedQueue).Info("marking managed queue for deletion",
-			zap.String("queue", sq.QueuePath))
-		sq.doRemoveQueue()
-		if len(sq.children) > 0 {
-			for _, child := range children {
-				child.MarkQueueForRemoval()
-			}
+	log.Log(log.SchedQueue).Info("marking managed queue for deletion",
+		zap.String("queue", sq.QueuePath))
+	sq.doRemoveQueue()
+	if len(sq.children) > 0 {
+		for _, child := range children {
+			child.MarkQueueForRemoval()
 		}
 	}
 }


### PR DESCRIPTION
### What is this PR for?
Avoid potential deadlock while removing queues during config refresh. `MarkQueueForRemoval()` performs a top-down traversal of the hierarchy, while resource increment/decrement does the opposite.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2548

### How should this be tested?
Run test from `smoke_test.go` with the deadlock detector enabled.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
