### PR TITLE
[YUNIKORN-2657] Validate queue generated as part of the placement rules

### DIFF
--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -69,7 +69,11 @@ var DefaultPreemptionDelay = 30 * time.Second
 
 // A queue can be a username with the dot replaced. Most systems allow a 32 character user name.
 // The queue name must thus allow for at least that length with the replacement of dots.
-var QueueNameRegExp = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+var QueueNameRegExp = regexp.MustCompile(`^[a-zA-Z0-9_:#/@-]{1,64}$`)
+
+// A queue can be a username with the dot replaced. Most systems allow a 32 character user name.
+// The queue name must thus allow for at least that length with the replacement of dots.
+var QueuePathRegExp = regexp.MustCompile(`^[a-zA-Z0-9_.:#/@-]{1,64}$`)
 
 // User and group name check: systems allow different things POSIX is the base but we need to be lenient and allow more.
 // allow upper and lower case, add the @ and . (dot) and officially no length.
@@ -653,9 +657,9 @@ func checkQueues(queue *QueueConfig, level int) error {
 	// check this level for name compliance and uniqueness
 	queueMap := make(map[string]bool)
 	for _, child := range queue.Queues {
-		if !QueueNameRegExp.MatchString(child.Name) {
-			return fmt.Errorf("invalid child name '%s', a name must only have alphanumeric characters,"+
-				" - or _, and be no longer than 64 characters", child.Name)
+		err = IsQueueNameValid(child.Name)
+		if err != nil {
+			return err
 		}
 		if queueMap[strings.ToLower(child.Name)] {
 			return fmt.Errorf("duplicate child name found with name '%s', level %d", child.Name, level)
@@ -669,6 +673,22 @@ func checkQueues(queue *QueueConfig, level int) error {
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func IsQueueNameValid(queueName string) error {
+	if !QueueNameRegExp.MatchString(queueName) {
+		return fmt.Errorf("invalid child name '%s', a name must only have alphanumeric characters,"+
+			" - or _, and be no longer than 64 characters", queueName)
+	}
+	return nil
+}
+
+func IsQueuePathValid(queuePath string) error {
+	if !QueuePathRegExp.MatchString(queuePath) {
+		return fmt.Errorf("invalid queue path '%s', a queue path must only have alphanumeric characters,"+
+			" - or _, and be no longer than 64 characters", queuePath)
 	}
 	return nil
 }

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -675,8 +675,7 @@ func checkQueues(queue *QueueConfig, level int) error {
 
 func IsQueueNameValid(queueName string) error {
 	if !QueueNameRegExp.MatchString(queueName) {
-		return fmt.Errorf("invalid child name '%s', a name must only have alphanumeric characters,"+
-			" - or _, and be no longer than 64 characters", queueName)
+		return fmt.Errorf("invalid queue name '%s', max 64 characters consisting of alphanumeric characters and '-', '_', '#', '@', '/', ':' allowed", queueName)
 	}
 	return nil
 }

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -71,10 +71,6 @@ var DefaultPreemptionDelay = 30 * time.Second
 // The queue name must thus allow for at least that length with the replacement of dots.
 var QueueNameRegExp = regexp.MustCompile(`^[a-zA-Z0-9_:#/@-]{1,64}$`)
 
-// A queue can be a username with the dot replaced. Most systems allow a 32 character user name.
-// The queue name must thus allow for at least that length with the replacement of dots.
-var QueuePathRegExp = regexp.MustCompile(`^[a-zA-Z0-9_.:#/@-]{1,64}$`)
-
 // User and group name check: systems allow different things POSIX is the base but we need to be lenient and allow more.
 // allow upper and lower case, add the @ and . (dot) and officially no length.
 var UserRegExp = regexp.MustCompile(`^[_a-zA-Z][a-zA-Z0-9:#/_.@-]*[$]?$`)
@@ -681,14 +677,6 @@ func IsQueueNameValid(queueName string) error {
 	if !QueueNameRegExp.MatchString(queueName) {
 		return fmt.Errorf("invalid child name '%s', a name must only have alphanumeric characters,"+
 			" - or _, and be no longer than 64 characters", queueName)
-	}
-	return nil
-}
-
-func IsQueuePathValid(queuePath string) error {
-	if !QueuePathRegExp.MatchString(queuePath) {
-		return fmt.Errorf("invalid queue path '%s', a queue path must only have alphanumeric characters,"+
-			" - or _, and be no longer than 64 characters", queuePath)
 	}
 	return nil
 }

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -675,7 +675,7 @@ func checkQueues(queue *QueueConfig, level int) error {
 
 func IsQueueNameValid(queueName string) error {
 	if !QueueNameRegExp.MatchString(queueName) {
-		return fmt.Errorf("invalid queue name '%s', max 64 characters consisting of alphanumeric characters and '-', '_', '#', '@', '/', ':' allowed", queueName)
+		return common.InvalidQueueName
 	}
 	return nil
 }

--- a/pkg/common/configs/configvalidator_test.go
+++ b/pkg/common/configs/configvalidator_test.go
@@ -2295,7 +2295,7 @@ func TestCheckQueues(t *testing.T) { //nolint:funlen
 				},
 			},
 			level:            0,
-			expectedErrorMsg: "invalid queue name 'thisQueueNameIsTooLongthisQueueNameIsTooLongthisQueueNameIsTooLong', max 64 characters consisting of alphanumeric characters and '-', '_', '#', '@', '/', ':' allowed",
+			expectedErrorMsg: common.InvalidQueueName.Error(),
 		},
 		{
 			name: "Invalid Child Queue Name With Special Character",
@@ -2308,7 +2308,7 @@ func TestCheckQueues(t *testing.T) { //nolint:funlen
 				},
 			},
 			level:            0,
-			expectedErrorMsg: "invalid queue name 'queue_Name$', max 64 characters consisting of alphanumeric characters and '-', '_', '#', '@', '/', ':' allowed",
+			expectedErrorMsg: common.InvalidQueueName.Error(),
 		},
 		{
 			name: "Valid Multiple Queues",

--- a/pkg/common/configs/configvalidator_test.go
+++ b/pkg/common/configs/configvalidator_test.go
@@ -2295,7 +2295,7 @@ func TestCheckQueues(t *testing.T) { //nolint:funlen
 				},
 			},
 			level:            0,
-			expectedErrorMsg: "invalid child name 'thisQueueNameIsTooLongthisQueueNameIsTooLongthisQueueNameIsTooLong', a name must only have alphanumeric characters, - or _, and be no longer than 64 characters",
+			expectedErrorMsg: "invalid queue name 'thisQueueNameIsTooLongthisQueueNameIsTooLongthisQueueNameIsTooLong', max 64 characters consisting of alphanumeric characters and '-', '_', '#', '@', '/', ':' allowed",
 		},
 		{
 			name: "Invalid Child Queue Name With Special Character",
@@ -2308,7 +2308,7 @@ func TestCheckQueues(t *testing.T) { //nolint:funlen
 				},
 			},
 			level:            0,
-			expectedErrorMsg: "invalid child name 'queue_Name$', a name must only have alphanumeric characters, - or _, and be no longer than 64 characters",
+			expectedErrorMsg: "invalid queue name 'queue_Name$', max 64 characters consisting of alphanumeric characters and '-', '_', '#', '@', '/', ':' allowed",
 		},
 		{
 			name: "Valid Multiple Queues",

--- a/pkg/common/configs/configvalidator_test.go
+++ b/pkg/common/configs/configvalidator_test.go
@@ -2414,3 +2414,15 @@ func TestCheckNodeSortingPolicy(t *testing.T) { //nolint:funlen
 		})
 	}
 }
+
+func TestIsQueueNameValid(t *testing.T) {
+	assert.NilError(t, IsQueueNameValid("parent_Child_test-a_b_#_c_#_d_/_e@dom:ain"))
+	err := IsQueueNameValid("invalid!queue")
+	if err == nil {
+		t.Errorf("invalid queue name, validation should have failed. err is %v", err)
+	}
+	err = IsQueueNameValid("root.parent")
+	if err == nil {
+		t.Errorf("invalid queue name, validation should have failed. err is %v", err)
+	}
+}

--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -1,0 +1,27 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package common
+
+import "errors"
+
+// Common errors
+var (
+	// InvalidQueueName returned when queue name is invalid
+	InvalidQueueName = errors.New("invalid queue name, max 64 characters consisting of alphanumeric characters and '-', '_', '#', '@', '/', ':' allowed")
+)

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -177,8 +177,8 @@ func NewDynamicQueue(name string, leaf bool, parent *Queue) (*Queue, error) {
 		return nil, fmt.Errorf("dynamic queue can not be added without parent: %s", name)
 	}
 	// name might not be checked do it here
-	if !configs.QueueNameRegExp.MatchString(name) {
-		return nil, fmt.Errorf("invalid queue name '%s', a name must only have alphanumeric characters, - or _, and be no longer than 64 characters", name)
+	if !configs.QueueNameRegExp.MatchString(name) || name == common.RecoveryQueue {
+		return nil, fmt.Errorf("invalid queue name '%s', a name must only have alphanumeric characters, - or _, and be no longer than 64 characters except the recovery queue root.@recovery@", name)
 	}
 	return newDynamicQueueInternal(name, leaf, parent)
 }

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -177,8 +177,11 @@ func NewDynamicQueue(name string, leaf bool, parent *Queue) (*Queue, error) {
 		return nil, fmt.Errorf("dynamic queue can not be added without parent: %s", name)
 	}
 	// name might not be checked do it here
-	if !configs.QueueNameRegExp.MatchString(name) || name == common.RecoveryQueue {
-		return nil, fmt.Errorf("invalid queue name '%s', a name must only have alphanumeric characters, - or _, and be no longer than 64 characters except the recovery queue root.@recovery@", name)
+	if err := configs.IsQueueNameValid(name); err != nil {
+		return nil, err
+	}
+	if name == common.RecoveryQueue {
+		return nil, fmt.Errorf("dynamic queue cannot be root.@recovery@")
 	}
 	return newDynamicQueueInternal(name, leaf, parent)
 }

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -2192,7 +2192,7 @@ func TestNewDynamicQueue(t *testing.T) {
 	assert.Equal(t, childLeaf.preemptionPolicy, policies.DefaultPreemptionPolicy)
 
 	// case 1: non-leaf can't use template but it can inherit template from parent
-	childNonLeaf, err := NewDynamicQueue("nonleaf", false, parent)
+	childNonLeaf, err := NewDynamicQueue("nonleaf_Test-a_b_#_c_#_d_/_e@dom:ain", false, parent)
 	assert.NilError(t, err, "failed to create dynamic queue: %v", err)
 	assert.Assert(t, reflect.DeepEqual(childNonLeaf.template, parent.template))
 	assert.Equal(t, len(childNonLeaf.properties), 0)
@@ -2201,6 +2201,12 @@ func TestNewDynamicQueue(t *testing.T) {
 	assert.Assert(t, childNonLeaf.prioritySortEnabled)
 	assert.Equal(t, childNonLeaf.priorityPolicy, policies.DefaultPriorityPolicy)
 	assert.Equal(t, childNonLeaf.preemptionPolicy, policies.DefaultPreemptionPolicy)
+
+	// case 2: invalid queue name
+	_, err = NewDynamicQueue("invalid!queue", false, parent)
+	if err == nil {
+		t.Errorf("new dynamic queue should have failed to create, err is %v", err)
+	}
 }
 
 func TestTemplateIsNotOverrideByParent(t *testing.T) {

--- a/pkg/scheduler/placement/fixed_rule.go
+++ b/pkg/scheduler/placement/fixed_rule.go
@@ -68,6 +68,12 @@ func (fr *fixedRule) initialise(conf configs.PlacementRule) error {
 	if fr.queue == "" {
 		return fmt.Errorf("a fixed queue rule must have a queue name set")
 	}
+	parts := strings.Split(fr.queue, configs.DOT)
+	for _, part := range parts {
+		if err := configs.IsQueueNameValid(part); err != nil {
+			return err
+		}
+	}
 	fr.create = conf.Create
 	fr.filter = newFilter(conf.Filter)
 	// if we have a fully qualified queue name already we should not have a parent
@@ -90,12 +96,6 @@ func (fr *fixedRule) placeApplication(app *objects.Application, queueFn func(str
 			zap.Any("user", app.GetUser()),
 			zap.String("queueName", fr.queue))
 		return "", nil
-	}
-	parts := strings.Split(fr.queue, configs.DOT)
-	for _, part := range parts {
-		if err := configs.IsQueueNameValid(part); err != nil {
-			return "", err
-		}
 	}
 	queueName := fr.queue
 	// not fully qualified queue, run the parent rule if set

--- a/pkg/scheduler/placement/fixed_rule.go
+++ b/pkg/scheduler/placement/fixed_rule.go
@@ -121,19 +121,18 @@ func (fr *fixedRule) placeApplication(app *objects.Application, queueFn func(str
 		if parentName == "" {
 			parentName = configs.RootQueue
 		}
-		childQueueName := replaceDot(fr.queue)
-		if err = configs.IsQueueNameValid(childQueueName); err != nil {
+		queueName = parentName + configs.DOT + fr.queue
+	}
+	parts := strings.Split(queueName, configs.DOT)
+	for _, part := range parts {
+		if err := configs.IsQueueNameValid(part); err != nil {
 			return "", err
 		}
-		queueName = parentName + configs.DOT + childQueueName
 	}
 	// Log the result before we check the create flag
 	log.Log(log.SchedApplication).Debug("Fixed rule intermediate result",
 		zap.String("application", app.ApplicationID),
 		zap.String("queue", queueName))
-	if err := configs.IsQueuePathValid(queueName); err != nil {
-		return "", err
-	}
 	// get the queue object
 	queue := queueFn(queueName)
 	// if we cannot create the queue must exist

--- a/pkg/scheduler/placement/fixed_rule.go
+++ b/pkg/scheduler/placement/fixed_rule.go
@@ -121,12 +121,19 @@ func (fr *fixedRule) placeApplication(app *objects.Application, queueFn func(str
 		if parentName == "" {
 			parentName = configs.RootQueue
 		}
-		queueName = parentName + configs.DOT + fr.queue
+		childQueueName := replaceDot(fr.queue)
+		if err = configs.IsQueueNameValid(childQueueName); err != nil {
+			return "", err
+		}
+		queueName = parentName + configs.DOT + childQueueName
 	}
 	// Log the result before we check the create flag
 	log.Log(log.SchedApplication).Debug("Fixed rule intermediate result",
 		zap.String("application", app.ApplicationID),
 		zap.String("queue", queueName))
+	if err := configs.IsQueuePathValid(queueName); err != nil {
+		return "", err
+	}
 	// get the queue object
 	queue := queueFn(queueName)
 	// if we cannot create the queue must exist

--- a/pkg/scheduler/placement/fixed_rule.go
+++ b/pkg/scheduler/placement/fixed_rule.go
@@ -91,8 +91,14 @@ func (fr *fixedRule) placeApplication(app *objects.Application, queueFn func(str
 			zap.String("queueName", fr.queue))
 		return "", nil
 	}
+	parts := strings.Split(fr.queue, configs.DOT)
+	for _, part := range parts {
+		if err := configs.IsQueueNameValid(part); err != nil {
+			return "", err
+		}
+	}
 	queueName := fr.queue
-	// if the fixed queue is already fully qualified skip the parent check
+	// not fully qualified queue, run the parent rule if set
 	if !fr.qualified {
 		var parentName string
 		var err error
@@ -122,12 +128,6 @@ func (fr *fixedRule) placeApplication(app *objects.Application, queueFn func(str
 			parentName = configs.RootQueue
 		}
 		queueName = parentName + configs.DOT + fr.queue
-	}
-	parts := strings.Split(queueName, configs.DOT)
-	for _, part := range parts {
-		if err := configs.IsQueueNameValid(part); err != nil {
-			return "", err
-		}
 	}
 	// Log the result before we check the create flag
 	log.Log(log.SchedApplication).Debug("Fixed rule intermediate result",

--- a/pkg/scheduler/placement/fixed_rule_test.go
+++ b/pkg/scheduler/placement/fixed_rule_test.go
@@ -88,7 +88,7 @@ partitions:
 		nilError      bool
 	}{
 		{"fixed queue that exists directly under the root", "root.testqueue", configs.PlacementRule{Name: "fixed", Value: "testqueue"}, true},
-		{"fixed queue that exists directly in hierarchy", "root.testparent.testchild", configs.PlacementRule{Name: "fixed", Value: "root.testparent.testchild"}, true},
+		{"fixed queue that exists directly in hierarchy", "root.testparent.testchild", configs.PlacementRule{Name: "fixed", Value: "testparent.testchild"}, true},
 		{"fixed queue that does not exists", "root.newqueue", configs.PlacementRule{Name: "fixed", Value: "newqueue", Create: true}, true},
 		{"place in a parent queue should not fail: failure happens on create in this case", "root.testparent", configs.PlacementRule{Name: "fixed", Value: "root.testparent"}, true},
 		{"place in a child using a parent", "root.testparent.testchild", configs.PlacementRule{Name: "fixed", Value: "testchild", Parent: &configs.PlacementRule{Name: "fixed", Value: "testparent"}}, true},
@@ -101,39 +101,28 @@ partitions:
 		t.Run(tt.name, func(t *testing.T) {
 			var fr rule
 			fr, err = newRule(tt.config)
-			if err != nil || fr == nil {
-				t.Errorf("fixed rule create failed with queue name, err %v", err)
-			}
-			var queue string
 			if tt.nilError {
-				queue, err = fr.placeApplication(app, queueFunc)
-				if queue != tt.expectedQueue || err != nil {
-					t.Errorf("fixed rule failed to place queue in correct queue '%s', err %v", queue, err)
+				if err != nil || fr == nil {
+					t.Errorf("fixed rule create failed with queue name, err %v", err)
+				}
+				var queue string
+				if tt.nilError {
+					queue, err = fr.placeApplication(app, queueFunc)
+					if queue != tt.expectedQueue || err != nil {
+						t.Errorf("fixed rule failed to place queue in correct queue '%s', err %v", queue, err)
+					}
+				} else {
+					_, err = fr.placeApplication(app, queueFunc)
+					if err == nil {
+						t.Errorf("fixed rule should have failed to place queue, err %v", err)
+					}
 				}
 			} else {
-				_, err = fr.placeApplication(app, queueFunc)
 				if err == nil {
-					t.Errorf("fixed rule should have failed to place queue, err %v", err)
+					t.Errorf("fixed rule should have failed with queue name, err %v", err)
 				}
 			}
 		})
-	}
-
-	// deny filter type should got got empty queue
-	conf := configs.PlacementRule{
-		Name:  "fixed",
-		Value: "testchild",
-		Filter: configs.Filter{
-			Type: filterDeny,
-		},
-	}
-	fr, err := newRule(conf)
-	if err != nil || fr == nil {
-		t.Errorf("fixed rule create failed with queue name, err %v", err)
-	}
-	queue, err := fr.placeApplication(app, queueFunc)
-	if queue != "" || err != nil {
-		t.Errorf("fixed rule with deny filter type should got empty queue, err nil")
 	}
 }
 
@@ -221,12 +210,8 @@ func TestFixedRuleParent(t *testing.T) {
 		},
 	}
 	fr, err = newRule(conf)
-	if err != nil || fr == nil {
-		t.Errorf("fixed rule create failed with queue name, err %v", err)
-	}
-	_, err = fr.placeApplication(app, queueFunc)
 	if err == nil {
-		t.Errorf("fixed rule with non existing invalid child queue should have failed, error %v", err)
+		t.Errorf("fixed rule create should have failed with queue name, err %v", err)
 	}
 
 	// trying to place in a child using a parent which is defined as a leaf

--- a/pkg/scheduler/placement/fixed_rule_test.go
+++ b/pkg/scheduler/placement/fixed_rule_test.go
@@ -94,6 +94,7 @@ partitions:
 		{"place in a child using a parent", "root.testparent.testchild", configs.PlacementRule{Name: "fixed", Value: "testchild", Parent: &configs.PlacementRule{Name: "fixed", Value: "testparent"}}, true},
 		{"invalid queue name", "", configs.PlacementRule{Name: "fixed", Value: "testqueue!>invalid<"}, false},
 		{"invalid queue name with full queue hierarchy", "", configs.PlacementRule{Name: "fixed", Value: "root.testparent!>invalid<test.testqueue"}, false},
+		{"deny filter type should got empty queue", "", configs.PlacementRule{Name: "fixed", Value: "testchild", Filter: configs.Filter{Type: filterDeny}}, true},
 	}
 
 	for _, tt := range tests {
@@ -119,18 +120,18 @@ partitions:
 	}
 
 	// deny filter type should got got empty queue
-	conf = configs.PlacementRule{
+	conf := configs.PlacementRule{
 		Name:  "fixed",
 		Value: "testchild",
 		Filter: configs.Filter{
 			Type: filterDeny,
 		},
 	}
-	fr, err = newRule(conf)
+	fr, err := newRule(conf)
 	if err != nil || fr == nil {
 		t.Errorf("fixed rule create failed with queue name, err %v", err)
 	}
-	queue, err = fr.placeApplication(app, queueFunc)
+	queue, err := fr.placeApplication(app, queueFunc)
 	if queue != "" || err != nil {
 		t.Errorf("fixed rule with deny filter type should got empty queue, err nil")
 	}

--- a/pkg/scheduler/placement/fixed_rule_test.go
+++ b/pkg/scheduler/placement/fixed_rule_test.go
@@ -117,10 +117,8 @@ partitions:
 						t.Errorf("fixed rule should have failed to place queue, err %v", err)
 					}
 				}
-			} else {
-				if err == nil {
-					t.Errorf("fixed rule should have failed with queue name, err %v", err)
-				}
+			} else if err == nil {
+				t.Errorf("fixed rule should have failed with queue name, err %v", err)
 			}
 		})
 	}
@@ -209,7 +207,7 @@ func TestFixedRuleParent(t *testing.T) {
 			Create: true,
 		},
 	}
-	fr, err = newRule(conf)
+	_, err = newRule(conf)
 	if err == nil {
 		t.Errorf("fixed rule create should have failed with queue name, err %v", err)
 	}

--- a/pkg/scheduler/placement/provided_rule.go
+++ b/pkg/scheduler/placement/provided_rule.go
@@ -112,20 +112,19 @@ func (pr *providedRule) placeApplication(app *objects.Application, queueFn func(
 		if parentName == "" {
 			parentName = configs.RootQueue
 		}
-		childQueueName := replaceDot(queueName)
-		if err = configs.IsQueueNameValid(childQueueName); err != nil {
+		// Make it a fully qualified queue
+		queueName = parentName + configs.DOT + replaceDot(queueName)
+	}
+	parts := strings.Split(queueName, configs.DOT)
+	for _, part := range parts {
+		if err := configs.IsQueueNameValid(part); err != nil {
 			return "", err
 		}
-		// Make it a fully qualified queue
-		queueName = parentName + configs.DOT + childQueueName
 	}
 	// Log the result before we check the create flag
 	log.Log(log.SchedApplication).Debug("Provided rule intermediate result",
 		zap.String("application", app.ApplicationID),
 		zap.String("queue", queueName))
-	if err = configs.IsQueuePathValid(queueName); err != nil {
-		return "", err
-	}
 	// get the queue object
 	queue := queueFn(queueName)
 	// if we cannot create the queue must exist

--- a/pkg/scheduler/placement/provided_rule.go
+++ b/pkg/scheduler/placement/provided_rule.go
@@ -85,8 +85,21 @@ func (pr *providedRule) placeApplication(app *objects.Application, queueFn func(
 	}
 	var parentName string
 	var err error
-	// if we have a fully qualified queue passed in do not run the parent rule
-	if !strings.HasPrefix(queueName, configs.RootQueue+configs.DOT) {
+
+	// fully qualified queue, do not run the parent rule
+	if strings.HasPrefix(queueName, configs.RootQueue+configs.DOT) {
+		parts := strings.Split(queueName, configs.DOT)
+		for _, part := range parts {
+			if err = configs.IsQueueNameValid(part); err != nil {
+				return "", err
+			}
+		}
+	} else {
+		// not fully qualified queue
+		childQueueName := replaceDot(queueName)
+		if err = configs.IsQueueNameValid(childQueueName); err != nil {
+			return "", err
+		}
 		// run the parent rule if set
 		if pr.parent != nil {
 			parentName, err = pr.parent.placeApplication(app, queueFn)
@@ -113,13 +126,7 @@ func (pr *providedRule) placeApplication(app *objects.Application, queueFn func(
 			parentName = configs.RootQueue
 		}
 		// Make it a fully qualified queue
-		queueName = parentName + configs.DOT + replaceDot(queueName)
-	}
-	parts := strings.Split(queueName, configs.DOT)
-	for _, part := range parts {
-		if err := configs.IsQueueNameValid(part); err != nil {
-			return "", err
-		}
+		queueName = parentName + configs.DOT + childQueueName
 	}
 	// Log the result before we check the create flag
 	log.Log(log.SchedApplication).Debug("Provided rule intermediate result",

--- a/pkg/scheduler/placement/provided_rule.go
+++ b/pkg/scheduler/placement/provided_rule.go
@@ -112,13 +112,20 @@ func (pr *providedRule) placeApplication(app *objects.Application, queueFn func(
 		if parentName == "" {
 			parentName = configs.RootQueue
 		}
+		childQueueName := replaceDot(queueName)
+		if err = configs.IsQueueNameValid(childQueueName); err != nil {
+			return "", err
+		}
 		// Make it a fully qualified queue
-		queueName = parentName + configs.DOT + replaceDot(queueName)
+		queueName = parentName + configs.DOT + childQueueName
 	}
 	// Log the result before we check the create flag
 	log.Log(log.SchedApplication).Debug("Provided rule intermediate result",
 		zap.String("application", app.ApplicationID),
 		zap.String("queue", queueName))
+	if err = configs.IsQueuePathValid(queueName); err != nil {
+		return "", err
+	}
 	// get the queue object
 	queue := queueFn(queueName)
 	// if we cannot create the queue must exist

--- a/pkg/scheduler/placement/provided_rule_test.go
+++ b/pkg/scheduler/placement/provided_rule_test.go
@@ -98,7 +98,7 @@ partitions:
 	if err != nil || pr == nil {
 		t.Errorf("provided rule create failed, err %v", err)
 	}
-	queue, err = pr.placeApplication(appInfo, queueFunc)
+	_, err = pr.placeApplication(appInfo, queueFunc)
 	if err == nil {
 		t.Errorf("provided rule should have failed to place app, error %v", err)
 	}
@@ -132,7 +132,7 @@ partitions:
 
 	// invalid queue with parent rule (parent rule ignored)
 	appInfo = newApplication("app1", "default", "root.testp!arent", user, tags, nil, "")
-	queue, err = pr.placeApplication(appInfo, queueFunc)
+	_, err = pr.placeApplication(appInfo, queueFunc)
 	if err == nil {
 		t.Errorf("provided rule should have failed to place app, error %v", err)
 	}
@@ -225,7 +225,7 @@ func TestProvidedRuleParent(t *testing.T) {
 		t.Errorf("provided rule create failed, err %v", err)
 	}
 	appInfo = newApplication("app1", "default", "testc!hild", user, tags, nil, "")
-	queue, err = pr.placeApplication(appInfo, queueFunc)
+	_, err = pr.placeApplication(appInfo, queueFunc)
 	if err == nil {
 		t.Errorf("provided rule with non existing parent invalid queue should have failed to create, error %v", err)
 	}

--- a/pkg/scheduler/placement/tag_rule.go
+++ b/pkg/scheduler/placement/tag_rule.go
@@ -92,8 +92,20 @@ func (tr *tagRule) placeApplication(app *objects.Application, queueFn func(strin
 	var parentName string
 	var err error
 	queueName := tagVal
-	// if we have a fully qualified queue in the value do not run the parent rule
-	if !strings.HasPrefix(queueName, configs.RootQueue+configs.DOT) {
+	// fully qualified queue, do not run the parent rule
+	if strings.HasPrefix(queueName, configs.RootQueue+configs.DOT) {
+		parts := strings.Split(queueName, configs.DOT)
+		for _, part := range parts {
+			if err = configs.IsQueueNameValid(part); err != nil {
+				return "", err
+			}
+		}
+	} else {
+		// not fully qualified queue
+		childQueueName := replaceDot(tagVal)
+		if err = configs.IsQueueNameValid(childQueueName); err != nil {
+			return "", err
+		}
 		// run the parent rule if set
 		if tr.parent != nil {
 			parentName, err = tr.parent.placeApplication(app, queueFn)
@@ -119,16 +131,10 @@ func (tr *tagRule) placeApplication(app *objects.Application, queueFn func(strin
 		if parentName == "" {
 			parentName = configs.RootQueue
 		}
-		queueName = parentName + configs.DOT + replaceDot(tagVal)
-	}
-	parts := strings.Split(queueName, configs.DOT)
-	for _, part := range parts {
-		if err := configs.IsQueueNameValid(part); err != nil {
-			return "", err
-		}
+		queueName = parentName + configs.DOT + childQueueName
 	}
 	// Log the result before we check the create flag
-	log.Log(log.SchedApplication).Debug("Tag rule intermediate result",
+	log.Log(log.SchedApplication).Info("Tag rule intermediate result",
 		zap.String("application", app.ApplicationID),
 		zap.String("queue", queueName))
 	// get the queue object

--- a/pkg/scheduler/placement/tag_rule.go
+++ b/pkg/scheduler/placement/tag_rule.go
@@ -119,19 +119,18 @@ func (tr *tagRule) placeApplication(app *objects.Application, queueFn func(strin
 		if parentName == "" {
 			parentName = configs.RootQueue
 		}
-		childQueueName := replaceDot(tagVal)
-		if err = configs.IsQueueNameValid(childQueueName); err != nil {
+		queueName = parentName + configs.DOT + replaceDot(tagVal)
+	}
+	parts := strings.Split(queueName, configs.DOT)
+	for _, part := range parts {
+		if err := configs.IsQueueNameValid(part); err != nil {
 			return "", err
 		}
-		queueName = parentName + configs.DOT + childQueueName
 	}
 	// Log the result before we check the create flag
 	log.Log(log.SchedApplication).Debug("Tag rule intermediate result",
 		zap.String("application", app.ApplicationID),
 		zap.String("queue", queueName))
-	if err := configs.IsQueuePathValid(queueName); err != nil {
-		return "", err
-	}
 	// get the queue object
 	queue := queueFn(queueName)
 	// if we cannot create the queue it must exist, rule does not match otherwise

--- a/pkg/scheduler/placement/tag_rule.go
+++ b/pkg/scheduler/placement/tag_rule.go
@@ -119,12 +119,19 @@ func (tr *tagRule) placeApplication(app *objects.Application, queueFn func(strin
 		if parentName == "" {
 			parentName = configs.RootQueue
 		}
-		queueName = parentName + configs.DOT + replaceDot(tagVal)
+		childQueueName := replaceDot(tagVal)
+		if err = configs.IsQueueNameValid(childQueueName); err != nil {
+			return "", err
+		}
+		queueName = parentName + configs.DOT + childQueueName
 	}
 	// Log the result before we check the create flag
 	log.Log(log.SchedApplication).Debug("Tag rule intermediate result",
 		zap.String("application", app.ApplicationID),
 		zap.String("queue", queueName))
+	if err := configs.IsQueuePathValid(queueName); err != nil {
+		return "", err
+	}
 	// get the queue object
 	queue := queueFn(queueName)
 	// if we cannot create the queue it must exist, rule does not match otherwise

--- a/pkg/scheduler/placement/tag_rule_test.go
+++ b/pkg/scheduler/placement/tag_rule_test.go
@@ -107,7 +107,7 @@ partitions:
 	// tag invalid queue
 	tags = map[string]string{"label1": "test!queue"}
 	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
-	queue, err = tr.placeApplication(appInfo, queueFunc)
+	_, err = tr.placeApplication(appInfo, queueFunc)
 	if err == nil {
 		t.Errorf("tag rule should have failed to place app, err %v", err)
 	}
@@ -131,7 +131,7 @@ partitions:
 	// tag invalid queue fully qualified
 	tags = map[string]string{"label1": "root.testparent.test!child"}
 	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
-	queue, err = tr.placeApplication(appInfo, queueFunc)
+	_, err = tr.placeApplication(appInfo, queueFunc)
 	if err == nil {
 		t.Errorf("tag rule should have failed with fully qualified invalid queue, error %v", err)
 	}
@@ -172,7 +172,7 @@ partitions:
 
 	tags = map[string]string{"label1": "testchild", "label2": "testp!arent"}
 	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
-	queue, err = tr.placeApplication(appInfo, queueFunc)
+	_, err = tr.placeApplication(appInfo, queueFunc)
 	if err == nil {
 		t.Errorf("tag rule with parent queue should have failed, error %v", err)
 	}

--- a/pkg/scheduler/placement/tag_rule_test.go
+++ b/pkg/scheduler/placement/tag_rule_test.go
@@ -104,6 +104,14 @@ partitions:
 		t.Errorf("tag rule failed to place queue in correct queue '%s', err %v", queue, err)
 	}
 
+	// tag invalid queue
+	tags = map[string]string{"label1": "test!queue"}
+	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
+	queue, err = tr.placeApplication(appInfo, queueFunc)
+	if err == nil {
+		t.Errorf("tag rule should have failed to place app, err %v", err)
+	}
+
 	// tag queue that does not exists
 	tags = map[string]string{"label1": "unknown"}
 	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
@@ -118,6 +126,14 @@ partitions:
 	queue, err = tr.placeApplication(appInfo, queueFunc)
 	if queue != "root.testparent.testchild" || err != nil {
 		t.Errorf("tag rule did fail with qualified queue '%s', error %v", queue, err)
+	}
+
+	// tag invalid queue fully qualified
+	tags = map[string]string{"label1": "root.testparent.test!child"}
+	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
+	queue, err = tr.placeApplication(appInfo, queueFunc)
+	if err == nil {
+		t.Errorf("tag rule should have failed with fully qualified invalid queue, error %v", err)
 	}
 
 	// tag queue references recovery
@@ -152,6 +168,13 @@ partitions:
 	queue, err = tr.placeApplication(appInfo, queueFunc)
 	if queue != "root.testparent.testchild" || err != nil {
 		t.Errorf("tag rule with parent queue incorrect queue '%s', error %v", queue, err)
+	}
+
+	tags = map[string]string{"label1": "testchild", "label2": "testp!arent"}
+	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
+	queue, err = tr.placeApplication(appInfo, queueFunc)
+	if err == nil {
+		t.Errorf("tag rule with parent queue should have failed, error %v", err)
 	}
 
 	// deny filter type should got got empty queue

--- a/pkg/scheduler/placement/testrule.go
+++ b/pkg/scheduler/placement/testrule.go
@@ -21,6 +21,7 @@ package placement
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/apache/yunikorn-core/pkg/common/configs"
 	"github.com/apache/yunikorn-core/pkg/scheduler/objects"
@@ -70,8 +71,11 @@ func (tr *testRule) placeApplication(app *objects.Application, queueFn func(stri
 		return "", fmt.Errorf("nil app passed in")
 	}
 	if queuePath := app.GetQueuePath(); queuePath != "" {
-		if err := configs.IsQueuePathValid(queuePath); err != nil {
-			return "", err
+		parts := strings.Split(queuePath, configs.DOT)
+		for _, part := range parts {
+			if err := configs.IsQueueNameValid(part); err != nil {
+				return "", err
+			}
 		}
 		return replaceDot(queuePath), nil
 	}

--- a/pkg/scheduler/placement/testrule.go
+++ b/pkg/scheduler/placement/testrule.go
@@ -70,6 +70,9 @@ func (tr *testRule) placeApplication(app *objects.Application, queueFn func(stri
 		return "", fmt.Errorf("nil app passed in")
 	}
 	if queuePath := app.GetQueuePath(); queuePath != "" {
+		if err := configs.IsQueuePathValid(queuePath); err != nil {
+			return "", err
+		}
 		return replaceDot(queuePath), nil
 	}
 	return types.Test, nil

--- a/pkg/scheduler/placement/testrule_test.go
+++ b/pkg/scheduler/placement/testrule_test.go
@@ -20,6 +20,9 @@ package placement
 
 import (
 	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
 
 	"github.com/apache/yunikorn-core/pkg/common/configs"
 	"github.com/apache/yunikorn-core/pkg/common/security"
@@ -96,4 +99,39 @@ func newApplication(appID, partition, queueName string, ugi security.UserGroup, 
 		Tags:          tags,
 	}
 	return objects.NewApplication(siApp, ugi, eventHandler, rmID)
+}
+
+func TestTestRulePlace(t *testing.T) {
+	// Create the structure for the test
+	data := `
+partitions:
+  - name: default
+    queues:
+      - name: testparent
+        queues:
+          - name: testchild
+`
+	err := initQueueStructure([]byte(data))
+	assert.NilError(t, err, "setting up the queue config failed")
+
+	tags := make(map[string]string)
+	user := security.UserGroup{
+		User:   "test",
+		Groups: []string{},
+	}
+
+	conf := configs.PlacementRule{
+		Name: "test",
+	}
+	var pr rule
+	pr, err = newRule(conf)
+	if err != nil || pr == nil {
+		t.Errorf("test rule create failed, err %v", err)
+	}
+	appInfo := newApplication("app1", "default", "testchild", user, tags, nil, "")
+	var queue string
+	queue, err = pr.placeApplication(appInfo, queueFunc)
+	if queue != "testchild" || err != nil {
+		t.Errorf("test rule placed app in incorrect queue '%s', err %v", queue, err)
+	}
 }

--- a/pkg/scheduler/placement/user_rule.go
+++ b/pkg/scheduler/placement/user_rule.go
@@ -75,6 +75,10 @@ func (ur *userRule) placeApplication(app *objects.Application, queueFn func(stri
 			zap.Any("user", app.GetUser()))
 		return "", nil
 	}
+	childQueueName := replaceDot(userName)
+	if err := configs.IsQueueNameValid(childQueueName); err != nil {
+		return "", err
+	}
 	var parentName string
 	var err error
 	// run the parent rule if set
@@ -101,11 +105,6 @@ func (ur *userRule) placeApplication(app *objects.Application, queueFn func(stri
 	// the parent is set from the rule otherwise set it to the root
 	if parentName == "" {
 		parentName = configs.RootQueue
-	}
-
-	childQueueName := replaceDot(userName)
-	if err = configs.IsQueueNameValid(childQueueName); err != nil {
-		return "", err
 	}
 	queueName := parentName + configs.DOT + childQueueName
 	// Log the result before we check the create flag

--- a/pkg/scheduler/placement/user_rule.go
+++ b/pkg/scheduler/placement/user_rule.go
@@ -102,7 +102,12 @@ func (ur *userRule) placeApplication(app *objects.Application, queueFn func(stri
 	if parentName == "" {
 		parentName = configs.RootQueue
 	}
-	queueName := parentName + configs.DOT + replaceDot(userName)
+
+	childQueueName := replaceDot(userName)
+	if err = configs.IsQueueNameValid(childQueueName); err != nil {
+		return "", err
+	}
+	queueName := parentName + configs.DOT + childQueueName
 	// Log the result before we check the create flag
 	log.Log(log.SchedApplication).Debug("User rule intermediate result",
 		zap.String("application", app.ApplicationID),

--- a/pkg/scheduler/placement/user_rule_test.go
+++ b/pkg/scheduler/placement/user_rule_test.go
@@ -60,6 +60,7 @@ partitions:
 		{"user queue with oidc supported characters", security.UserGroup{User: "test.user@gmail.com", Groups: []string{}}, "root.test_dot_user@gmail_dot_com", configs.PlacementRule{Name: "user", Create: true}, true},
 		{"user queue with oidc supported characters", security.UserGroup{User: "http://domain.com/server1/testuser@cloudera.com", Groups: []string{}}, "root.http://domain_dot_com/server1/testuser@cloudera_dot_com", configs.PlacementRule{Name: "user", Create: true}, true},
 		{"invalid queue name", security.UserGroup{User: "invalid!us>er", Groups: []string{}}, "root.http://domain_dot_com/server1/testuser@cloudera_dot_com", configs.PlacementRule{Name: "user", Create: true}, false},
+		{"deny filter type should got empty queue", security.UserGroup{User: "unknown", Groups: []string{}}, "", configs.PlacementRule{Name: "user", Filter: configs.Filter{Type: filterDeny}}, true},
 	}
 
 	for _, tt := range tests {
@@ -83,23 +84,6 @@ partitions:
 				}
 			}
 		})
-	}
-
-	// deny filter type should got got empty queue
-	conf = configs.PlacementRule{
-		Name: "user",
-		Filter: configs.Filter{
-			Type: filterDeny,
-		},
-	}
-	ur, err = newRule(conf)
-	if err != nil || ur == nil {
-		t.Errorf("user rule create failed with queue name, err %v", err)
-	}
-	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
-	queue, err = ur.placeApplication(appInfo, queueFunc)
-	if queue != "" || err != nil {
-		t.Errorf("user rule with deny filter type should got empty queue, err nil")
 	}
 }
 

--- a/pkg/scheduler/placement/user_rule_test.go
+++ b/pkg/scheduler/placement/user_rule_test.go
@@ -44,117 +44,45 @@ partitions:
 	assert.NilError(t, err, "setting up the queue config failed")
 
 	tags := make(map[string]string)
-	user := security.UserGroup{
-		User:   "testchild",
-		Groups: []string{},
-	}
-	appInfo := newApplication("app1", "default", "ignored", user, tags, nil, "")
 
-	// user queue that exists directly under the root
-	conf := configs.PlacementRule{
-		Name: "user",
-	}
-	var ur rule
-	ur, err = newRule(conf)
-	if err != nil || ur == nil {
-		t.Errorf("user rule create failed, err %v", err)
-	}
-	var queue string
-	queue, err = ur.placeApplication(appInfo, queueFunc)
-	if queue != "root.testchild" || err != nil {
-		t.Errorf("user rule failed to place queue in correct queue '%s', err %v", queue, err)
-	}
-	// trying to place in a parent queue should fail on queue create not in the rule
-	user = security.UserGroup{
-		User:   "testparent",
-		Groups: []string{},
-	}
-	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
-	queue, err = ur.placeApplication(appInfo, queueFunc)
-	if queue != "root.testparent" || err != nil {
-		t.Errorf("user rule failed with parent queue '%s', error %v", queue, err)
+	var tests = []struct {
+		name          string
+		user          security.UserGroup
+		expectedQueue string
+		config        configs.PlacementRule
+		nilError      bool
+	}{
+		{"user queue that exists directly under the root", security.UserGroup{User: "testchild", Groups: []string{}}, "root.testchild", configs.PlacementRule{Name: "user"}, true},
+		{"trying to place in a parent queue should fail on queue create not in the rule", security.UserGroup{User: "testparent", Groups: []string{}}, "root.testparent", configs.PlacementRule{Name: "user"}, true},
+		{"user rule with dotted user should not have failed", security.UserGroup{User: "test.user", Groups: []string{}}, "root.test_dot_user", configs.PlacementRule{Name: "user"}, true},
+		{"user queue that exists directly in hierarchy", security.UserGroup{User: "testchild", Groups: []string{}}, "root.testparent.testchild", configs.PlacementRule{Name: "user", Parent: &configs.PlacementRule{Name: "fixed", Value: "testparent"}}, true},
+		{"user queue that does not exists", security.UserGroup{User: "unknown", Groups: []string{}}, "root.unknown", configs.PlacementRule{Name: "user", Create: true}, true},
+		{"user queue with oidc supported characters", security.UserGroup{User: "test.user@gmail.com", Groups: []string{}}, "root.test_dot_user@gmail_dot_com", configs.PlacementRule{Name: "user", Create: true}, true},
+		{"user queue with oidc supported characters", security.UserGroup{User: "http://domain.com/server1/testuser@cloudera.com", Groups: []string{}}, "root.http://domain_dot_com/server1/testuser@cloudera_dot_com", configs.PlacementRule{Name: "user", Create: true}, true},
+		{"invalid queue name", security.UserGroup{User: "invalid!us>er", Groups: []string{}}, "root.http://domain_dot_com/server1/testuser@cloudera_dot_com", configs.PlacementRule{Name: "user", Create: true}, false},
 	}
 
-	user = security.UserGroup{
-		User:   "test.user",
-		Groups: []string{},
-	}
-	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
-	queue, err = ur.placeApplication(appInfo, queueFunc)
-	if queue == "" || err != nil {
-		t.Errorf("user rule with dotted user should not have failed '%s', error %v", queue, err)
-	}
-
-	// user queue that exists directly in hierarchy
-	conf = configs.PlacementRule{
-		Name: "user",
-		Parent: &configs.PlacementRule{
-			Name:  "fixed",
-			Value: "testparent",
-		},
-	}
-	user = security.UserGroup{
-		User:   "testchild",
-		Groups: []string{},
-	}
-	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
-	ur, err = newRule(conf)
-	if err != nil || ur == nil {
-		t.Errorf("user rule create failed with queue name, err %v", err)
-	}
-	queue, err = ur.placeApplication(appInfo, queueFunc)
-	if queue != "root.testparent.testchild" || err != nil {
-		t.Errorf("user rule failed to place queue in correct queue '%s', err %v", queue, err)
-	}
-
-	// user queue that does not exists
-	user = security.UserGroup{
-		User:   "unknown",
-		Groups: []string{},
-	}
-	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
-
-	conf = configs.PlacementRule{
-		Name:   "user",
-		Create: true,
-	}
-	ur, err = newRule(conf)
-	if err != nil || ur == nil {
-		t.Errorf("user rule create failed with queue name, err %v", err)
-	}
-	queue, err = ur.placeApplication(appInfo, queueFunc)
-	if queue != "root.unknown" || err != nil {
-		t.Errorf("user rule placed in to be created queue with create false '%s', err %v", queue, err)
-	}
-
-	user = security.UserGroup{
-		User:   "test.user@gmail.com",
-		Groups: []string{},
-	}
-	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
-	queue, err = ur.placeApplication(appInfo, queueFunc)
-	if queue != "root.test_dot_user@gmail_dot_com" || err != nil {
-		t.Errorf("user rule with dotted user should not have failed '%s', error %v", queue, err)
-	}
-
-	user = security.UserGroup{
-		User:   "http://domain.com/server1/testuser@cloudera.com",
-		Groups: []string{},
-	}
-	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
-	queue, err = ur.placeApplication(appInfo, queueFunc)
-	if queue != "root.http://domain_dot_com/server1/testuser@cloudera_dot_com" || err != nil {
-		t.Errorf("user rule with dotted user should not have failed '%s', error %v", queue, err)
-	}
-
-	user = security.UserGroup{
-		User:   "invalid!us>er",
-		Groups: []string{},
-	}
-	appInfo = newApplication("app1", "default", "ignored", user, tags, nil, "")
-	queue, err = ur.placeApplication(appInfo, queueFunc)
-	if err == nil {
-		t.Errorf("user rule with invalid username should have failed, error %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ur rule
+			ur, err = newRule(tt.config)
+			if err != nil || ur == nil {
+				t.Errorf("user rule create failed, err %v", err)
+			}
+			appInfo := newApplication("app1", "default", "ignored", tt.user, tags, nil, "")
+			var queue string
+			if tt.nilError {
+				queue, err = ur.placeApplication(appInfo, queueFunc)
+				if queue != tt.expectedQueue || err != nil {
+					t.Errorf("user rule failed to place queue in correct queue '%s', err %v", queue, err)
+				}
+			} else {
+				_, err = ur.placeApplication(appInfo, queueFunc)
+				if err == nil {
+					t.Errorf("user rule should have failed to place queue, err %v", err)
+				}
+			}
+		})
 	}
 
 	// deny filter type should got got empty queue
@@ -252,7 +180,7 @@ func TestUserRuleParent(t *testing.T) {
 		Groups: []string{},
 	}
 	appInfo1 := newApplication("app1", "default", "unknown", user1, tags, nil, "")
-	queue, err = ur.placeApplication(appInfo1, queueFunc)
+	_, err = ur.placeApplication(appInfo1, queueFunc)
 	if err == nil {
 		t.Errorf("user rule with non existing parent queue and invalid child queue should have failed, error %v", err)
 	}

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -135,10 +135,8 @@ func validateQueue(queuePath string) error {
 	if queuePath != "" {
 		queueNameArr := strings.Split(queuePath, ".")
 		for _, name := range queueNameArr {
-			if !configs.QueueNameRegExp.MatchString(name) && name != common.RecoveryQueue {
-				return fmt.Errorf("problem in queue query parameter parsing as queue param "+
-					"%s contains invalid queue name %s. Queue name must only have "+
-					"alphanumeric characters, - or _, and be no longer than 64 characters except the recovery queue root.@recovery@", queuePath, name)
+			if err := configs.IsQueueNameValid(name); err != nil {
+				return err
 			}
 		}
 	}

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1744,7 +1744,7 @@ func assertQueueInvalid(t *testing.T, resp *MockResponseWriter, invalidQueuePath
 	err := json.Unmarshal(resp.outputBytes, &errInfo)
 	assert.NilError(t, err, unmarshalError)
 	assert.Equal(t, http.StatusBadRequest, resp.statusCode, statusCodeError)
-	assert.Equal(t, errInfo.Message, "problem in queue query parameter parsing as queue param "+invalidQueuePath+" contains invalid queue name "+invalidQueueName+". Queue name must only have alphanumeric characters, - or _, and be no longer than 64 characters except the recovery queue root.@recovery@", jsonMessageError)
+	assert.Equal(t, errInfo.Message, common.InvalidQueueName.Error(), jsonMessageError)
 	assert.Equal(t, errInfo.StatusCode, http.StatusBadRequest)
 }
 
@@ -1839,9 +1839,8 @@ func TestValidateQueue(t *testing.T) {
 	assert.NilError(t, err, "Queue path is correct but still throwing error.")
 
 	invalidQueuePath := "root.test.test123!"
-	invalidQueueName := "test123!"
 	err1 := validateQueue(invalidQueuePath)
-	assert.Error(t, err1, "problem in queue query parameter parsing as queue param "+invalidQueuePath+" contains invalid queue name "+invalidQueueName+". Queue name must only have alphanumeric characters, - or _, and be no longer than 64 characters except the recovery queue root.@recovery@")
+	assert.Error(t, err1, common.InvalidQueueName.Error())
 
 	err2 := validateQueue("root")
 	assert.NilError(t, err2, "Queue path is correct but still throwing error.")

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1241,11 +1241,11 @@ func TestGetPartitionQueuesHandler(t *testing.T) {
 	// test invalid queue name
 	req, err = http.NewRequest("GET", "/ws/v1/partition/default/queue/root.a", strings.NewReader(""))
 	assert.NilError(t, err, "HTTP request create failed")
-	req = req.WithContext(context.WithValue(req.Context(), httprouter.ParamsKey, httprouter.Params{httprouter.Param{Key: "partition", Value: "default"}, httprouter.Param{Key: "queue", Value: "root.notexists@"}}))
+	req = req.WithContext(context.WithValue(req.Context(), httprouter.ParamsKey, httprouter.Params{httprouter.Param{Key: "partition", Value: "default"}, httprouter.Param{Key: "queue", Value: "root.notexists!"}}))
 	assert.NilError(t, err)
 	resp = &MockResponseWriter{}
 	getPartitionQueue(resp, req)
-	assertQueueInvalid(t, resp, "root.notexists@", "notexists@")
+	assertQueueInvalid(t, resp, "root.notexists!", "notexists!")
 
 	// test queue is not exists
 	req, err = http.NewRequest("GET", "/ws/v1/partition/default/queue/root.a", strings.NewReader(""))
@@ -1696,13 +1696,13 @@ func TestGetApplicationHandler(t *testing.T) {
 	assert.NilError(t, err, "HTTP request create failed")
 	req5 = req5.WithContext(context.WithValue(req.Context(), httprouter.ParamsKey, httprouter.Params{
 		httprouter.Param{Key: "partition", Value: partitionNameWithoutClusterID},
-		httprouter.Param{Key: "queue", Value: "root.test.test123@"},
+		httprouter.Param{Key: "queue", Value: "root.test.test123!"},
 		httprouter.Param{Key: "application", Value: "app-1"},
 	}))
 	assert.NilError(t, err, "Get Application Handler request failed")
 	resp5 := &MockResponseWriter{}
 	getApplication(resp5, req5)
-	assertQueueInvalid(t, resp5, "root.test.test123@", "test123@")
+	assertQueueInvalid(t, resp5, "root.test.test123!", "test123!")
 
 	// test missing params name
 	req, err = http.NewRequest("GET", "/ws/v1/partition/default/queue/root.default/application/app-1", strings.NewReader(""))
@@ -1838,8 +1838,8 @@ func TestValidateQueue(t *testing.T) {
 	err := validateQueue("root.test.test123")
 	assert.NilError(t, err, "Queue path is correct but still throwing error.")
 
-	invalidQueuePath := "root.test.test123@"
-	invalidQueueName := "test123@"
+	invalidQueuePath := "root.test.test123!"
+	invalidQueueName := "test123!"
 	err1 := validateQueue(invalidQueuePath)
 	assert.Error(t, err1, "problem in queue query parameter parsing as queue param "+invalidQueuePath+" contains invalid queue name "+invalidQueueName+". Queue name must only have alphanumeric characters, - or _, and be no longer than 64 characters except the recovery queue root.@recovery@")
 


### PR DESCRIPTION
### What is this PR for?

Queue name being generated as part of the various placement rule should follow similar validation checks already being carried out for queuename coming through config.

### What type of PR is it?
* [ ] - Feature

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2657

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
