### PR TITLE
[YUNIKORN-2594] Remove unused field AllocationAsk.execTimeout

### DIFF
--- a/pkg/scheduler/objects/allocation_ask.go
+++ b/pkg/scheduler/objects/allocation_ask.go
@@ -37,10 +37,9 @@ type AllocationAsk struct {
 	allocationKey     string
 	applicationID     string
 	partitionName     string
-	taskGroupName     string        // task group this allocation ask belongs to
-	placeholder       bool          // is this a placeholder allocation ask
-	execTimeout       time.Duration // execTimeout for the allocation ask
-	createTime        time.Time     // the time this ask was created (used in reservations)
+	taskGroupName     string    // task group this allocation ask belongs to
+	placeholder       bool      // is this a placeholder allocation ask
+	createTime        time.Time // the time this ask was created (used in reservations)
 	priority          int32
 	requiredNode      string
 	allowPreemptSelf  bool
@@ -95,7 +94,6 @@ func NewAllocationAskFromSI(ask *si.AllocationAsk) *AllocationAsk {
 		tags:              CloneAllocationTags(ask.Tags),
 		createTime:        time.Now(),
 		priority:          ask.Priority,
-		execTimeout:       common.ConvertSITimeout(ask.ExecutionTimeoutMilliSeconds),
 		placeholder:       ask.Placeholder,
 		taskGroupName:     ask.TaskGroupName,
 		requiredNode:      common.GetRequiredNodeFromTag(ask.Tags),
@@ -197,11 +195,6 @@ func (aa *AllocationAsk) IsPlaceholder() bool {
 // GetTaskGroup returns the task group name for this ask
 func (aa *AllocationAsk) GetTaskGroup() string {
 	return aa.taskGroupName
-}
-
-// GetTimeout returns the timeout for this ask
-func (aa *AllocationAsk) GetTimeout() time.Duration {
-	return aa.execTimeout
 }
 
 // GetRequiredNode gets the node (if any) required by this ask.

--- a/pkg/scheduler/objects/allocation_ask_test.go
+++ b/pkg/scheduler/objects/allocation_ask_test.go
@@ -141,24 +141,6 @@ func TestPlaceHolder(t *testing.T) {
 	assert.Equal(t, ask.GetTaskGroup(), "testgroup", "TaskGroupName not set as expected")
 }
 
-func TestGetTimeout(t *testing.T) {
-	siAsk := &si.AllocationAsk{
-		AllocationKey: "ask1",
-		ApplicationID: "app1",
-		PartitionName: "default",
-	}
-	ask := NewAllocationAskFromSI(siAsk)
-	assert.Equal(t, ask.GetTimeout(), time.Duration(0), "standard ask should not have timeout")
-	siAsk = &si.AllocationAsk{
-		AllocationKey:                "ask1",
-		ApplicationID:                "app1",
-		PartitionName:                "default",
-		ExecutionTimeoutMilliSeconds: 10,
-	}
-	ask = NewAllocationAskFromSI(siAsk)
-	assert.Equal(t, ask.GetTimeout(), 10*time.Millisecond, "ask timeout not set as expected")
-}
-
 func TestGetRequiredNode(t *testing.T) {
 	tag := make(map[string]string)
 	// unset case

--- a/pkg/webservice/dao/allocation_ask_info.go
+++ b/pkg/webservice/dao/allocation_ask_info.go
@@ -34,7 +34,6 @@ type AllocationAskDAOInfo struct {
 	ApplicationID       string                     `json:"applicationId,omitempty"`
 	Partition           string                     `json:"partition,omitempty"`
 	Placeholder         bool                       `json:"placeholder,omitempty"`
-	PlaceholderTimeout  int64                      `json:"placeholderTimeout,omitempty"`
 	TaskGroupName       string                     `json:"taskGroupName,omitempty"`
 	AllocationLog       []*AllocationAskLogDAOInfo `json:"allocationLog,omitempty"`
 	TriggeredPreemption bool                       `json:"triggeredPreemption,omitempty"`

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -329,7 +329,6 @@ func getAllocationAskDAO(ask *objects.AllocationAsk) *dao.AllocationAskDAOInfo {
 		ApplicationID:       ask.GetApplicationID(),
 		Partition:           common.GetPartitionNameWithoutClusterID(ask.GetPartitionName()),
 		Placeholder:         ask.IsPlaceholder(),
-		PlaceholderTimeout:  ask.GetTimeout().Nanoseconds(),
 		TaskGroupName:       ask.GetTaskGroup(),
 		AllocationLog:       getAllocationLogsDAO(ask.GetAllocationLog()),
 		TriggeredPreemption: ask.HasTriggeredPreemption(),


### PR DESCRIPTION
### What is this PR for?
The execTimeout field in AllocationAsk is populated but unused.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2594

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
