### PR TITLE
[YUNIKORN-2572]delete unused conditional

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -95,9 +95,6 @@ func NewResourceFromConf(configMap map[string]string) (*Resource, error) {
 		if err != nil {
 			return nil, err
 		}
-		if intValue < 0 {
-			return nil, fmt.Errorf("negative resources not permitted: %v", configMap)
-		}
 		res.Resources[key] = intValue
 	}
 	return res, nil

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -119,6 +119,7 @@ func TestNewResourceFromConf(t *testing.T) {
 		{"vcore multipliers with \"m\"", map[string]string{"vcore": "10m"}, expectedvalues{true, 1, "map[vcore:10]"}},
 		{"failure case: parse error", map[string]string{"fail": "xx"}, expectedvalues{false, 0, ""}},
 		{"negative resource", map[string]string{"memory": "-15"}, expectedvalues{false, 0, ""}},
+		{"nagative resource for vcore", map[string]string{"vcore": "-15"}, expectedvalues{false, 0, "invalid quantity"}},
 		{"\"milli\" used for anything other than vcore", map[string]string{"memory": "10m"}, expectedvalues{false, 0, ""}},
 	}
 	for _, tt := range tests {

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -119,7 +119,7 @@ func TestNewResourceFromConf(t *testing.T) {
 		{"vcore multipliers with \"m\"", map[string]string{"vcore": "10m"}, expectedvalues{true, 1, "map[vcore:10]"}},
 		{"failure case: parse error", map[string]string{"fail": "xx"}, expectedvalues{false, 0, ""}},
 		{"negative resource", map[string]string{"memory": "-15"}, expectedvalues{false, 0, ""}},
-		{"nagative resource for vcore", map[string]string{"vcore": "-15"}, expectedvalues{false, 0, "invalid quantity"}},
+		{"nagative resource for vcore", map[string]string{"vcore": "-15"}, expectedvalues{false, 0, ""}},
 		{"\"milli\" used for anything other than vcore", map[string]string{"memory": "10m"}, expectedvalues{false, 0, ""}},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### What is this PR for?
This [conditional](https://github.com/apache/yunikorn-core/blob/55e9fe650760bdf30d27a7ecf85b34d5f96c492f/pkg/common/resources/resources.go#L98) is not used because intValue will never be negative, since it's before filtered by [regular expression](https://github.com/apache/yunikorn-core/blob/55e9fe650760bdf30d27a7ecf85b34d5f96c492f/pkg/common/resources/quantity.go#L38).
```go
if intValue < 0 {
            return nil, fmt.Errorf("negative resources not permitted: %v", configMap)
}
```


Thus, it will never omit error about negative resource, instead it will raise invalid quantity error at https://github.com/apache/yunikorn-core/blob/55e9fe650760bdf30d27a7ecf85b34d5f96c492f/pkg/common/resources/quantity.go#L74.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2572

### How should this be tested?
```sh
make test
```

### Screenshots (if appropriate)

### Questions:
N/A
