### PR TITLE
[YUNIKORN-2574] totalPartitionResource should not be mutated with AddTo/SubFrom

### DIFF
--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -580,7 +580,7 @@ func (pc *PartitionContext) updatePartitionResource(delta *resources.Resource) {
 		if pc.totalPartitionResource == nil {
 			pc.totalPartitionResource = delta.Clone()
 		} else {
-			pc.totalPartitionResource.AddTo(delta)
+			pc.totalPartitionResource = resources.Add(pc.totalPartitionResource, delta)
 		}
 		pc.root.SetMaxResource(pc.totalPartitionResource)
 	}
@@ -608,7 +608,7 @@ func (pc *PartitionContext) addNodeResources(node *objects.Node) {
 	if pc.totalPartitionResource == nil {
 		pc.totalPartitionResource = node.GetCapacity().Clone()
 	} else {
-		pc.totalPartitionResource.AddTo(node.GetCapacity())
+		pc.totalPartitionResource = resources.Add(pc.totalPartitionResource, node.GetCapacity())
 	}
 	pc.root.SetMaxResource(pc.totalPartitionResource)
 	log.Log(log.SchedPartition).Info("Updated available resources from added node",
@@ -641,7 +641,7 @@ func (pc *PartitionContext) removeNodeResources(node *objects.Node) {
 	pc.Lock()
 	defer pc.Unlock()
 	// cleanup the available resources, partition resources cannot be nil at this point
-	pc.totalPartitionResource.SubFrom(node.GetCapacity())
+	pc.totalPartitionResource = resources.Sub(pc.totalPartitionResource, node.GetCapacity())
 	pc.root.SetMaxResource(pc.totalPartitionResource)
 	log.Log(log.SchedPartition).Info("Updated available resources from removed node",
 		zap.String("partitionName", pc.Name),

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -582,7 +582,7 @@ func (pc *PartitionContext) updatePartitionResource(delta *resources.Resource) {
 		} else {
 			pc.totalPartitionResource.AddTo(delta)
 		}
-		pc.root.SetMaxResource(pc.totalPartitionResource)
+		pc.root.SetMaxResource(pc.totalPartitionResource.Clone())
 	}
 }
 
@@ -610,7 +610,7 @@ func (pc *PartitionContext) addNodeResources(node *objects.Node) {
 	} else {
 		pc.totalPartitionResource.AddTo(node.GetCapacity())
 	}
-	pc.root.SetMaxResource(pc.totalPartitionResource)
+	pc.root.SetMaxResource(pc.totalPartitionResource.Clone())
 	log.Log(log.SchedPartition).Info("Updated available resources from added node",
 		zap.String("partitionName", pc.Name),
 		zap.String("nodeID", node.NodeID),
@@ -642,7 +642,7 @@ func (pc *PartitionContext) removeNodeResources(node *objects.Node) {
 	defer pc.Unlock()
 	// cleanup the available resources, partition resources cannot be nil at this point
 	pc.totalPartitionResource.SubFrom(node.GetCapacity())
-	pc.root.SetMaxResource(pc.totalPartitionResource)
+	pc.root.SetMaxResource(pc.totalPartitionResource.Clone())
 	log.Log(log.SchedPartition).Info("Updated available resources from removed node",
 		zap.String("partitionName", pc.Name),
 		zap.String("nodeID", node.NodeID),
@@ -1013,7 +1013,7 @@ func (pc *PartitionContext) GetTotalPartitionResource() *resources.Resource {
 	pc.RLock()
 	defer pc.RUnlock()
 
-	return pc.totalPartitionResource
+	return pc.totalPartitionResource.Clone()
 }
 
 func (pc *PartitionContext) GetAllocatedResource() *resources.Resource {

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -580,7 +580,7 @@ func (pc *PartitionContext) updatePartitionResource(delta *resources.Resource) {
 		if pc.totalPartitionResource == nil {
 			pc.totalPartitionResource = delta.Clone()
 		} else {
-			pc.totalPartitionResource = resources.Add(pc.totalPartitionResource, delta)
+			pc.totalPartitionResource.AddTo(delta)
 		}
 		pc.root.SetMaxResource(pc.totalPartitionResource)
 	}
@@ -608,7 +608,7 @@ func (pc *PartitionContext) addNodeResources(node *objects.Node) {
 	if pc.totalPartitionResource == nil {
 		pc.totalPartitionResource = node.GetCapacity().Clone()
 	} else {
-		pc.totalPartitionResource = resources.Add(pc.totalPartitionResource, node.GetCapacity())
+		pc.totalPartitionResource.AddTo(node.GetCapacity())
 	}
 	pc.root.SetMaxResource(pc.totalPartitionResource)
 	log.Log(log.SchedPartition).Info("Updated available resources from added node",
@@ -641,7 +641,7 @@ func (pc *PartitionContext) removeNodeResources(node *objects.Node) {
 	pc.Lock()
 	defer pc.Unlock()
 	// cleanup the available resources, partition resources cannot be nil at this point
-	pc.totalPartitionResource = resources.Sub(pc.totalPartitionResource, node.GetCapacity())
+	pc.totalPartitionResource.SubFrom(node.GetCapacity())
 	pc.root.SetMaxResource(pc.totalPartitionResource)
 	log.Log(log.SchedPartition).Info("Updated available resources from removed node",
 		zap.String("partitionName", pc.Name),

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -582,7 +582,7 @@ func (pc *PartitionContext) updatePartitionResource(delta *resources.Resource) {
 		} else {
 			pc.totalPartitionResource.AddTo(delta)
 		}
-		pc.root.SetMaxResource(pc.totalPartitionResource.Clone())
+		pc.root.SetMaxResource(pc.totalPartitionResource)
 	}
 }
 
@@ -610,7 +610,7 @@ func (pc *PartitionContext) addNodeResources(node *objects.Node) {
 	} else {
 		pc.totalPartitionResource.AddTo(node.GetCapacity())
 	}
-	pc.root.SetMaxResource(pc.totalPartitionResource.Clone())
+	pc.root.SetMaxResource(pc.totalPartitionResource)
 	log.Log(log.SchedPartition).Info("Updated available resources from added node",
 		zap.String("partitionName", pc.Name),
 		zap.String("nodeID", node.NodeID),
@@ -642,7 +642,7 @@ func (pc *PartitionContext) removeNodeResources(node *objects.Node) {
 	defer pc.Unlock()
 	// cleanup the available resources, partition resources cannot be nil at this point
 	pc.totalPartitionResource.SubFrom(node.GetCapacity())
-	pc.root.SetMaxResource(pc.totalPartitionResource.Clone())
+	pc.root.SetMaxResource(pc.totalPartitionResource)
 	log.Log(log.SchedPartition).Info("Updated available resources from removed node",
 		zap.String("partitionName", pc.Name),
 		zap.String("nodeID", node.NodeID),


### PR DESCRIPTION
### What is this PR for?
Do not mutate the `totalPartitionResource` field with `AddTo()` and `SubFrom()` methods. These should be only used for local variables for quick, in-place updates. Struct fields that are often read by other goroutines must use the immutable-based approach (eg. `resources.Add()`, `resources.Sub()`, etc).

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2574

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
