### PR TITLE
[YUNIKORN-2551] Extract buildRules function from AppPlacementManager

### DIFF
--- a/pkg/scheduler/placement/placement.go
+++ b/pkg/scheduler/placement/placement.go
@@ -67,7 +67,7 @@ func (m *AppPlacementManager) UpdateRules(rules []configs.PlacementRule) error {
 func (m *AppPlacementManager) initialise(rules []configs.PlacementRule) error {
 	log.Log(log.Config).Info("Building new rule list for placement manager")
 	// build temp list from new config
-	tempRules, err := m.buildRules(rules)
+	tempRules, err := buildRules(rules)
 	if err != nil {
 		return err
 	}
@@ -83,33 +83,6 @@ func (m *AppPlacementManager) initialise(rules []configs.PlacementRule) error {
 			zap.String("ruleName", m.rules[rule].getName()))
 	}
 	return nil
-}
-
-// Build the rule set based on the config.
-// If the rule set is correct and can be used the new set is returned.
-// If any error is encountered a nil array is returned and the error set
-func (m *AppPlacementManager) buildRules(rules []configs.PlacementRule) ([]rule, error) {
-	// empty list should result in a single "provided" rule
-	if len(rules) == 0 {
-		log.Log(log.Config).Info("Placement manager configured without rules: using implicit provided rule")
-		rules = []configs.PlacementRule{{
-			Name:   types.Provided,
-			Create: false,
-		}}
-	}
-	// build temp list from new config
-	var newRules []rule
-	for _, conf := range rules {
-		buildRule, err := newRule(conf)
-		if err != nil {
-			return nil, err
-		}
-		newRules = append(newRules, buildRule)
-	}
-	// ensure the recovery rule is always present
-	newRules = append(newRules, &recoveryRule{})
-
-	return newRules, nil
 }
 
 func (m *AppPlacementManager) PlaceApplication(app *objects.Application) error {
@@ -199,4 +172,31 @@ func (m *AppPlacementManager) PlaceApplication(app *objects.Application) error {
 	// Add the queue into the application, overriding what was submitted
 	app.SetQueuePath(queueName)
 	return nil
+}
+
+// Build the rule set based on the config.
+// If the rule set is correct and can be used the new set is returned.
+// If any error is encountered a nil array is returned and the error set
+func buildRules(rules []configs.PlacementRule) ([]rule, error) {
+	// empty list should result in a single "provided" rule
+	if len(rules) == 0 {
+		log.Log(log.Config).Info("Placement manager configured without rules: using implicit provided rule")
+		rules = []configs.PlacementRule{{
+			Name:   types.Provided,
+			Create: false,
+		}}
+	}
+	// build temp list from new config
+	var newRules []rule
+	for _, conf := range rules {
+		buildRule, err := newRule(conf)
+		if err != nil {
+			return nil, err
+		}
+		newRules = append(newRules, buildRule)
+	}
+	// ensure the recovery rule is always present
+	newRules = append(newRules, &recoveryRule{})
+
+	return newRules, nil
 }

--- a/pkg/scheduler/placement/placement_test.go
+++ b/pkg/scheduler/placement/placement_test.go
@@ -102,11 +102,10 @@ func TestManagerUpdate(t *testing.T) {
 
 func TestManagerBuildRule(t *testing.T) {
 	// basic with 1 rule
-	man := NewPlacementManager(nil, queueFunc)
 	rules := []configs.PlacementRule{
 		{Name: "test"},
 	}
-	ruleObjs, err := man.buildRules(rules)
+	ruleObjs, err := buildRules(rules)
 	if err != nil {
 		t.Errorf("test rule build should not have failed, err: %v", err)
 	}
@@ -122,7 +121,7 @@ func TestManagerBuildRule(t *testing.T) {
 			},
 		},
 	}
-	ruleObjs, err = man.buildRules(rules)
+	ruleObjs, err = buildRules(rules)
 	if err != nil || len(ruleObjs) != 2 {
 		t.Errorf("test rule build should not have failed and created 2 top level rule, err: %v, rules: %v", err, ruleObjs)
 	} else {
@@ -137,7 +136,7 @@ func TestManagerBuildRule(t *testing.T) {
 		{Name: "user"},
 		{Name: "test"},
 	}
-	ruleObjs, err = man.buildRules(rules)
+	ruleObjs, err = buildRules(rules)
 	if err != nil || len(ruleObjs) != 3 {
 		t.Errorf("rule build should not have failed and created 3 rules, err: %v, rules: %v", err, ruleObjs)
 	} else if ruleObjs[0].getName() != "user" || ruleObjs[1].getName() != "test" || ruleObjs[2].getName() != "recovery" {


### PR DESCRIPTION
### What is this PR for?
The `buildRules` function has been extracted from `AppPlacementManager` since it's not using any  fields of `AppPlacementManager`

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
N/A

### What is the Jira issue?
[[YUNIKORN-2551]](https://issues.apache.org/jira/browse/YUNIKORN-2551)

### How should this be tested?
It passed all the tests by using `make test`

### Screenshots (if appropriate)
N/A

### Questions:
N/A