### PR TITLE
[YUNIKORN-2482] Failure to set template does not return error

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -351,7 +351,7 @@ func (sq *Queue) applyConf(conf configs.QueueConfig) error {
 
 	if !sq.isLeaf {
 		if err = sq.setTemplate(conf.ChildTemplate); err != nil {
-			return nil
+			return err
 		}
 	}
 

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -2062,6 +2062,18 @@ func TestApplyConf(t *testing.T) {
 	err = errQueue.ApplyConf(errConf2)
 	assert.ErrorContains(t, err, "multiple spaces found in ACL")
 
+	// wrong ChildTemplate
+	errConf3 := configs.QueueConfig{
+		Parent: true,
+		ChildTemplate: configs.ChildTemplate{
+			Resources: configs.Resources{
+				Guaranteed: map[string]string{"wrong template": "-100"},
+			},
+		},
+	}
+	err = errQueue.ApplyConf(errConf3)
+	assert.ErrorContains(t, err, "invalid quantity")
+
 	// isManaged is changed from unmanaged to managed
 	childConf := configs.QueueConfig{}
 


### PR DESCRIPTION
### What is this PR for?
The update of setting a template on a parent could fail if the template is not correct. The error is swallowed and a success is returned but the update of the queue has not finished correctly:  
*Queue.applyConf()
```go
if !sq.isLeaf {
    if err = sq.setTemplate(conf.ChildTemplate); err != nil {
       return nil
    }
} 
```
I also add tests to make sure we do not regress.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2482 

### How should this be tested?

```
make test
```

### Screenshots (if appropriate)
N/A

### Questions:
N/A
