### PR TITLE
[YUNIKORN-2181] Remove Named Returns in checkQueueHierarchyForPlacement

### DIFF
--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -356,24 +356,20 @@ func checkPlacementRules(partition *PartitionConfig) error {
 	return nil
 }
 
-func checkQueueHierarchyForPlacement(path []string, create, hasDynamicPart bool, conf []QueueConfig, parentConf *QueueConfig) (result placementPathCheckResult, lastQueueName string) {
+func checkQueueHierarchyForPlacement(path []string, create, hasDynamicPart bool, conf []QueueConfig, parentConf *QueueConfig) (placementPathCheckResult, string) {
 	queueName := path[0]
-	lastQueueName = ""
 
 	// no more queues in the configuration
 	if len(conf) == 0 {
 		if !parentConf.Parent {
 			// path in the hierarchy is shorter, but the last queue is a leaf
-			result = errLastQueueLeaf
-			lastQueueName = parentConf.Name
-			return
+			return errLastQueueLeaf, parentConf.Name
 		}
 		if !create {
-			result = errNonExistingQueue
-			return
+			return errNonExistingQueue, ""
 		}
-		result = placementOK
-		return
+
+		return placementOK, ""
 	}
 
 	var queueConf *QueueConfig
@@ -388,11 +384,10 @@ func checkQueueHierarchyForPlacement(path []string, create, hasDynamicPart bool,
 	// queue not found on this level
 	if queueConf == nil {
 		if !create {
-			result = errNonExistingQueue
-			return
+			return errNonExistingQueue, ""
 		}
-		result = placementOK
-		return
+
+		return placementOK, ""
 	}
 
 	if len(path) == 1 {
@@ -400,18 +395,16 @@ func checkQueueHierarchyForPlacement(path []string, create, hasDynamicPart bool,
 			// the "fixed" rule is followed by other rules like tag, user, etc. (root.dev.<user>),
 			// which means that the "fixed" part must point to a parent
 			if queueConf.Parent {
-				result = placementOK
-				return
+				return placementOK, ""
 			}
-			result = errQueueNotLeaf
-			return
+
+			return errQueueNotLeaf, ""
 		}
 		if queueConf.Parent {
-			result = errQueueNotLeaf
-			return
+			return errQueueNotLeaf, ""
 		}
-		result = placementOK
-		return
+
+		return placementOK, ""
 	}
 
 	path = path[1:]

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -364,7 +364,8 @@ func checkQueueHierarchyForPlacement(path []string, create, hasDynamicPart bool,
 	if len(conf) == 0 {
 		if !parentConf.Parent {
 			// path in the hierarchy is shorter, but the last queue is a leaf
-			return errLastQueueLeaf, parentConf.Name
+			lastQueueName = parentConf.Name
+			return errLastQueueLeaf, lastQueueName
 		}
 		if !create {
 			return errNonExistingQueue, lastQueueName

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -358,6 +358,7 @@ func checkPlacementRules(partition *PartitionConfig) error {
 
 func checkQueueHierarchyForPlacement(path []string, create, hasDynamicPart bool, conf []QueueConfig, parentConf *QueueConfig) (placementPathCheckResult, string) {
 	queueName := path[0]
+	lastQueueName := ""
 
 	// no more queues in the configuration
 	if len(conf) == 0 {
@@ -366,10 +367,10 @@ func checkQueueHierarchyForPlacement(path []string, create, hasDynamicPart bool,
 			return errLastQueueLeaf, parentConf.Name
 		}
 		if !create {
-			return errNonExistingQueue, ""
+			return errNonExistingQueue, lastQueueName
 		}
 
-		return placementOK, ""
+		return placementOK, lastQueueName
 	}
 
 	var queueConf *QueueConfig
@@ -384,10 +385,10 @@ func checkQueueHierarchyForPlacement(path []string, create, hasDynamicPart bool,
 	// queue not found on this level
 	if queueConf == nil {
 		if !create {
-			return errNonExistingQueue, ""
+			return errNonExistingQueue, lastQueueName
 		}
 
-		return placementOK, ""
+		return placementOK, lastQueueName
 	}
 
 	if len(path) == 1 {
@@ -395,16 +396,16 @@ func checkQueueHierarchyForPlacement(path []string, create, hasDynamicPart bool,
 			// the "fixed" rule is followed by other rules like tag, user, etc. (root.dev.<user>),
 			// which means that the "fixed" part must point to a parent
 			if queueConf.Parent {
-				return placementOK, ""
+				return placementOK, lastQueueName
 			}
 
-			return errQueueNotLeaf, ""
+			return errQueueNotLeaf, lastQueueName
 		}
 		if queueConf.Parent {
-			return errQueueNotLeaf, ""
+			return errQueueNotLeaf, lastQueueName
 		}
 
-		return placementOK, ""
+		return placementOK, lastQueueName
 	}
 
 	path = path[1:]


### PR DESCRIPTION
### What is this PR for?

This change removes all named returns  in `checkQueueHierarchyForPlacement` and return the results directly.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-2181

### How should this be tested?

Run `make test` locally and all tests are passed

### Screenshots (if appropriate)

N/A

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
