### PR TITLE
[YUNIKORN-2553] Enable deadlock detection during unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,9 @@ build: commands
 
 # Run the tests after building
 .PHONY: test
+test: export DEADLOCK_DETECTION_ENABLED = true
+test: export DEADLOCK_TIMEOUT_SECONDS = 10
+test: export DEADLOCK_EXIT = true
 test:
 	@echo "running unit tests"
 	@mkdir -p build

--- a/pkg/locking/locking.go
+++ b/pkg/locking/locking.go
@@ -84,6 +84,7 @@ func reInit() {
 	}
 
 	if enabled {
+		//  We want to ensure that we write this before any other subsystem is initialized, including logging which may also use locks.
 		fmt.Fprintf(os.Stderr, "=== Deadlock detection enabled (timeout: %d seconds, exit on deadlock: %v) ===\n", timeoutSec, exitOnDeadlock)
 	}
 }

--- a/pkg/locking/locking.go
+++ b/pkg/locking/locking.go
@@ -33,11 +33,14 @@ import (
 
 const EnvDeadlockDetectionEnabled = "DEADLOCK_DETECTION_ENABLED"
 const EnvDeadlockTimeoutSeconds = "DEADLOCK_TIMEOUT_SECONDS"
+const EnvExitOnDeadlock = "DEADLOCK_EXIT"
 
 var once sync.Once
 var trackingEnabled atomic.Bool
 var timeoutSeconds atomic.Int32
 var deadlockDetected atomic.Bool
+var testingMode atomic.Bool
+var exitOnDeadlock bool
 
 type errorBuf struct {
 	data string
@@ -74,13 +77,26 @@ func reInit() {
 	godeadlock.Opts.DeadlockTimeout = time.Duration(timeoutSec) * time.Second
 	godeadlock.Opts.LogBuf = &errorBuf{}
 	godeadlock.Opts.OnPotentialDeadlock = onPotentialDeadlock
+	if exitEnv, err := strconv.ParseBool(os.Getenv(EnvExitOnDeadlock)); err != nil {
+		exitOnDeadlock = false
+	} else {
+		exitOnDeadlock = exitEnv
+	}
+
 	if enabled {
-		fmt.Fprintf(os.Stderr, "=== Deadlock detection enabled (timeout: %d seconds) ===\n", timeoutSec)
+		fmt.Fprintf(os.Stderr, "=== Deadlock detection enabled (timeout: %d seconds, exit on deadlock: %v) ===\n", timeoutSec, exitOnDeadlock)
 	}
 }
 
 func onPotentialDeadlock() {
 	deadlockDetected.Store(true)
+	printBufContents()
+	if exitOnDeadlock && !testingMode.Load() {
+		os.Exit(1)
+	}
+}
+
+func printBufContents() {
 	buf, ok := godeadlock.Opts.LogBuf.(*errorBuf)
 	buf.Lock()
 	defer buf.Unlock()

--- a/pkg/locking/locking_test.go
+++ b/pkg/locking/locking_test.go
@@ -34,12 +34,14 @@ import (
 func disableTracking() {
 	os.Unsetenv(EnvDeadlockDetectionEnabled)
 	os.Unsetenv(EnvDeadlockTimeoutSeconds)
+	testingMode.Store(false)
 	reInit()
 }
 
 func enableTracking() {
 	os.Setenv(EnvDeadlockDetectionEnabled, "true")
 	os.Setenv(EnvDeadlockTimeoutSeconds, "1")
+	testingMode.Store(true)
 	reInit()
 }
 


### PR DESCRIPTION
### What is this PR for?
Enable deadlock detection when running unit tests with "make test". Original locking tests should be unaffected.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2553

### How should this be tested?
1. Create a tiny test file eg. `pkg/scheduler/objects/mutex_test.go`:

```
package objects

import (
	"testing"
	"github.com/apache/yunikorn-core/pkg/locking"
)

func TestDeadlock(t *testing.T) {
	var mutex locking.Mutex
	mutex.Lock()
	mutex.Lock()
}
```

2. Run `make test`

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
