### PR TITLE
[YUNIKORN-2642] Don't set resources on the recovery queue

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -729,6 +729,11 @@ func (sq *Queue) AddApplication(app *Application) {
 	appID := app.ApplicationID
 	sq.applications[appID] = app
 	sq.queueEvents.sendNewApplicationEvent(sq.QueuePath, appID)
+	if common.IsRecoveryQueue(sq.QueuePath) {
+		// don't set tag-based resources on the recovery queue
+		return
+	}
+
 	// YUNIKORN-199: update the quota from the namespace
 	// get the tag with the quota
 	quota := app.GetTag(siCommon.AppTagNamespaceResourceQuota)

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -979,6 +979,22 @@ func TestAddAppForced(t *testing.T) {
 	assert.Equal(t, common.RecoveryQueueFull, partApp3.GetQueuePath(), "wrong queue path for app3")
 	assert.Check(t, recoveryQueue == partApp3.GetQueue(), "wrong queue for app3")
 	assert.Equal(t, 3, len(recoveryQueue.GetCopyOfApps()), "wrong queue length")
+
+	// add recovered forced apps with resource tags
+	app4 := newApplicationTags("app-4", "default", common.RecoveryQueueFull, map[string]string{
+		siCommon.AppTagCreateForce:                 "true",
+		siCommon.AppTagNamespaceResourceGuaranteed: "{\"resources\":{\"vcore\":{\"value\":111}}}"})
+	err = partition.AddApplication(app4)
+	assert.NilError(t, err, "app4 could not be added")
+	assert.Assert(t, recoveryQueue.GetGuaranteedResource() == nil, "guaranteed resource should be unset")
+	assert.Assert(t, recoveryQueue.GetMaxResource() == nil, "max resource should be unset")
+	app5 := newApplicationTags("app-5", "default", common.RecoveryQueueFull, map[string]string{
+		siCommon.AppTagCreateForce:            "true",
+		siCommon.AppTagNamespaceResourceQuota: "{\"resources\":{\"vcore\":{\"value\":111}}}"})
+	err = partition.AddApplication(app5)
+	assert.NilError(t, err, "app5 could not be added")
+	assert.Assert(t, recoveryQueue.GetGuaranteedResource() == nil, "guaranteed resource should be unset")
+	assert.Assert(t, recoveryQueue.GetMaxResource() == nil, "max resource should be unset")
 }
 
 func TestAddAppForcedWithPlacement(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
Don't set resources from tags on the recovery queue.

This PR is for branch-1.5.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2642

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
