### PR TITLE
[YUNIKORN-2642] Don't set resources on the recovery queue

### DIFF
--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -320,8 +320,9 @@ func (pc *PartitionContext) AddApplication(app *objects.Application) error {
 	queue := pc.getQueueInternal(queueName)
 
 	// create the queue if necessary
+	isRecoveryQueue := common.IsRecoveryQueue(queueName)
 	if queue == nil {
-		if common.IsRecoveryQueue(queueName) {
+		if isRecoveryQueue {
 			queue, err = pc.createRecoveryQueue()
 			if err != nil {
 				return fmt.Errorf("failed to create recovery queue %s for application %s", common.RecoveryQueueFull, appID)
@@ -341,7 +342,7 @@ func (pc *PartitionContext) AddApplication(app *objects.Application) error {
 
 	guaranteedRes := app.GetGuaranteedResource()
 	maxRes := app.GetMaxResource()
-	if guaranteedRes != nil || maxRes != nil {
+	if !isRecoveryQueue && (guaranteedRes != nil || maxRes != nil) {
 		// set resources based on tags, but only if the queue is dynamic (unmanaged)
 		if queue.IsManaged() {
 			log.Log(log.SchedQueue).Warn("Trying to set resources on a queue that is not an unmanaged leaf",

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -964,6 +964,22 @@ func TestAddAppForced(t *testing.T) {
 	assert.Equal(t, common.RecoveryQueueFull, partApp3.GetQueuePath(), "wrong queue path for app3")
 	assert.Check(t, recoveryQueue == partApp3.GetQueue(), "wrong queue for app3")
 	assert.Equal(t, 3, len(recoveryQueue.GetCopyOfApps()), "wrong queue length")
+
+	// add recovered forced apps with resource tags
+	app4 := newApplicationTags("app-4", "default", common.RecoveryQueueFull, map[string]string{
+		siCommon.AppTagCreateForce:                 "true",
+		siCommon.AppTagNamespaceResourceGuaranteed: "{\"resources\":{\"vcore\":{\"value\":111}}}"})
+	err = partition.AddApplication(app4)
+	assert.NilError(t, err, "app4 could not be added")
+	assert.Assert(t, recoveryQueue.GetGuaranteedResource() == nil, "guaranteed resource should be unset")
+	assert.Assert(t, recoveryQueue.GetMaxResource() == nil, "max resource should be unset")
+	app5 := newApplicationTags("app-5", "default", common.RecoveryQueueFull, map[string]string{
+		siCommon.AppTagCreateForce:            "true",
+		siCommon.AppTagNamespaceResourceQuota: "{\"resources\":{\"vcore\":{\"value\":111}}}"})
+	err = partition.AddApplication(app5)
+	assert.NilError(t, err, "app5 could not be added")
+	assert.Assert(t, recoveryQueue.GetGuaranteedResource() == nil, "guaranteed resource should be unset")
+	assert.Assert(t, recoveryQueue.GetMaxResource() == nil, "max resource should be unset")
 }
 
 func TestAddAppForcedWithPlacement(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
Don't set resources from tags on the recovery queue.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2642

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
