### PR TITLE
[YUNIKORN-2666] Fix DeepEqual comparison in Test_fixedRule_ruleDAO

### DIFF
--- a/pkg/scheduler/placement/fixed_rule_test.go
+++ b/pkg/scheduler/placement/fixed_rule_test.go
@@ -19,6 +19,7 @@
 package placement
 
 import (
+	"sort"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -282,6 +283,12 @@ func Test_fixedRule_ruleDAO(t *testing.T) {
 			ur, err := newRule(tt.conf)
 			assert.NilError(t, err, "setting up the rule failed")
 			ruleDAO := ur.ruleDAO()
+			if tt.want.Filter != nil {
+				sort.Strings(tt.want.Filter.UserList)
+				sort.Strings(ruleDAO.Filter.UserList)
+				sort.Strings(tt.want.Filter.GroupList)
+				sort.Strings(ruleDAO.Filter.GroupList)
+			}
 			assert.DeepEqual(t, tt.want, ruleDAO)
 		})
 	}


### PR DESCRIPTION
### What is this PR for?
Sort string slices before calling `assert.DeepEqual()` to avoid differences caused by map iteration.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2666

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
