### PR TITLE
[YUNIKORN-2541] Sync scheduler-interface and golang.org/x/crypto version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ module github.com/apache/yunikorn-core
 go 1.21
 
 require (
-	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240415160614-c40fbd225716
+	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240422062544-b70081933c38
 	github.com/google/btree v1.1.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
@@ -57,7 +57,7 @@ require (
 
 replace (
 	github.com/petermattis/goid => github.com/petermattis/goid v0.0.0-20240327183114-c42a807a84ba
-	golang.org/x/crypto => golang.org/x/crypto v0.19.0
+	golang.org/x/crypto => golang.org/x/crypto v0.21.0
 	golang.org/x/net => golang.org/x/net v0.23.0
 	golang.org/x/sys => golang.org/x/sys v0.18.0
 	golang.org/x/text => golang.org/x/text v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240415160614-c40fbd225716 h1:lSK2WFoD2ANMm7HYh0hUxRQd8DGhT1B9BN+VzhkCSBc=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240415160614-c40fbd225716/go.mod h1:SuKZcz1JFA4QVVMxeMZAsFMz4xG2XqTHT8FWoJnuHFQ=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240422062544-b70081933c38 h1:/02cjuc0xpQPZIGezL45QZ6muGI7dfesu9l38U9fbx0=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240422062544-b70081933c38/go.mod h1:WuHJpVk34t8N5+1ErYGj/5Qq33/cRzL4YtuoAsbMtWc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=


### PR DESCRIPTION
### What is this PR for?
After k8shim updated golang.org/x/net module (https://github.com/apache/yunikorn-k8shim/pull/822), the golang.org/x/crypto module is automatically updated by `go mod tidy`.
Because both the scheduler-interface and core projects also use this module, these two projects should be updated too.
The scheduler-interface has already been updated, so this PR aims to update the versions of both the scheduler-interface and golang.org/x/crypto module.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - update k8shim 

### What is the Jira issue?
[YUNIKORN-2541](https://issues.apache.org/jira/browse/YUNIKORN-2541/)

### How should this be tested?
N/A

### Screenshots (if appropriate)
N/A

### Questions:
N/A
