### PR TITLE
[YUNIKORN-2461] Add new RESTful API to get queue applications filtered by state

### DIFF
--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1552,7 +1552,8 @@ func TestGetPartitionApplicationsByStateHandler(t *testing.T) {
 }
 
 func checkGetQueueAppByStatus(t *testing.T, partition, queue, status string, expectedApp []*objects.Application) {
-	req, err := http.NewRequest("GET", "/ws/v1/partition/default/applications/queue/root.default/New", strings.NewReader(""))
+	url := fmt.Sprintf("/ws/v1/partition/%s/queue/%s/applications/%s", partition, queue, status)
+	req, err := http.NewRequest("GET", url, strings.NewReader(""))
 	req = req.WithContext(context.WithValue(req.Context(), httprouter.ParamsKey, httprouter.Params{
 		httprouter.Param{Key: "partition", Value: partition},
 		httprouter.Param{Key: "queue", Value: queue},
@@ -1571,7 +1572,8 @@ func checkGetQueueAppByStatus(t *testing.T, partition, queue, status string, exp
 }
 
 func checkGetQueueAppByIllegalStatus(t *testing.T, partition, queue, status string) {
-	req, err := http.NewRequest("GET", "/ws/v1/partition/default/applications/queue/root.default/New", strings.NewReader(""))
+	url := fmt.Sprintf("/ws/v1/partition/%s/queue/%s/applications/%s", partition, queue, status)
+	req, err := http.NewRequest("GET", url, strings.NewReader(""))
 	req = req.WithContext(context.WithValue(req.Context(), httprouter.ParamsKey, httprouter.Params{
 		httprouter.Param{Key: "partition", Value: partition},
 		httprouter.Param{Key: "queue", Value: queue},

--- a/pkg/webservice/routes.go
+++ b/pkg/webservice/routes.go
@@ -143,6 +143,12 @@ var webRoutes = routes{
 	route{
 		"Scheduler",
 		"GET",
+		"/ws/v1/partition/:partition/queue/:queue/applications/:status",
+		getQueueApplicationsByStatus,
+	},
+	route{
+		"Scheduler",
+		"GET",
 		"/ws/v1/partition/:partition/usage/users",
 		getUsersResourceUsage,
 	},


### PR DESCRIPTION
### What is this PR for?
In [YUNIKORN-2235](https://issues.apache.org/jira/browse/YUNIKORN-2235), an API to retrieve applications by state in partition was added. However, there is currently no API serving the same purpose at the queue level.
This PR add a new RESTful API that allows filtering applications by state at queue level, which unifies API behavior.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
N/A

### What is the Jira issue?
[YUNIKORN-2461](https://issues.apache.org/jira/browse/YUNIKORN-2461/)

### How should this be tested?
It has been checked locally by `make test`.

### Screenshots (if appropriate)
N/A

### Questions:
N/A
