### PR TITLE
[YUNIKORN-2552] Recursive locking when sending remove queue event

### DIFF
--- a/pkg/scheduler/objects/queue_events.go
+++ b/pkg/scheduler/objects/queue_events.go
@@ -20,93 +20,92 @@ package objects
 
 import (
 	"github.com/apache/yunikorn-core/pkg/common"
+	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/events"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
 type queueEvents struct {
 	eventSystem events.EventSystem
-	queue       *Queue
 }
 
-func (q *queueEvents) sendNewQueueEvent() {
+func (q *queueEvents) sendNewQueueEvent(queuePath string, managed bool) {
 	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
 	detail := si.EventRecord_QUEUE_DYNAMIC
-	if q.queue.IsManaged() {
+	if managed {
 		detail = si.EventRecord_DETAILS_NONE
 	}
-	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, common.Empty, si.EventRecord_ADD,
+	event := events.CreateQueueEventRecord(queuePath, common.Empty, common.Empty, si.EventRecord_ADD,
 		detail, nil)
 	q.eventSystem.AddEvent(event)
 }
 
-func (q *queueEvents) sendNewApplicationEvent(appID string) {
+func (q *queueEvents) sendNewApplicationEvent(queuePath, appID string) {
 	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, appID, si.EventRecord_ADD,
+	event := events.CreateQueueEventRecord(queuePath, common.Empty, appID, si.EventRecord_ADD,
 		si.EventRecord_QUEUE_APP, nil)
 	q.eventSystem.AddEvent(event)
 }
 
-func (q *queueEvents) sendRemoveQueueEvent() {
+func (q *queueEvents) sendRemoveQueueEvent(queuePath string, managed bool) {
 	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
 	detail := si.EventRecord_QUEUE_DYNAMIC
-	if q.queue.IsManaged() {
+	if managed {
 		detail = si.EventRecord_DETAILS_NONE
 	}
-	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, common.Empty, si.EventRecord_REMOVE,
+	event := events.CreateQueueEventRecord(queuePath, common.Empty, common.Empty, si.EventRecord_REMOVE,
 		detail, nil)
 	q.eventSystem.AddEvent(event)
 }
 
-func (q *queueEvents) sendRemoveApplicationEvent(appID string) {
+func (q *queueEvents) sendRemoveApplicationEvent(queuePath, appID string) {
 	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, appID, si.EventRecord_REMOVE,
+	event := events.CreateQueueEventRecord(queuePath, common.Empty, appID, si.EventRecord_REMOVE,
 		si.EventRecord_QUEUE_APP, nil)
 	q.eventSystem.AddEvent(event)
 }
 
-func (q *queueEvents) sendMaxResourceChangedEvent() {
+func (q *queueEvents) sendMaxResourceChangedEvent(queuePath string, maxResource *resources.Resource) {
 	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, common.Empty, si.EventRecord_SET,
-		si.EventRecord_QUEUE_MAX, q.queue.maxResource)
+	event := events.CreateQueueEventRecord(queuePath, common.Empty, common.Empty, si.EventRecord_SET,
+		si.EventRecord_QUEUE_MAX, maxResource)
 	q.eventSystem.AddEvent(event)
 }
 
-func (q *queueEvents) sendGuaranteedResourceChangedEvent() {
+func (q *queueEvents) sendGuaranteedResourceChangedEvent(queuePath string, guaranteed *resources.Resource) {
 	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-	event := events.CreateQueueEventRecord(q.queue.QueuePath, common.Empty, common.Empty, si.EventRecord_SET,
-		si.EventRecord_QUEUE_GUARANTEED, q.queue.guaranteedResource)
+	event := events.CreateQueueEventRecord(queuePath, common.Empty, common.Empty, si.EventRecord_SET,
+		si.EventRecord_QUEUE_GUARANTEED, guaranteed)
 	q.eventSystem.AddEvent(event)
 }
 
-func (q *queueEvents) sendTypeChangedEvent() {
+func (q *queueEvents) sendTypeChangedEvent(queuePath string, isLeaf bool) {
 	if !q.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
 	message := "leaf queue: false"
-	if q.queue.isLeaf {
+	if isLeaf {
 		message = "leaf queue: true"
 	}
-	event := events.CreateQueueEventRecord(q.queue.QueuePath, message, common.Empty, si.EventRecord_SET,
+	event := events.CreateQueueEventRecord(queuePath, message, common.Empty, si.EventRecord_SET,
 		si.EventRecord_QUEUE_TYPE, nil)
 	q.eventSystem.AddEvent(event)
 }
 
-func newQueueEvents(queue *Queue, evt events.EventSystem) *queueEvents {
+func newQueueEvents(evt events.EventSystem) *queueEvents {
 	return &queueEvents{
 		eventSystem: evt,
-		queue:       queue,
 	}
 }

--- a/pkg/scheduler/objects/queue_events_test.go
+++ b/pkg/scheduler/objects/queue_events_test.go
@@ -39,13 +39,13 @@ func TestSendNewQueueEvent(t *testing.T) {
 		isManaged: true,
 	}
 	eventSystem := mock.NewEventSystemDisabled()
-	nq := newQueueEvents(queue, eventSystem)
-	nq.sendNewQueueEvent()
+	nq := newQueueEvents(eventSystem)
+	nq.sendNewQueueEvent(queue.QueuePath, false)
 	assert.Equal(t, 0, len(eventSystem.Events), "unexpected event")
 
 	eventSystem = mock.NewEventSystem()
-	nq = newQueueEvents(queue, eventSystem)
-	nq.sendNewQueueEvent()
+	nq = newQueueEvents(eventSystem)
+	nq.sendNewQueueEvent(queue.QueuePath, true)
 	assert.Equal(t, 1, len(eventSystem.Events), "event was not generated")
 	event := eventSystem.Events[0]
 	assert.Equal(t, si.EventRecord_QUEUE, event.Type)
@@ -56,28 +56,21 @@ func TestSendNewQueueEvent(t *testing.T) {
 	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
 	assert.Equal(t, 0, len(event.Resource.Resources))
 	eventSystem = mock.NewEventSystem()
-	nq = newQueueEvents(&Queue{
-		QueuePath: testQueuePath,
-		isManaged: false,
-	}, eventSystem)
-	nq.sendNewQueueEvent()
+	nq = newQueueEvents(eventSystem)
+	nq.sendNewQueueEvent(queue.QueuePath, false)
 	event = eventSystem.Events[0]
 	assert.Equal(t, si.EventRecord_QUEUE_DYNAMIC, event.EventChangeDetail)
 }
 
 func TestSendRemoveQueueEvent(t *testing.T) {
-	queue := &Queue{
-		QueuePath: testQueuePath,
-		isManaged: true,
-	}
 	eventSystem := mock.NewEventSystemDisabled()
-	nq := newQueueEvents(queue, eventSystem)
-	nq.sendRemoveQueueEvent()
+	nq := newQueueEvents(eventSystem)
+	nq.sendRemoveQueueEvent(testQueuePath, true)
 	assert.Equal(t, 0, len(eventSystem.Events), "unexpected event")
 
 	eventSystem = mock.NewEventSystem()
-	nq = newQueueEvents(queue, eventSystem)
-	nq.sendRemoveQueueEvent()
+	nq = newQueueEvents(eventSystem)
+	nq.sendRemoveQueueEvent(testQueuePath, true)
 	assert.Equal(t, 1, len(eventSystem.Events), "event was not generated")
 	event := eventSystem.Events[0]
 	assert.Equal(t, si.EventRecord_QUEUE, event.Type)
@@ -88,27 +81,21 @@ func TestSendRemoveQueueEvent(t *testing.T) {
 	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
 	assert.Equal(t, 0, len(event.Resource.Resources))
 	eventSystem = mock.NewEventSystem()
-	nq = newQueueEvents(&Queue{
-		QueuePath: testQueuePath,
-		isManaged: false,
-	}, eventSystem)
-	nq.sendRemoveQueueEvent()
+	nq = newQueueEvents(eventSystem)
+	nq.sendRemoveQueueEvent(testQueuePath, false)
 	event = eventSystem.Events[0]
 	assert.Equal(t, si.EventRecord_QUEUE_DYNAMIC, event.EventChangeDetail)
 }
 
 func TestNewApplicationEvent(t *testing.T) {
-	queue := &Queue{
-		QueuePath: testQueuePath,
-	}
 	eventSystem := mock.NewEventSystemDisabled()
-	nq := newQueueEvents(queue, eventSystem)
-	nq.sendNewApplicationEvent(appID0)
+	nq := newQueueEvents(eventSystem)
+	nq.sendNewApplicationEvent(testQueuePath, appID0)
 	assert.Equal(t, 0, len(eventSystem.Events), "unexpected event")
 
 	eventSystem = mock.NewEventSystem()
-	nq = newQueueEvents(queue, eventSystem)
-	nq.sendNewApplicationEvent(appID0)
+	nq = newQueueEvents(eventSystem)
+	nq.sendNewApplicationEvent(testQueuePath, appID0)
 	assert.Equal(t, 1, len(eventSystem.Events), "event was not generated")
 	event := eventSystem.Events[0]
 	assert.Equal(t, si.EventRecord_QUEUE, event.Type)
@@ -121,17 +108,14 @@ func TestNewApplicationEvent(t *testing.T) {
 }
 
 func TestRemoveApplicationEvent(t *testing.T) {
-	queue := &Queue{
-		QueuePath: testQueuePath,
-	}
 	eventSystem := mock.NewEventSystemDisabled()
-	nq := newQueueEvents(queue, eventSystem)
-	nq.sendRemoveApplicationEvent(appID0)
+	nq := newQueueEvents(eventSystem)
+	nq.sendRemoveApplicationEvent(testQueuePath, appID0)
 	assert.Equal(t, 0, len(eventSystem.Events), "unexpected event")
 
 	eventSystem = mock.NewEventSystem()
-	nq = newQueueEvents(queue, eventSystem)
-	nq.sendRemoveApplicationEvent(appID0)
+	nq = newQueueEvents(eventSystem)
+	nq.sendRemoveApplicationEvent(testQueuePath, appID0)
 	assert.Equal(t, 1, len(eventSystem.Events), "event was not generated")
 	event := eventSystem.Events[0]
 	assert.Equal(t, si.EventRecord_QUEUE, event.Type)
@@ -144,17 +128,14 @@ func TestRemoveApplicationEvent(t *testing.T) {
 }
 
 func TestTypeChangedEvent(t *testing.T) {
-	queue := &Queue{
-		QueuePath: testQueuePath,
-	}
 	eventSystem := mock.NewEventSystemDisabled()
-	nq := newQueueEvents(queue, eventSystem)
-	nq.sendTypeChangedEvent()
+	nq := newQueueEvents(eventSystem)
+	nq.sendTypeChangedEvent(testQueuePath, true)
 	assert.Equal(t, 0, len(eventSystem.Events), "unexpected event")
 
 	eventSystem = mock.NewEventSystem()
-	nq = newQueueEvents(queue, eventSystem)
-	nq.sendTypeChangedEvent()
+	nq = newQueueEvents(eventSystem)
+	nq.sendTypeChangedEvent(testQueuePath, false)
 	assert.Equal(t, 1, len(eventSystem.Events), "event was not generated")
 	event := eventSystem.Events[0]
 	assert.Equal(t, si.EventRecord_QUEUE, event.Type)
@@ -168,18 +149,14 @@ func TestTypeChangedEvent(t *testing.T) {
 
 func TestSendMaxResourceChangedEvent(t *testing.T) {
 	maxRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1})
-	queue := &Queue{
-		QueuePath:   testQueuePath,
-		maxResource: maxRes,
-	}
 	eventSystem := mock.NewEventSystemDisabled()
-	nq := newQueueEvents(queue, eventSystem)
-	nq.sendMaxResourceChangedEvent()
+	nq := newQueueEvents(eventSystem)
+	nq.sendMaxResourceChangedEvent(testQueuePath, maxRes)
 	assert.Equal(t, 0, len(eventSystem.Events), "unexpected event")
 
 	eventSystem = mock.NewEventSystem()
-	nq = newQueueEvents(queue, eventSystem)
-	nq.sendMaxResourceChangedEvent()
+	nq = newQueueEvents(eventSystem)
+	nq.sendMaxResourceChangedEvent(testQueuePath, maxRes)
 	assert.Equal(t, 1, len(eventSystem.Events), "event was not generated")
 	event := eventSystem.Events[0]
 	assert.Equal(t, si.EventRecord_QUEUE, event.Type)
@@ -195,18 +172,14 @@ func TestSendMaxResourceChangedEvent(t *testing.T) {
 
 func TestSendGuaranteedResourceChangedEvent(t *testing.T) {
 	guaranteed := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1})
-	queue := &Queue{
-		QueuePath:          testQueuePath,
-		guaranteedResource: guaranteed,
-	}
 	eventSystem := mock.NewEventSystemDisabled()
-	nq := newQueueEvents(queue, eventSystem)
-	nq.sendGuaranteedResourceChangedEvent()
+	nq := newQueueEvents(eventSystem)
+	nq.sendGuaranteedResourceChangedEvent(testQueuePath, guaranteed)
 	assert.Equal(t, 0, len(eventSystem.Events), "unexpected event")
 
 	eventSystem = mock.NewEventSystem()
-	nq = newQueueEvents(queue, eventSystem)
-	nq.sendGuaranteedResourceChangedEvent()
+	nq = newQueueEvents(eventSystem)
+	nq.sendGuaranteedResourceChangedEvent(testQueuePath, guaranteed)
 	assert.Equal(t, 1, len(eventSystem.Events), "event was not generated")
 	event := eventSystem.Events[0]
 	assert.Equal(t, si.EventRecord_QUEUE, event.Type)


### PR DESCRIPTION
### What is this PR for?
Recursive locking (ie acquiring the same lock twice) was detected by the go-deadlock tool. The PR removes the `objects.Queue` references from `objects.queueEvents` and necessary input are passed as  arguments.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2552

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
