### PR TITLE
[YUNIKORN-2550] Fix locking in PartitionContext

### DIFF
--- a/pkg/scheduler/objects/node_collection.go
+++ b/pkg/scheduler/objects/node_collection.go
@@ -37,6 +37,8 @@ var acceptAll = func(node *Node) bool {
 	return true
 }
 
+// NodeCollection represents a collection of nodes for a partition.
+// Implementations of this interface must be internally synchronized to avoid data races.
 type NodeCollection interface {
 	AddNode(node *Node) error
 	RemoveNode(nodeID string) *Node

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -159,7 +159,8 @@ func (pc *PartitionContext) updatePreemption(conf configs.PartitionConfig) {
 }
 
 func (pc *PartitionContext) updatePartitionDetails(conf configs.PartitionConfig) error {
-	// this must be performed without locking to avoid lock order differences between PartitionContext and AppPlacementManager
+	// the following piece of code (before pc.Lock()) must be performed without locking
+	// to avoid lock order differences between PartitionContext and AppPlacementManager
 	if len(conf.Queues) == 0 || conf.Queues[0].Name != configs.RootQueue {
 		return fmt.Errorf("partition cannot be created without root queue")
 	}
@@ -611,7 +612,6 @@ func (pc *PartitionContext) addNodeToList(node *objects.Node) error {
 }
 
 // removeNodeFromList removes the node from the list of partition nodes.
-// This locks the partition.
 func (pc *PartitionContext) removeNodeFromList(nodeID string) *objects.Node {
 	node := pc.nodes.RemoveNode(nodeID)
 	if node == nil {


### PR DESCRIPTION
### What is this PR for?
Potential deadlock was detected between `PartitionContext` and `AppPlacementManager`.
Config update for the placement manager must run without holding any `PartitionContext` lock.

We also don't need any locking to access `pc.nodes` because the type is internally synchronized and the field is set once.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2550

### How should this be tested?
Run `smoke_test.go` from the core with deadlock detection enabled.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
