### PR TITLE
[YUNIKORN-2559] DATA RACE: EventStore.Store() and Context.PublishEvents()

### DIFF
--- a/pkg/events/event_store.go
+++ b/pkg/events/event_store.go
@@ -81,14 +81,6 @@ func (es *EventStore) CollectEvents() []*si.EventRecord {
 	return messages
 }
 
-// test only
-func (es *EventStore) CollectInternalEvents(idx uint64) []*si.EventRecord {
-	es.RLock()
-	defer es.RUnlock()
-	messages := es.events[:idx]
-	return messages
-}
-
 func (es *EventStore) CountStoredEvents() uint64 {
 	es.RLock()
 	defer es.RUnlock()

--- a/pkg/events/event_store.go
+++ b/pkg/events/event_store.go
@@ -43,8 +43,9 @@ type EventStore struct {
 
 func newEventStore(size uint64) *EventStore {
 	return &EventStore{
-		events: make([]*si.EventRecord, size),
-		size:   size,
+		events:   make([]*si.EventRecord, size),
+		size:     size,
+		lastSize: size,
 	}
 }
 
@@ -77,6 +78,14 @@ func (es *EventStore) CollectEvents() []*si.EventRecord {
 	es.lastSize = es.size
 
 	metrics.GetEventMetrics().AddEventsCollected(len(messages))
+	return messages
+}
+
+// test only
+func (es *EventStore) CollectInternalEvents(idx uint64) []*si.EventRecord {
+	es.RLock()
+	defer es.RUnlock()
+	messages := es.events[:idx]
 	return messages
 }
 

--- a/pkg/events/event_store.go
+++ b/pkg/events/event_store.go
@@ -66,7 +66,9 @@ func (es *EventStore) CollectEvents() []*si.EventRecord {
 	es.Lock()
 	defer es.Unlock()
 
-	messages := es.events[:es.idx]
+	messages := make([]*si.EventRecord, len(es.events[:es.idx]))
+	copy(messages, es.events[:es.idx])
+
 	if es.size != es.lastSize {
 		log.Log(log.Events).Info("Resizing event store", zap.Uint64("last", es.lastSize), zap.Uint64("new", es.size))
 		es.events = make([]*si.EventRecord, es.size)

--- a/pkg/events/event_store_test.go
+++ b/pkg/events/event_store_test.go
@@ -57,13 +57,12 @@ func TestStoreAndRetrieve(t *testing.T) {
 	assert.DeepEqual(t, records[1], event2, cmpopts.IgnoreUnexported(si.EventRecord{}))
 
 	// ensure that the underlying array of the return slice of CollectEvents() isn't the same as the one in EventStore.events
-	newSliceData := unsafe.SliceData(records) // pointer to underlying array of the return slice of EventStore.CollectEvents()
-	internalEvents := store.events[:2]
-	internalSliceData := unsafe.SliceData(internalEvents) // pointer to underlying array of EventStore.events
+	newSliceData := unsafe.SliceData(records)           // pointer to underlying array of the return slice of EventStore.CollectEvents()
+	internalSliceData := unsafe.SliceData(store.events) // pointer to underlying array of EventStore.events
 	assert.Check(t, newSliceData != internalSliceData)
 
 	// ensure modify EventStore.events won't affect the return slice of store.CollectEvents()
-	internalEvents[0] = event2
+	store.events[0] = event2
 	assert.DeepEqual(t, records[0], event1, cmpopts.IgnoreUnexported(si.EventRecord{}))
 
 	// calling CollectEvents erases the eventChannel map

--- a/pkg/events/event_store_test.go
+++ b/pkg/events/event_store_test.go
@@ -58,7 +58,7 @@ func TestStoreAndRetrieve(t *testing.T) {
 
 	// ensure that the underlying array of the return slice of CollectEvents() isn't the same as the one in EventStore.events
 	newSliceData := unsafe.SliceData(records) // pointer to underlying array of the return slice of EventStore.CollectEvents()
-	internalEvents := store.CollectInternalEvents(2)
+	internalEvents := store.events[:2]
 	internalSliceData := unsafe.SliceData(internalEvents) // pointer to underlying array of EventStore.events
 	assert.Check(t, newSliceData != internalSliceData)
 

--- a/pkg/events/event_store_test.go
+++ b/pkg/events/event_store_test.go
@@ -90,6 +90,13 @@ func TestStoreWithLimitedSize(t *testing.T) {
 
 func TestSetStoreSize(t *testing.T) {
 	store := newEventStore(5)
+
+	// validate that store.CollectEvents() doesn't create a new slice for store.events if the store size remain unchanged after EventStore is initialized.
+	oldSliceData := unsafe.SliceData(store.events)
+	store.CollectEvents()
+	newSliceData := unsafe.SliceData(store.events)
+	assert.Check(t, oldSliceData == newSliceData)
+
 	// store 5 events
 	for i := 0; i < 5; i++ {
 		store.Store(&si.EventRecord{
@@ -109,4 +116,8 @@ func TestSetStoreSize(t *testing.T) {
 	events := store.CollectEvents()
 	assert.Equal(t, 5, len(events))
 	assert.Equal(t, 3, len(store.events))
+
+	// validate that store.CollectEvents() create a new slice for store.events after the store size has changed
+	newSliceData = unsafe.SliceData(store.events)
+	assert.Check(t, oldSliceData != newSliceData)
 }


### PR DESCRIPTION
### What is this PR for?
Fix the racing issue.
-  Return a new []*si.EventRecord in EventStore.CollectEvents() instead of reference of EventStore.events



### What type of PR is it?
* [x] - Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2559

### How should this be tested?
Run make test in shim.

### Screenshots (if appropriate)
NA

### Questions:
NA
