### PR TITLE
[YUNIKORN-2587] Core: Convert AllocationID to AllocationKey

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ module github.com/apache/yunikorn-core
 go 1.21
 
 require (
-	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240423191701-8c98b1604a7a
+	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240425182941-07f5695119a1
 	github.com/google/btree v1.1.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240423191701-8c98b1604a7a h1:H978zsTL2FvbRFnySO83DOFLO33PwHWFdmHvMoSVXsc=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240423191701-8c98b1604a7a/go.mod h1:WuHJpVk34t8N5+1ErYGj/5Qq33/cRzL4YtuoAsbMtWc=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240425182941-07f5695119a1 h1:v4J9L3MlW8BQfYnbq6FV2l3uyay3SqMS2Ffpo+SFat4=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240425182941-07f5695119a1/go.mod h1:WuHJpVk34t8N5+1ErYGj/5Qq33/cRzL4YtuoAsbMtWc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/pkg/examples/simple_example.go
+++ b/pkg/examples/simple_example.go
@@ -41,7 +41,7 @@ func (m *exampleRMCallback) UpdateAllocation(response *si.AllocationResponse) er
 	m.Lock()
 	defer m.Unlock()
 	for _, alloc := range response.New {
-		m.Allocations[alloc.AllocationID] = alloc
+		m.Allocations[alloc.AllocationKey] = alloc
 		if val, ok := m.nodeAllocations[alloc.NodeID]; ok {
 			val = append(val, alloc)
 			m.nodeAllocations[alloc.NodeID] = val
@@ -53,7 +53,7 @@ func (m *exampleRMCallback) UpdateAllocation(response *si.AllocationResponse) er
 	}
 
 	for _, alloc := range response.Released {
-		delete(m.Allocations, alloc.AllocationID)
+		delete(m.Allocations, alloc.AllocationKey)
 	}
 	return nil
 }

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -143,7 +143,7 @@ func (cc *ClusterContext) schedule() bool {
 			metrics.GetSchedulerMetrics().ObserveSchedulingLatency(schedulingStart)
 			if alloc.GetResult() == objects.Replaced {
 				// communicate the removal to the RM
-				cc.notifyRMAllocationReleased(psc.RmID, alloc.GetReleasesClone(), si.TerminationType_PLACEHOLDER_REPLACED, "replacing allocationID: "+alloc.GetAllocationID())
+				cc.notifyRMAllocationReleased(psc.RmID, alloc.GetReleasesClone(), si.TerminationType_PLACEHOLDER_REPLACED, "replacing allocationKey: "+alloc.GetAllocationKey())
 			} else {
 				cc.notifyRMNewAllocation(psc.RmID, alloc)
 			}
@@ -898,7 +898,6 @@ func (cc *ClusterContext) notifyRMAllocationReleased(rmID string, released []*ob
 		releaseEvent.ReleasedAllocations = append(releaseEvent.ReleasedAllocations, &si.AllocationRelease{
 			ApplicationID:   alloc.GetApplicationID(),
 			PartitionName:   alloc.GetPartitionName(),
-			AllocationID:    alloc.GetAllocationID(),
 			TerminationType: terminationType,
 			Message:         message,
 			AllocationKey:   alloc.GetAllocationKey(),

--- a/pkg/scheduler/health_checker.go
+++ b/pkg/scheduler/health_checker.go
@@ -335,7 +335,7 @@ func checkAppAllocations(app *objects.Application, nodes objects.NodeCollection)
 	orphanAllocationsOnApp := make([]*objects.Allocation, 0)
 	for _, alloc := range app.GetAllAllocations() {
 		if node := nodes.GetNode(alloc.GetNodeID()); node != nil {
-			if node.GetAllocation(alloc.GetAllocationID()) == nil {
+			if node.GetAllocation(alloc.GetAllocationKey()) == nil {
 				orphanAllocationsOnApp = append(orphanAllocationsOnApp, alloc)
 			}
 		} else {

--- a/pkg/scheduler/objects/allocation_test.go
+++ b/pkg/scheduler/objects/allocation_test.go
@@ -53,7 +53,7 @@ func TestNewAlloc(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("NewAllocation create failed while it should not")
 	}
-	assert.Equal(t, alloc.GetAllocationID(), "ask-1")
+	assert.Equal(t, alloc.GetAllocationKey(), "ask-1")
 	assert.Equal(t, alloc.GetResult(), Allocated, "New alloc should default to result Allocated")
 	assert.Assert(t, resources.Equals(alloc.GetAllocatedResource(), res), "Allocated resource not set correctly")
 	assert.Assert(t, !alloc.IsPlaceholder(), "ask should not have been a placeholder")
@@ -62,7 +62,7 @@ func TestNewAlloc(t *testing.T) {
 	alloc.SetInstanceType(instType1)
 	assert.Equal(t, alloc.GetInstanceType(), instType1, "Instance type not set as expected")
 	allocStr := alloc.String()
-	expected := "applicationID=app-1, allocationID=ask-1, allocationKey=ask-1, Node=node-1, result=Allocated"
+	expected := "applicationID=app-1, allocationKey=ask-1, Node=node-1, result=Allocated"
 	assert.Equal(t, allocStr, expected, "Strings should have been equal")
 	assert.Assert(t, !alloc.IsPlaceholderUsed(), fmt.Sprintf("Alloc should not be placeholder replacement by default: got %t, expected %t", alloc.IsPlaceholderUsed(), false))
 	created := alloc.GetCreateTime()
@@ -90,10 +90,9 @@ func TestNewReservedAlloc(t *testing.T) {
 		t.Fatal("NewReservedAllocation create failed while it should not")
 	}
 	assert.Equal(t, alloc.GetResult(), Reserved, "NewReservedAlloc should have Reserved result")
-	assert.Equal(t, alloc.GetAllocationID(), "", "NewReservedAlloc should not have allocationID")
 	assert.Assert(t, resources.Equals(alloc.GetAllocatedResource(), res), "Allocated resource not set correctly")
 	allocStr := alloc.String()
-	expected := "applicationID=app-1, allocationID=N/A, allocationKey=ask-1, Node=node-1, result=Reserved"
+	expected := "applicationID=app-1, allocationKey=ask-1, Node=node-1, result=Reserved"
 	assert.Equal(t, allocStr, expected, "Strings should have been equal")
 }
 
@@ -106,10 +105,9 @@ func TestNewUnreservedAlloc(t *testing.T) {
 		t.Fatal("NewReservedAllocation create failed while it should not")
 	}
 	assert.Equal(t, alloc.GetResult(), Unreserved, "NewReservedAlloc should have Reserved result")
-	assert.Equal(t, alloc.GetAllocationID(), "", "NewReservedAlloc should not have allocationID")
 	assert.Assert(t, resources.Equals(alloc.GetAllocatedResource(), res), "Allocated resource not set correctly")
 	allocStr := alloc.String()
-	expected := "applicationID=app-1, allocationID=N/A, allocationKey=ask-1, Node=node-1, result=Unreserved"
+	expected := "applicationID=app-1, allocationKey=ask-1, Node=node-1, result=Unreserved"
 	assert.Equal(t, allocStr, expected, "Strings should have been equal")
 }
 
@@ -131,7 +129,6 @@ func TestSIFromAlloc(t *testing.T) {
 	assert.NilError(t, err, "Resource creation failed")
 	expectedSI := &si.Allocation{
 		AllocationKey:    "ask-1",
-		AllocationID:     "ask-1",
 		NodeID:           "node-1",
 		ApplicationID:    "app-1",
 		ResourcePerAlloc: res.ToProto(),
@@ -152,7 +149,6 @@ func TestSIFromAlloc(t *testing.T) {
 
 	allocSI := alloc.NewSIFromAllocation()
 	assert.Equal(t, expectedSI.AllocationKey, allocSI.AllocationKey, "wrong AllocationKey")
-	assert.Equal(t, expectedSI.AllocationID, allocSI.AllocationID, "wrong AllocationID")
 	assert.Equal(t, expectedSI.NodeID, allocSI.NodeID, "wrong NodeID")
 	assert.Equal(t, expectedSI.ApplicationID, allocSI.ApplicationID, "wrong ApplicationID")
 	assert.Check(t, allocSI.Originator, "originator flag should be set")
@@ -186,7 +182,6 @@ func TestNewAllocFromSI(t *testing.T) {
 	tags[siCommon.CreationTime] = strconv.FormatInt(past, 10)
 	allocSI := &si.Allocation{
 		AllocationKey:    "ask-1",
-		AllocationID:     "test-allocationid",
 		NodeID:           "node-1",
 		ApplicationID:    "app-1",
 		ResourcePerAlloc: res.ToProto(),

--- a/pkg/scheduler/objects/application_events.go
+++ b/pkg/scheduler/objects/application_events.go
@@ -44,7 +44,7 @@ func (evt *applicationEvents) sendNewAllocationEvent(alloc *Allocation) {
 	if !evt.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-	event := events.CreateAppEventRecord(evt.app.ApplicationID, common.Empty, alloc.GetAllocationID(), si.EventRecord_ADD, si.EventRecord_APP_ALLOC, alloc.GetAllocatedResource())
+	event := events.CreateAppEventRecord(evt.app.ApplicationID, common.Empty, alloc.GetAllocationKey(), si.EventRecord_ADD, si.EventRecord_APP_ALLOC, alloc.GetAllocatedResource())
 	evt.eventSystem.AddEvent(event)
 }
 
@@ -75,7 +75,7 @@ func (evt *applicationEvents) sendRemoveAllocationEvent(alloc *Allocation, termi
 		eventChangeDetail = si.EventRecord_ALLOC_REPLACED
 	}
 
-	event := events.CreateAppEventRecord(evt.app.ApplicationID, common.Empty, alloc.GetAllocationID(), si.EventRecord_REMOVE, eventChangeDetail, alloc.GetAllocatedResource())
+	event := events.CreateAppEventRecord(evt.app.ApplicationID, common.Empty, alloc.GetAllocationKey(), si.EventRecord_REMOVE, eventChangeDetail, alloc.GetAllocatedResource())
 	evt.eventSystem.AddEvent(event)
 }
 

--- a/pkg/scheduler/objects/application_events_test.go
+++ b/pkg/scheduler/objects/application_events_test.go
@@ -19,8 +19,9 @@
 package objects
 
 import (
-	"gotest.tools/v3/assert"
 	"testing"
+
+	"gotest.tools/v3/assert"
 
 	"github.com/apache/yunikorn-core/pkg/common"
 	"github.com/apache/yunikorn-core/pkg/events/mock"
@@ -84,14 +85,13 @@ func TestSendNewAllocationEvent(t *testing.T) {
 	appEvents.sendNewAllocationEvent(&Allocation{
 		applicationID: appID0,
 		allocationKey: aKey,
-		allocationID:  aAllocationID,
 	})
 	assert.Equal(t, 1, len(eventSystem.Events), "event was not generated")
 	assert.Equal(t, si.EventRecord_APP, eventSystem.Events[0].Type, "event type is not expected")
 	assert.Equal(t, si.EventRecord_ADD, eventSystem.Events[0].EventChangeType, "event change type is not expected")
 	assert.Equal(t, si.EventRecord_APP_ALLOC, eventSystem.Events[0].EventChangeDetail, "event change detail is not expected")
 	assert.Equal(t, appID0, eventSystem.Events[0].ObjectID, "event object id is not expected")
-	assert.Equal(t, aAllocationID, eventSystem.Events[0].ReferenceID, "event reference id is not expected")
+	assert.Equal(t, aKey, eventSystem.Events[0].ReferenceID, "event reference id is not expected")
 	assert.Equal(t, common.Empty, eventSystem.Events[0].Message, "message is not expected")
 }
 
@@ -147,61 +147,61 @@ func TestSendRemoveAllocationEvent(t *testing.T) {
 			name:                 "remove allocation cause of node removal",
 			eventSystemMock:      mock.NewEventSystem(),
 			terminationType:      si.TerminationType_UNKNOWN_TERMINATION_TYPE,
-			allocation:           &Allocation{applicationID: appID0, allocationKey: aKey, allocationID: aAllocationID},
+			allocation:           &Allocation{applicationID: appID0, allocationKey: aKey},
 			expectedEventCnt:     1,
 			expectedType:         si.EventRecord_APP,
 			expectedChangeType:   si.EventRecord_REMOVE,
 			expectedChangeDetail: si.EventRecord_ALLOC_NODEREMOVED,
 			expectedObjectID:     appID0,
-			expectedReferenceID:  aAllocationID,
+			expectedReferenceID:  aKey,
 		},
 		{
 			name:                 "remove allocation cause of resource manager cancel",
 			eventSystemMock:      mock.NewEventSystem(),
 			terminationType:      si.TerminationType_STOPPED_BY_RM,
-			allocation:           &Allocation{applicationID: appID0, allocationKey: aKey, allocationID: aAllocationID},
+			allocation:           &Allocation{applicationID: appID0, allocationKey: aKey},
 			expectedEventCnt:     1,
 			expectedType:         si.EventRecord_APP,
 			expectedChangeType:   si.EventRecord_REMOVE,
 			expectedChangeDetail: si.EventRecord_ALLOC_CANCEL,
 			expectedObjectID:     appID0,
-			expectedReferenceID:  aAllocationID,
+			expectedReferenceID:  aKey,
 		},
 		{
 			name:                 "remove allocation cause of timeout",
 			eventSystemMock:      mock.NewEventSystem(),
 			terminationType:      si.TerminationType_TIMEOUT,
-			allocation:           &Allocation{applicationID: appID0, allocationKey: aKey, allocationID: aAllocationID},
+			allocation:           &Allocation{applicationID: appID0, allocationKey: aKey},
 			expectedEventCnt:     1,
 			expectedType:         si.EventRecord_APP,
 			expectedChangeType:   si.EventRecord_REMOVE,
 			expectedChangeDetail: si.EventRecord_ALLOC_TIMEOUT,
 			expectedObjectID:     appID0,
-			expectedReferenceID:  aAllocationID,
+			expectedReferenceID:  aKey,
 		},
 		{
 			name:                 "remove allocation cause of preemption",
 			eventSystemMock:      mock.NewEventSystem(),
 			terminationType:      si.TerminationType_PREEMPTED_BY_SCHEDULER,
-			allocation:           &Allocation{applicationID: appID0, allocationKey: aKey, allocationID: aAllocationID},
+			allocation:           &Allocation{applicationID: appID0, allocationKey: aKey},
 			expectedEventCnt:     1,
 			expectedType:         si.EventRecord_APP,
 			expectedChangeType:   si.EventRecord_REMOVE,
 			expectedChangeDetail: si.EventRecord_ALLOC_PREEMPT,
 			expectedObjectID:     appID0,
-			expectedReferenceID:  aAllocationID,
+			expectedReferenceID:  aKey,
 		},
 		{
 			name:                 "remove allocation cause of replacement",
 			eventSystemMock:      mock.NewEventSystem(),
 			terminationType:      si.TerminationType_PLACEHOLDER_REPLACED,
-			allocation:           &Allocation{applicationID: appID0, allocationKey: aKey, allocationID: aAllocationID},
+			allocation:           &Allocation{applicationID: appID0, allocationKey: aKey},
 			expectedEventCnt:     1,
 			expectedType:         si.EventRecord_APP,
 			expectedChangeType:   si.EventRecord_REMOVE,
 			expectedChangeDetail: si.EventRecord_ALLOC_REPLACED,
 			expectedObjectID:     appID0,
-			expectedReferenceID:  aAllocationID,
+			expectedReferenceID:  aKey,
 		},
 	}
 	for _, testCase := range testCases {

--- a/pkg/scheduler/objects/node_events.go
+++ b/pkg/scheduler/objects/node_events.go
@@ -48,20 +48,20 @@ func (n *nodeEvents) sendNodeRemovedEvent() {
 	n.eventSystem.AddEvent(event)
 }
 
-func (n *nodeEvents) sendAllocationAddedEvent(allocID string, res *resources.Resource) {
+func (n *nodeEvents) sendAllocationAddedEvent(allocKey string, res *resources.Resource) {
 	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, allocID, si.EventRecord_ADD,
+	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, allocKey, si.EventRecord_ADD,
 		si.EventRecord_NODE_ALLOC, res)
 	n.eventSystem.AddEvent(event)
 }
 
-func (n *nodeEvents) sendAllocationRemovedEvent(allocID string, res *resources.Resource) {
+func (n *nodeEvents) sendAllocationRemovedEvent(allocKey string, res *resources.Resource) {
 	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, allocID, si.EventRecord_REMOVE,
+	event := events.CreateNodeEventRecord(n.node.NodeID, common.Empty, allocKey, si.EventRecord_REMOVE,
 		si.EventRecord_NODE_ALLOC, res)
 	n.eventSystem.AddEvent(event)
 }

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -54,7 +54,7 @@ type Preemptor struct {
 
 	// lazily-populated work structures
 	allocationsByQueue map[string]*QueuePreemptionSnapshot // map of queue snapshots by queue path
-	queueByAlloc       map[string]*QueuePreemptionSnapshot // map of queue snapshots by allocationID
+	queueByAlloc       map[string]*QueuePreemptionSnapshot // map of queue snapshots by allocationKey
 	allocationsByNode  map[string][]*Allocation            // map of allocation by nodeID
 	nodeAvailableMap   map[string]*resources.Resource      // map of available resources by nodeID
 }
@@ -144,7 +144,7 @@ func (p *Preemptor) initWorkingState() {
 	queueByAlloc := make(map[string]*QueuePreemptionSnapshot)
 	nodeAvailableMap := make(map[string]*resources.Resource)
 
-	// build a map from NodeID to allocation and from allocationID to queue capacities
+	// build a map from NodeID to allocation and from allocationKey to queue capacities
 	for _, victims := range p.allocationsByQueue {
 		for _, allocation := range victims.PotentialVictims {
 			nodeID := allocation.GetNodeID()

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -2522,7 +2522,7 @@ func TestQueueRunningAppsForSingleAllocationApp(t *testing.T) {
 	_, err = app.allocateAsk(ask)
 	assert.NilError(t, err, "failed to decrease pending resources")
 
-	app.RemoveAllocation(alloc.GetAllocationID(), si.TerminationType_STOPPED_BY_RM)
+	app.RemoveAllocation(alloc.GetAllocationKey(), si.TerminationType_STOPPED_BY_RM)
 	assert.Equal(t, app.CurrentState(), Completing.String(), "app state should be completing")
 	assert.Equal(t, leaf.runningApps, uint64(0), "leaf should have 0 app running")
 }

--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -36,15 +36,14 @@ import (
 )
 
 const (
-	appID0        = "app-0"
-	appID1        = "app-1"
-	appID2        = "app-2"
-	aKey          = "alloc-1"
-	aKey2         = "alloc-2"
-	aAllocationID = "alloc-allocationid-1"
-	nodeID1       = "node-1"
-	nodeID2       = "node-2"
-	instType1     = "itype-1"
+	appID0    = "app-0"
+	appID1    = "app-1"
+	appID2    = "app-2"
+	aKey      = "alloc-1"
+	aKey2     = "alloc-2"
+	nodeID1   = "node-1"
+	nodeID2   = "node-2"
+	instType1 = "itype-1"
 )
 
 // Create the root queue, base for all testing

--- a/pkg/scheduler/tests/application_tracking_test.go
+++ b/pkg/scheduler/tests/application_tracking_test.go
@@ -135,9 +135,9 @@ func TestApplicationHistoryTracking(t *testing.T) {
 
 	allocations := ms.mockRM.getAllocations()
 	assert.Equal(t, 1, len(allocations), "number of allocations")
-	var allocationID string
+	var allocationKey string
 	for key := range allocations {
-		allocationID = key
+		allocationKey = key
 	}
 
 	// terminate allocation & check events
@@ -147,7 +147,7 @@ func TestApplicationHistoryTracking(t *testing.T) {
 				{
 					ApplicationID:   appID1,
 					PartitionName:   "default",
-					AllocationID:    allocationID,
+					AllocationKey:   allocationKey,
 					TerminationType: si.TerminationType_STOPPED_BY_RM,
 				},
 			},

--- a/pkg/scheduler/tests/mock_rm_callback_test.go
+++ b/pkg/scheduler/tests/mock_rm_callback_test.go
@@ -79,7 +79,7 @@ func (m *mockRMCallback) UpdateAllocation(response *si.AllocationResponse) error
 	m.Lock()
 	defer m.Unlock()
 	for _, alloc := range response.New {
-		m.Allocations[alloc.AllocationID] = alloc
+		m.Allocations[alloc.AllocationKey] = alloc
 		if val, ok := m.nodeAllocations[alloc.NodeID]; ok {
 			val = append(val, alloc)
 			m.nodeAllocations[alloc.NodeID] = val
@@ -90,9 +90,9 @@ func (m *mockRMCallback) UpdateAllocation(response *si.AllocationResponse) error
 		}
 	}
 	for _, alloc := range response.Released {
-		delete(m.Allocations, alloc.AllocationID)
+		delete(m.Allocations, alloc.AllocationKey)
 		if alloc.TerminationType == si.TerminationType_PLACEHOLDER_REPLACED {
-			m.releasedPhs[alloc.AllocationID] = alloc
+			m.releasedPhs[alloc.AllocationKey] = alloc
 		}
 	}
 	return nil

--- a/pkg/scheduler/tests/mockscheduler_test.go
+++ b/pkg/scheduler/tests/mockscheduler_test.go
@@ -146,11 +146,11 @@ func (m *mockScheduler) removeApp(appID, partition string) error {
 	})
 }
 
-func (m *mockScheduler) addAppRequest(appID, allocID string, resource *si.Resource, repeat int) error {
+func (m *mockScheduler) addAppRequest(appID, allocKeyPrefix string, resource *si.Resource, repeat int) error {
 	asks := make([]*si.AllocationAsk, repeat)
 	for i := 0; i < repeat; i++ {
 		asks[i] = &si.AllocationAsk{
-			AllocationKey: fmt.Sprintf("%s-%d", allocID, i),
+			AllocationKey: fmt.Sprintf("%s-%d", allocKeyPrefix, i),
 			ApplicationID: appID,
 			ResourceAsk:   resource,
 		}
@@ -161,13 +161,13 @@ func (m *mockScheduler) addAppRequest(appID, allocID string, resource *si.Resour
 	})
 }
 
-func (m *mockScheduler) releaseAllocRequest(appID, allocationID string) error {
+func (m *mockScheduler) releaseAllocRequest(appID, allocationKey string) error {
 	return m.proxy.UpdateAllocation(&si.AllocationRequest{
 		Releases: &si.AllocationReleasesRequest{
 			AllocationsToRelease: []*si.AllocationRelease{
 				{
 					ApplicationID: appID,
-					AllocationID:  allocationID,
+					AllocationKey: allocationKey,
 					PartitionName: m.partitionName,
 				},
 			},

--- a/pkg/scheduler/tests/recovery_test.go
+++ b/pkg/scheduler/tests/recovery_test.go
@@ -483,7 +483,6 @@ func TestSchedulerRecoveryWithoutAppInfo(t *testing.T) {
 				ExistingAllocations: []*si.Allocation{
 					{
 						AllocationKey: "allocation-key-01",
-						AllocationID:  "ALLOCATIONID01",
 						ApplicationID: "app-01",
 						PartitionName: "default",
 						NodeID:        "node-1:1234",
@@ -551,7 +550,6 @@ func TestSchedulerRecoveryWithoutAppInfo(t *testing.T) {
 				ExistingAllocations: []*si.Allocation{
 					{
 						AllocationKey: "allocation-key-01",
-						AllocationID:  "ALLOCATIONID01",
 						ApplicationID: "app-01",
 						PartitionName: "default",
 						NodeID:        "node-1:1234",
@@ -864,7 +862,6 @@ partitions:
 			existingAllocations = append(existingAllocations, &si.Allocation{
 				AllocationKey:    alloc.AllocationKey,
 				AllocationTags:   alloc.AllocationTags,
-				AllocationID:     alloc.AllocationID,
 				ResourcePerAlloc: alloc.ResourcePerAlloc,
 				Priority:         alloc.Priority,
 				NodeID:           alloc.NodeID,
@@ -959,7 +956,6 @@ func TestPlaceholderRecovery(t *testing.T) { //nolint:funlen
 		NodeID:        "node-1:1234",
 		ApplicationID: appID1,
 		TaskGroupName: "tg-1",
-		AllocationID:  "ph-alloc-1-0",
 		ResourcePerAlloc: &si.Resource{
 			Resources: map[string]*si.Quantity{
 				"memory": {
@@ -1025,9 +1021,9 @@ func TestPlaceholderRecovery(t *testing.T) { //nolint:funlen
 						"vcore":  {Value: 1},
 					},
 				},
-				ApplicationID:  appID1,
-				TaskGroupName:  "tg-2",
-				Placeholder:    true,
+				ApplicationID: appID1,
+				TaskGroupName: "tg-2",
+				Placeholder:   true,
 			},
 		},
 		RmID: "rm:123",
@@ -1046,8 +1042,8 @@ func TestPlaceholderRecovery(t *testing.T) { //nolint:funlen
 						"vcore":  {Value: 1},
 					},
 				},
-				ApplicationID:  appID1,
-				TaskGroupName:  "tg-1",
+				ApplicationID: appID1,
+				TaskGroupName: "tg-1",
 			},
 			{
 				AllocationKey: "real-alloc-2",
@@ -1057,8 +1053,8 @@ func TestPlaceholderRecovery(t *testing.T) { //nolint:funlen
 						"vcore":  {Value: 1},
 					},
 				},
-				ApplicationID:  appID1,
-				TaskGroupName:  "tg-2",
+				ApplicationID: appID1,
+				TaskGroupName: "tg-2",
 			},
 		},
 		RmID: "rm:123",
@@ -1073,13 +1069,13 @@ func TestPlaceholderRecovery(t *testing.T) { //nolint:funlen
 				{
 					ApplicationID:   appID1,
 					PartitionName:   "default",
-					AllocationID:    "ph-alloc-1",
+					AllocationKey:   "ph-alloc-1",
 					TerminationType: si.TerminationType_PLACEHOLDER_REPLACED,
 				},
 				{
 					ApplicationID:   appID1,
 					PartitionName:   "default",
-					AllocationID:    "ph-alloc-2",
+					AllocationKey:   "ph-alloc-2",
 					TerminationType: si.TerminationType_PLACEHOLDER_REPLACED,
 				},
 			},
@@ -1095,13 +1091,13 @@ func TestPlaceholderRecovery(t *testing.T) { //nolint:funlen
 				{
 					ApplicationID:   appID1,
 					PartitionName:   "default",
-					AllocationID:    "real-alloc-1",
+					AllocationKey:   "real-alloc-1",
 					TerminationType: si.TerminationType_STOPPED_BY_RM,
 				},
 				{
 					ApplicationID:   appID1,
 					PartitionName:   "default",
-					AllocationID:    "real-alloc-2",
+					AllocationKey:   "real-alloc-2",
 					TerminationType: si.TerminationType_STOPPED_BY_RM,
 				},
 			},

--- a/pkg/scheduler/tests/reservation_test.go
+++ b/pkg/scheduler/tests/reservation_test.go
@@ -422,7 +422,7 @@ func TestUnReservationAndDeletion(t *testing.T) {
 	}
 	// delete existing allocations
 	for _, alloc := range ms.mockRM.getAllocations() {
-		err = ms.releaseAllocRequest(appID1, alloc.AllocationID)
+		err = ms.releaseAllocRequest(appID1, alloc.AllocationKey)
 		assert.NilError(t, err, "allocation release update failed")
 	}
 	ms.scheduler.MultiStepSchedule(5)

--- a/pkg/scheduler/tests/smoke_test.go
+++ b/pkg/scheduler/tests/smoke_test.go
@@ -366,7 +366,7 @@ func TestBasicScheduler(t *testing.T) {
 	// Release all allocations
 	for _, v := range ms.mockRM.getAllocations() {
 		updateRequest.Releases.AllocationsToRelease = append(updateRequest.Releases.AllocationsToRelease, &si.AllocationRelease{
-			AllocationID:  v.AllocationID,
+			AllocationKey: v.AllocationKey,
 			ApplicationID: v.ApplicationID,
 			PartitionName: v.PartitionName,
 		})
@@ -917,7 +917,7 @@ partitions:
 				allocReleases = append(allocReleases, &si.AllocationRelease{
 					PartitionName: "default",
 					ApplicationID: appID1,
-					AllocationID:  alloc.AllocationID,
+					AllocationKey: alloc.AllocationKey,
 					Message:       "",
 				})
 			}
@@ -1411,7 +1411,7 @@ func TestDupReleasesInGangScheduling(t *testing.T) {
 				{
 					PartitionName:   "default",
 					ApplicationID:   appID1,
-					AllocationID:    placeholderAlloc.GetAllocationID(),
+					AllocationKey:   placeholderAlloc.GetAllocationKey(),
 					TerminationType: si.TerminationType_PLACEHOLDER_REPLACED,
 				},
 			},
@@ -1440,7 +1440,7 @@ func TestDupReleasesInGangScheduling(t *testing.T) {
 				{
 					PartitionName:   "default",
 					ApplicationID:   appID1,
-					AllocationID:    placeholderAlloc.GetAllocationID(),
+					AllocationKey:   placeholderAlloc.GetAllocationKey(),
 					TerminationType: si.TerminationType_PLACEHOLDER_REPLACED,
 				},
 			},
@@ -1605,7 +1605,7 @@ partitions:
 	// Release all allocations
 	for _, v := range ms.mockRM.getAllocations() {
 		updateRequest.Releases.AllocationsToRelease = append(updateRequest.Releases.AllocationsToRelease, &si.AllocationRelease{
-			AllocationID:  v.AllocationID,
+			AllocationKey: v.AllocationKey,
 			ApplicationID: v.ApplicationID,
 			PartitionName: v.PartitionName,
 		})

--- a/pkg/scheduler/utilities_test.go
+++ b/pkg/scheduler/utilities_test.go
@@ -47,9 +47,9 @@ const (
 	taskGroup       = "tg-1"
 	phID            = "ph-1"
 	phID2           = "ph-2"
-	allocID         = "alloc-1"
-	allocID2        = "alloc-2"
-	allocID3        = "alloc-3"
+	allocKey        = "alloc-1"
+	allocKey2       = "alloc-2"
+	allocKey3       = "alloc-3"
 	maxresources    = "maxresources"
 	maxapplications = "maxapplications"
 )

--- a/pkg/webservice/dao/allocation_info.go
+++ b/pkg/webservice/dao/allocation_info.go
@@ -24,8 +24,6 @@ type AllocationDAOInfo struct {
 	RequestTime      int64             `json:"requestTime,omitempty"`     // Allocation ask's createTime if PlaceholderUsed is false, otherwise equivalent to placeholder allocation's createTime
 	AllocationTime   int64             `json:"allocationTime,omitempty"`  // Allocation's createTime
 	AllocationDelay  int64             `json:"allocationDelay,omitempty"` // Difference between AllocationTime and RequestTime
-	UUID             string            `json:"uuid,omitempty"`            // Deprecated. Need to remove this in next major release
-	AllocationID     string            `json:"allocationID,omitempty"`    // Added to replace UUID.
 	ResourcePerAlloc map[string]int64  `json:"resource,omitempty"`
 	Priority         string            `json:"priority,omitempty"`
 	NodeID           string            `json:"nodeId,omitempty"`

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -219,8 +219,6 @@ func getAllocationDAO(alloc *objects.Allocation) *dao.AllocationDAOInfo {
 		RequestTime:      requestTime,
 		AllocationTime:   allocTime,
 		AllocationDelay:  allocTime - requestTime,
-		UUID:             alloc.GetAllocationID(),
-		AllocationID:     alloc.GetAllocationID(),
 		ResourcePerAlloc: alloc.GetAllocatedResource().DAOMap(),
 		PlaceholderUsed:  alloc.IsPlaceholderUsed(),
 		Placeholder:      alloc.IsPlaceholder(),

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1302,15 +1302,11 @@ func TestGetPartitionNodes(t *testing.T) {
 		if node.NodeID == node1ID {
 			assert.Equal(t, node.NodeID, node1ID)
 			assert.Equal(t, "alloc-1", node.Allocations[0].AllocationKey)
-			assert.Equal(t, "alloc-1", node.Allocations[0].UUID)
-			assert.Equal(t, "alloc-1", node.Allocations[0].AllocationID)
 			assert.DeepEqual(t, attributesOfnode1, node.Attributes)
 			assert.DeepEqual(t, map[string]int64{"memory": 50, "vcore": 30}, node.Utilized)
 		} else {
 			assert.Equal(t, node.NodeID, node2ID)
 			assert.Equal(t, "alloc-2", node.Allocations[0].AllocationKey)
-			assert.Equal(t, "alloc-2", node.Allocations[0].UUID)
-			assert.Equal(t, "alloc-2", node.Allocations[0].AllocationID)
 			assert.DeepEqual(t, attributesOfnode2, node.Attributes)
 			assert.DeepEqual(t, map[string]int64{"memory": 30, "vcore": 50}, node.Utilized)
 		}


### PR DESCRIPTION
### What is this PR for?
Having both AllocationID and AllocationKey in the core is redundant. Replace all references to AllocationID with AllocationKey and remove the duplicate variable in Allocation.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2587

### How should this be tested?
Unit tests updated as necessary.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
