### PR TITLE
[YUNIKORN-2677] Rename AllocationResult to AllocationResultType

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -141,7 +141,7 @@ func (cc *ClusterContext) schedule() bool {
 		}
 		if alloc != nil {
 			metrics.GetSchedulerMetrics().ObserveSchedulingLatency(schedulingStart)
-			if alloc.GetResult() == objects.Replaced {
+			if alloc.GetResultType() == objects.Replaced {
 				// communicate the removal to the RM
 				cc.notifyRMAllocationReleased(psc.RmID, psc.Name, []*objects.Allocation{alloc.GetRelease()}, si.TerminationType_PLACEHOLDER_REPLACED, "replacing allocationKey: "+alloc.GetAllocationKey())
 			} else {

--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -32,10 +32,10 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
-type AllocationResult int
+type AllocationResultType int
 
 const (
-	None AllocationResult = iota
+	None AllocationResultType = iota
 	Allocated
 	AllocatedReserved
 	Reserved
@@ -43,7 +43,7 @@ const (
 	Replaced
 )
 
-func (ar AllocationResult) String() string {
+func (ar AllocationResultType) String() string {
 	return [...]string{"None", "Allocated", "AllocatedReserved", "Reserved", "Unreserved", "Replaced"}[ar]
 }
 
@@ -66,7 +66,7 @@ type Allocation struct {
 	placeholderCreateTime time.Time
 	released              bool
 	reservedNodeID        string
-	result                AllocationResult
+	resultType            AllocationResultType
 	release               *Allocation
 	preempted             bool
 	instType              string
@@ -87,21 +87,21 @@ func NewAllocation(nodeID string, ask *AllocationAsk) *Allocation {
 		allocatedResource: ask.GetAllocatedResource().Clone(),
 		taskGroupName:     ask.GetTaskGroup(),
 		placeholder:       ask.IsPlaceholder(),
-		result:            Allocated,
+		resultType:        Allocated,
 	}
 }
 
 func newReservedAllocation(nodeID string, ask *AllocationAsk) *Allocation {
 	alloc := NewAllocation(nodeID, ask)
 	alloc.SetBindTime(time.Time{})
-	alloc.SetResult(Reserved)
+	alloc.SetResultType(Reserved)
 	return alloc
 }
 
 func newUnreservedAllocation(nodeID string, ask *AllocationAsk) *Allocation {
 	alloc := NewAllocation(nodeID, ask)
 	alloc.SetBindTime(time.Time{})
-	alloc.SetResult(Unreserved)
+	alloc.SetResultType(Unreserved)
 	return alloc
 }
 
@@ -179,7 +179,7 @@ func (a *Allocation) String() string {
 	}
 	a.RLock()
 	defer a.RUnlock()
-	return fmt.Sprintf("applicationID=%s, allocationKey=%s, Node=%s, result=%s", a.applicationID, a.allocationKey, a.nodeID, a.result.String())
+	return fmt.Sprintf("applicationID=%s, allocationKey=%s, Node=%s, resultType=%s", a.applicationID, a.allocationKey, a.nodeID, a.resultType.String())
 }
 
 // GetAsk returns the ask associated with this allocation
@@ -310,18 +310,18 @@ func (a *Allocation) GetTagsClone() map[string]string {
 	return CloneAllocationTags(a.tags)
 }
 
-// GetResult gets the result of this allocation
-func (a *Allocation) GetResult() AllocationResult {
+// GetResultType gets the result type of this allocation
+func (a *Allocation) GetResultType() AllocationResultType {
 	a.RLock()
 	defer a.RUnlock()
-	return a.result
+	return a.resultType
 }
 
-// SetResult sets the result of this allocation
-func (a *Allocation) SetResult(result AllocationResult) {
+// SetResultType sets the result type of this allocation
+func (a *Allocation) SetResultType(resultType AllocationResultType) {
 	a.Lock()
 	defer a.Unlock()
-	a.result = result
+	a.resultType = resultType
 }
 
 // GetRelease returns the associated release for this allocation

--- a/pkg/scheduler/objects/allocation_test.go
+++ b/pkg/scheduler/objects/allocation_test.go
@@ -54,7 +54,7 @@ func TestNewAlloc(t *testing.T) {
 		t.Fatal("NewAllocation create failed while it should not")
 	}
 	assert.Equal(t, alloc.GetAllocationKey(), "ask-1")
-	assert.Equal(t, alloc.GetResult(), Allocated, "New alloc should default to result Allocated")
+	assert.Equal(t, alloc.GetResultType(), Allocated, "New alloc should default to result type Allocated")
 	assert.Assert(t, resources.Equals(alloc.GetAllocatedResource(), res), "Allocated resource not set correctly")
 	assert.Assert(t, !alloc.IsPlaceholder(), "ask should not have been a placeholder")
 	assert.Equal(t, time.Now().Round(time.Second), alloc.GetCreateTime().Round(time.Second))
@@ -62,7 +62,7 @@ func TestNewAlloc(t *testing.T) {
 	alloc.SetInstanceType(instType1)
 	assert.Equal(t, alloc.GetInstanceType(), instType1, "Instance type not set as expected")
 	allocStr := alloc.String()
-	expected := "applicationID=app-1, allocationKey=ask-1, Node=node-1, result=Allocated"
+	expected := "applicationID=app-1, allocationKey=ask-1, Node=node-1, resultType=Allocated"
 	assert.Equal(t, allocStr, expected, "Strings should have been equal")
 	assert.Assert(t, !alloc.IsPlaceholderUsed(), fmt.Sprintf("Alloc should not be placeholder replacement by default: got %t, expected %t", alloc.IsPlaceholderUsed(), false))
 	// check that createTime is properly copied from the ask
@@ -82,10 +82,10 @@ func TestNewReservedAlloc(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("NewReservedAllocation create failed while it should not")
 	}
-	assert.Equal(t, alloc.GetResult(), Reserved, "NewReservedAlloc should have Reserved result")
+	assert.Equal(t, alloc.GetResultType(), Reserved, "NewReservedAlloc should have Reserved result type")
 	assert.Assert(t, resources.Equals(alloc.GetAllocatedResource(), res), "Allocated resource not set correctly")
 	allocStr := alloc.String()
-	expected := "applicationID=app-1, allocationKey=ask-1, Node=node-1, result=Reserved"
+	expected := "applicationID=app-1, allocationKey=ask-1, Node=node-1, resultType=Reserved"
 	assert.Equal(t, allocStr, expected, "Strings should have been equal")
 }
 
@@ -97,10 +97,10 @@ func TestNewUnreservedAlloc(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("NewReservedAllocation create failed while it should not")
 	}
-	assert.Equal(t, alloc.GetResult(), Unreserved, "NewReservedAlloc should have Reserved result")
+	assert.Equal(t, alloc.GetResultType(), Unreserved, "NewReservedAlloc should have Reserved result type")
 	assert.Assert(t, resources.Equals(alloc.GetAllocatedResource(), res), "Allocated resource not set correctly")
 	allocStr := alloc.String()
-	expected := "applicationID=app-1, allocationKey=ask-1, Node=node-1, result=Unreserved"
+	expected := "applicationID=app-1, allocationKey=ask-1, Node=node-1, resultType=Unreserved"
 	assert.Equal(t, allocStr, expected, "Strings should have been equal")
 }
 

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -960,7 +960,7 @@ func TestGangAllocChange(t *testing.T) {
 
 	// add a real alloc this should NOT trigger state update
 	alloc = newAllocation(appID1, nodeID1, res)
-	alloc.SetResult(Replaced)
+	alloc.SetResultType(Replaced)
 	app.AddAllocation(alloc)
 	assert.Equal(t, len(app.GetAllAllocations()), 3)
 	assert.Assert(t, app.IsRunning(), "app should still be in running state")
@@ -968,7 +968,7 @@ func TestGangAllocChange(t *testing.T) {
 
 	// add a second real alloc this should NOT trigger state update
 	alloc = newAllocation(appID1, nodeID1, res)
-	alloc.SetResult(Replaced)
+	alloc.SetResultType(Replaced)
 	app.AddAllocation(alloc)
 	assert.Equal(t, len(app.GetAllAllocations()), 4)
 	assert.Assert(t, app.IsRunning(), "app should still be in running state")
@@ -1271,7 +1271,7 @@ func TestReplaceAllocation(t *testing.T) {
 
 	// set the real one to replace the placeholder
 	realAlloc := newAllocation(appID1, nodeID1, res)
-	realAlloc.SetResult(Replaced)
+	realAlloc.SetResultType(Replaced)
 	ph.SetRelease(realAlloc)
 	alloc = app.ReplaceAllocation(ph.GetAllocationKey())
 	assert.Equal(t, alloc, ph, "returned allocation is not the placeholder")
@@ -1293,10 +1293,10 @@ func TestReplaceAllocation(t *testing.T) {
 
 	// set multiple real allocations to replace the placeholder
 	realAlloc = newAllocation(appID1, nodeID1, res)
-	realAlloc.SetResult(Replaced)
+	realAlloc.SetResultType(Replaced)
 	ph.SetRelease(realAlloc)
 	realAllocNoAdd := newAllocation(appID1, nodeID1, res)
-	realAllocNoAdd.SetResult(Replaced)
+	realAllocNoAdd.SetResultType(Replaced)
 	ph.SetRelease(realAlloc)
 	alloc = app.ReplaceAllocation(ph.GetAllocationKey())
 	assert.Equal(t, alloc, ph, "returned allocation is not the placeholder")
@@ -1345,21 +1345,21 @@ func TestReplaceAllocationTracking(t *testing.T) {
 
 	// replace placeholders
 	realAlloc1 := newAllocation(appID1, nodeID1, res)
-	realAlloc1.SetResult(Replaced)
+	realAlloc1.SetResultType(Replaced)
 	ph1.SetRelease(realAlloc1)
 	alloc1 := app.ReplaceAllocation(ph1.GetAllocationKey())
 	app.RemoveAllocation(ph1.GetAllocationKey(), si.TerminationType_PLACEHOLDER_REPLACED)
 	assert.Equal(t, ph1.GetAllocationKey(), alloc1.GetAllocationKey())
 	assert.Equal(t, true, app.HasPlaceholderAllocation())
 	realAlloc2 := newAllocation(appID1, nodeID1, res)
-	realAlloc2.SetResult(Replaced)
+	realAlloc2.SetResultType(Replaced)
 	ph2.SetRelease(realAlloc2)
 	alloc2 := app.ReplaceAllocation(ph2.GetAllocationKey())
 	app.RemoveAllocation(ph2.GetAllocationKey(), si.TerminationType_PLACEHOLDER_REPLACED)
 	assert.Equal(t, ph2.GetAllocationKey(), alloc2.GetAllocationKey())
 	assert.Equal(t, true, app.HasPlaceholderAllocation())
 	realAlloc3 := newAllocation(appID1, nodeID1, res)
-	realAlloc3.SetResult(Replaced)
+	realAlloc3.SetResultType(Replaced)
 	ph3.SetRelease(realAlloc3)
 	alloc3 := app.ReplaceAllocation(ph3.GetAllocationKey())
 	app.RemoveAllocation(ph3.GetAllocationKey(), si.TerminationType_PLACEHOLDER_REPLACED)
@@ -1861,7 +1861,7 @@ func TestTryAllocatePreemptQueue(t *testing.T) {
 	// pass the time and try again
 	ask3.createTime = ask3.createTime.Add(-30 * time.Second)
 	alloc3 = app2.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 0}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
-	assert.Assert(t, alloc3 != nil && alloc3.result == Reserved, "alloc3 should be a reservation")
+	assert.Assert(t, alloc3 != nil && alloc3.resultType == Reserved, "alloc3 should be a reservation")
 	assert.Assert(t, alloc2.IsPreempted(), "alloc2 should have been preempted")
 }
 
@@ -1932,7 +1932,7 @@ func TestTryAllocatePreemptNode(t *testing.T) {
 	alloc3 := app2.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 18}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Assert(t, alloc3 != nil, "alloc3 expected")
 	assert.Equal(t, "node1", alloc3.GetNodeID(), "wrong node assignment")
-	assert.Equal(t, Reserved, alloc3.GetResult(), "expected reservation")
+	assert.Equal(t, Reserved, alloc3.GetResultType(), "expected reservation")
 	assert.Assert(t, !alloc2.IsPreempted(), "alloc2 should not have been preempted")
 	err = node1.Reserve(app2, ask3)
 	assert.NilError(t, err)

--- a/pkg/scheduler/objects/node_test.go
+++ b/pkg/scheduler/objects/node_test.go
@@ -186,7 +186,7 @@ func TestCanAllocate(t *testing.T) {
 			sn := &Node{
 				availableResource: tt.available,
 			}
-			assert.Equal(t, sn.CanAllocate(tt.request), tt.want, "unexpected node can run result")
+			assert.Equal(t, sn.CanAllocate(tt.request), tt.want, "unexpected node can run resultType")
 		})
 	}
 }
@@ -765,7 +765,7 @@ func TestNode_FitInNode(t *testing.T) {
 			sn := &Node{
 				totalResource: tt.totalRes,
 			}
-			assert.Equal(t, sn.FitInNode(tt.resRequest), tt.want, "unexpected node fit result")
+			assert.Equal(t, sn.FitInNode(tt.resRequest), tt.want, "unexpected node fit resultType")
 		})
 	}
 }

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -206,7 +206,7 @@ func (p *Preemptor) checkPreemptionQueueGuarantees() bool {
 
 // calculateVictimsByNode takes a list of potential victims for a node and builds a list ready for the RM to process.
 // Result is a list of allocations and the starting index to check for the initial preemption list.
-// If the result is nil, the node should not be considered for preemption.
+// If the resultType is nil, the node should not be considered for preemption.
 func (p *Preemptor) calculateVictimsByNode(nodeAvailable *resources.Resource, potentialVictims []*Allocation) (int, []*Allocation) {
 	nodeCurrentAvailable := nodeAvailable.Clone()
 	allocationsByQueueSnap := p.duplicateQueueSnapshots()
@@ -345,7 +345,7 @@ func (p *Preemptor) checkPreemptionPredicates(predicateChecks []*si.PreemptionPr
 	// check for RM callback
 	plugin := plugins.GetResourceManagerCallbackPlugin()
 	if plugin == nil {
-		// if a plugin isn't registered, assume checks will succeed and synthesize a result
+		// if a plugin isn't registered, assume checks will succeed and synthesize a resultType
 		check := predicateChecks[0]
 		log.Log(log.SchedPreemption).Debug("No RM callback plugin registered, using first selected node for preemption",
 			zap.String("NodeID", check.NodeID),
@@ -380,7 +380,7 @@ func (p *Preemptor) checkPreemptionPredicates(predicateChecks []*si.PreemptionPr
 			close(ch)
 		}()
 		for result := range ch {
-			// if result is successful, keep track of it
+			// if resultType is successful, keep track of it
 			if result.success {
 				if bestResult == nil {
 					bestResult = result
@@ -389,7 +389,7 @@ func (p *Preemptor) checkPreemptionPredicates(predicateChecks []*si.PreemptionPr
 				}
 			}
 		}
-		// if the best result we have from this batch meets all our criteria, don't run another batch
+		// if the best resultType we have from this batch meets all our criteria, don't run another batch
 		if bestResult.isSatisfactory(p.allocationsByNode) {
 			break
 		}
@@ -897,7 +897,7 @@ func sortVictimsForPreemption(allocationsByNode map[string][]*Allocation) {
 	}
 }
 
-// preemptPredicateCheck performs a single predicate check and reports the result on a channel
+// preemptPredicateCheck performs a single predicate check and reports the resultType on a channel
 func preemptPredicateCheck(plugin api.ResourceManagerCallback, ch chan<- *predicateCheckResult, wg *sync.WaitGroup, args *si.PreemptionPredicatesArgs) {
 	defer wg.Done()
 	result := &predicateCheckResult{

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -173,7 +173,7 @@ func TestCheckPreemptionQueueGuaranteesWithNoGuaranteedResources(t *testing.T) {
 			childQ2.incPendingResource(ask3.GetAllocatedResource())
 			headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
 			preemptor := NewPreemptor(app2, headRoom, 30*time.Second, ask3, iterator(), false)
-			assert.Equal(t, tt.expected, preemptor.checkPreemptionQueueGuarantees(), "unexpected result")
+			assert.Equal(t, tt.expected, preemptor.checkPreemptionQueueGuarantees(), "unexpected resultType")
 		})
 	}
 }

--- a/pkg/scheduler/objects/sorters_test.go
+++ b/pkg/scheduler/objects/sorters_test.go
@@ -226,7 +226,7 @@ func TestSortAppsFifo(t *testing.T) {
 	list = sortApplications(input, policies.FifoSortPolicy, false, nil)
 	/*
 	* apps order: 0, 3, 1, 2
-	* the result of app index is [0, 2, 3, 1]
+	* the resultType of app index is [0, 2, 3, 1]
 	* app0 with index 0, app1 with index 2, app2 with index 3 and app3 with index 1
 	 */
 	assertAppList(t, list, []int{0, 2, 3, 1}, "fifo first, priority second")
@@ -306,7 +306,7 @@ func TestSortAppsFair(t *testing.T) {
 	list = sortApplications(input, policies.FairSortPolicy, false, resources.Multiply(res, 5))
 	/*
 	*  expected apps order: 0, 2, 3, 1 means
-	*  So result of apps indexs is [0, 3, 1, 2]
+	*  So resultType of apps indexs is [0, 3, 1, 2]
 	*  app0 in 0, app1 in 3, app2 in 1, app3 in 2:
 	 */
 	assertAppList(t, list, []int{0, 3, 1, 2}, "app-1 & app-3 allocated, app-3 high priority")

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -916,14 +916,14 @@ func (pc *PartitionContext) allocate(alloc *objects.Allocation) *objects.Allocat
 	}
 	alloc.SetInstanceType(node.GetInstanceType())
 	// reservation
-	if alloc.GetResult() == objects.Reserved {
+	if alloc.GetResultType() == objects.Reserved {
 		pc.reserve(app, node, alloc.GetAsk())
 		return nil
 	}
 	// unreserve
-	if alloc.GetResult() == objects.Unreserved || alloc.GetResult() == objects.AllocatedReserved {
+	if alloc.GetResultType() == objects.Unreserved || alloc.GetResultType() == objects.AllocatedReserved {
 		pc.unReserve(app, node, alloc.GetAsk())
-		if alloc.GetResult() == objects.Unreserved {
+		if alloc.GetResultType() == objects.Unreserved {
 			return nil
 		}
 		// remove the link to the reserved node

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -374,7 +374,7 @@ func TestRemoveNodeWithPlaceholders(t *testing.T) {
 	alloc.SetRelease(ph)
 	// double link as if the replacement is ongoing
 	ph.SetRelease(alloc)
-	alloc.SetResult(objects.Replaced)
+	alloc.SetResultType(objects.Replaced)
 
 	allocs = app.GetAllAllocations()
 	assert.Equal(t, len(allocs), 1, "expected one allocation for the app (placeholder)")
@@ -774,7 +774,7 @@ func TestRemoveNodeWithReplacement(t *testing.T) {
 	// add real allocation that is replacing the placeholder on the 2nd node
 	alloc := objects.NewAllocation(nodeID2, ask)
 	alloc.SetRelease(ph)
-	alloc.SetResult(objects.Replaced)
+	alloc.SetResultType(objects.Replaced)
 	node2.AddAllocation(alloc)
 	allocated = node2.GetAllAllocations()
 	assert.Equal(t, 1, len(allocated), "allocation not added correctly to node2")
@@ -801,7 +801,7 @@ func TestRemoveNodeWithReplacement(t *testing.T) {
 	allocs = app.GetAllAllocations()
 	assert.Equal(t, 1, len(allocs), "expected one allocation for the app (real)")
 	assert.Equal(t, alloc.GetAllocationKey(), allocs[0].GetAllocationKey(), "allocationKey for the app is not the same as the real allocation")
-	assert.Equal(t, objects.Allocated, allocs[0].GetResult(), "allocation state should be allocated")
+	assert.Equal(t, objects.Allocated, allocs[0].GetResultType(), "allocation result type should be allocated")
 	assert.Check(t, !allocs[0].HasRelease(), "real allocation should not have release liked anymore")
 	assertLimits(t, getTestUserGroup(), appRes)
 }
@@ -846,7 +846,7 @@ func TestRemoveNodeWithReal(t *testing.T) {
 	// add real allocation that is replacing the placeholder on the 2nd node
 	alloc := objects.NewAllocation(nodeID2, ask)
 	alloc.SetRelease(ph)
-	alloc.SetResult(objects.Replaced)
+	alloc.SetResultType(objects.Replaced)
 	node2.AddAllocation(alloc)
 	allocated = node2.GetAllAllocations()
 	assert.Equal(t, 1, len(allocated), "allocation not added correctly to node2")
@@ -1577,7 +1577,7 @@ func TestTryAllocate(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 	assert.Check(t, !alloc.HasRelease(), "released allocation should not exist")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocKey2, "expected ask alloc-2 to be allocated")
@@ -1588,7 +1588,7 @@ func TestTryAllocate(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 	assert.Check(t, !alloc.HasRelease(), "released allocation should not exist")
 	assert.Equal(t, alloc.GetApplicationID(), appID2, "expected application app-2 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocKey, "expected ask alloc-1 to be allocated")
@@ -1599,7 +1599,7 @@ func TestTryAllocate(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 	assert.Check(t, !alloc.HasRelease(), "released allocation should not exist")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocKey, "expected ask alloc-1 to be allocated")
@@ -1636,7 +1636,7 @@ func TestRequiredNodeReservation(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 	assert.Check(t, !alloc.HasRelease(), "released allocation should not exist")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocKey, "expected ask alloc-1 to be allocated")
@@ -1716,7 +1716,7 @@ func TestRequiredNodeCancelNonDSReservations(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("1st allocation did not return the correct allocation")
 	}
-	assert.Equal(t, objects.Allocated, alloc.GetResult(), "allocation result should have been allocated")
+	assert.Equal(t, objects.Allocated, alloc.GetResultType(), "allocation result type should have been allocated")
 
 	// the second one should be reserved as the 2nd node is not scheduling
 	alloc = partition.tryAllocate()
@@ -1745,7 +1745,7 @@ func TestRequiredNodeCancelNonDSReservations(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("1st allocation did not return the correct allocation")
 	}
-	assert.Equal(t, objects.Allocated, alloc.GetResult(), "allocation result should have been allocated")
+	assert.Equal(t, objects.Allocated, alloc.GetResultType(), "allocation result type should have been allocated")
 
 	// earlier app (app1) reservation count should be zero
 	assert.Equal(t, 0, len(app.GetReservations()), "ask should have been reserved")
@@ -1796,7 +1796,7 @@ func TestRequiredNodeCancelDSReservations(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("1st allocation did not return the correct allocation")
 	}
-	assert.Equal(t, objects.Allocated, alloc.GetResult(), "allocation result should have been allocated")
+	assert.Equal(t, objects.Allocated, alloc.GetResultType(), "allocation result type should have been allocated")
 
 	// the second one should be reserved as the 2nd node is not scheduling
 	alloc = partition.tryAllocate()
@@ -1895,7 +1895,7 @@ func TestRequiredNodeAllocation(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 	assert.Check(t, !alloc.HasRelease(), "released allocation should not exist")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocKey, "expected ask alloc-1 to be allocated")
@@ -1915,7 +1915,7 @@ func TestRequiredNodeAllocation(t *testing.T) {
 	// ensure there is no reservations
 	assert.Equal(t, 0, len(app.GetReservations()), "ask should not have been reserved")
 	assert.Equal(t, alloc.GetAllocationKey(), allocKey2, "expected ask alloc-2 to be allocated")
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 	assertLimits(t, getTestUserGroup(), resources.Multiply(res, 2))
 }
 
@@ -1994,7 +1994,7 @@ func TestPreemption(t *testing.T) {
 		t.Fatal("missing allocation")
 	}
 	assert.Equal(t, 0, len(app2.GetReservations()), "ask should not be reserved")
-	assert.Equal(t, alloc.GetResult(), objects.AllocatedReserved, "result should be allocated from reservation")
+	assert.Equal(t, alloc.GetResultType(), objects.AllocatedReserved, "result type should be allocated from reservation")
 	assert.Equal(t, alloc.GetAllocationKey(), allocKey3, "expected ask alloc-3 to be allocated")
 	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 10000}), getExpectedQueuesLimitsForPreemption())
 
@@ -2031,7 +2031,7 @@ func TestPreemptionForRequiredNodeReservedAlloc(t *testing.T) {
 	}
 	// check if updated (must be after allocate call)
 	assert.Equal(t, 0, len(app.GetReservations()), "ask should have no longer be reserved")
-	assert.Equal(t, alloc.GetResult(), objects.AllocatedReserved, "result is not the expected AllocatedReserved")
+	assert.Equal(t, alloc.GetResultType(), objects.AllocatedReserved, "result type is not the expected AllocatedReserved")
 	assert.Check(t, !alloc.HasRelease(), "released allocation should not be present")
 	assert.Equal(t, alloc.GetAllocationKey(), allocKey2, "expected ask alloc-2 to be allocated")
 	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 8000}), getExpectedQueuesLimitsForPreemption())
@@ -2144,7 +2144,7 @@ func setupPreemption(t *testing.T) (*PartitionContext, *objects.Application, *ob
 	if alloc1 == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc1.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc1.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 	assert.Check(t, !alloc1.HasRelease(), "released allocation should not be present")
 	assert.Equal(t, alloc1.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc1.GetAllocationKey(), allocKey, "expected ask alloc-1 to be allocated")
@@ -2162,7 +2162,7 @@ func setupPreemption(t *testing.T) (*PartitionContext, *objects.Application, *ob
 	if alloc2 == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc2.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc2.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 	assert.Check(t, !alloc2.HasRelease(), "released allocation should not be present")
 	assert.Equal(t, alloc2.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc2.GetAllocationKey(), allocKey2, "expected ask alloc-2 to be allocated")
@@ -2206,7 +2206,7 @@ func setupPreemptionForRequiredNode(t *testing.T) (*PartitionContext, *objects.A
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 	assert.Check(t, !alloc.HasRelease(), "released allocation should not be present")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocKey, "expected ask alloc-1 to be allocated")
@@ -2332,7 +2332,7 @@ func TestAllocReserveNewNode(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("1st allocation did not return the correct allocation")
 	}
-	assert.Equal(t, objects.Allocated, alloc.GetResult(), "allocation result should have been allocated")
+	assert.Equal(t, objects.Allocated, alloc.GetResultType(), "allocation result type should have been allocated")
 	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 8000}))
 
 	// the second one should be reserved as the 2nd node is not scheduling
@@ -2347,7 +2347,7 @@ func TestAllocReserveNewNode(t *testing.T) {
 	// turn on 2nd node
 	node2.SetSchedulable(true)
 	alloc = partition.tryReservedAllocate()
-	assert.Equal(t, objects.AllocatedReserved, alloc.GetResult(), "allocation result should have been allocatedReserved")
+	assert.Equal(t, objects.AllocatedReserved, alloc.GetResultType(), "allocation result type should have been allocatedReserved")
 	assert.Equal(t, "", alloc.GetReservedNodeID(), "reserved node should be reset after processing")
 	assert.Equal(t, node2.NodeID, alloc.GetNodeID(), "allocation should be fulfilled on new node")
 	// check if all updated
@@ -2398,7 +2398,7 @@ func TestTryAllocateReserve(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.AllocatedReserved, "result is not the expected allocated from reserved")
+	assert.Equal(t, alloc.GetResultType(), objects.AllocatedReserved, "result type is not the expected allocated from reserved")
 	assert.Equal(t, alloc.GetReservedNodeID(), "", "node should not be set for allocated from reserved")
 	assert.Check(t, !alloc.HasRelease(), "released allocation should not be present")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
@@ -2420,7 +2420,7 @@ func TestTryAllocateReserve(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 	assert.Check(t, !alloc.HasRelease(), "released allocation should not be present")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), "alloc-1", "expected ask alloc-1 to be allocated")
@@ -2469,7 +2469,7 @@ func TestTryAllocateWithReserved(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return correct an allocation")
 	}
-	assert.Equal(t, objects.AllocatedReserved, alloc.GetResult(), "expected reserved allocation to be returned")
+	assert.Equal(t, objects.AllocatedReserved, alloc.GetResultType(), "expected reserved allocation to be returned")
 	assert.Equal(t, "", alloc.GetReservedNodeID(), "reserved node should be reset after processing")
 	assert.Equal(t, 0, len(node2.GetReservationKeys()), "reservation should have been removed from node")
 	assert.Equal(t, false, app.IsReservedOnNode(node2.NodeID), "reservation cleanup for ask on app failed")
@@ -2480,7 +2480,7 @@ func TestTryAllocateWithReserved(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return correct allocation")
 	}
-	assert.Equal(t, objects.Allocated, alloc.GetResult(), "expected allocated allocation to be returned")
+	assert.Equal(t, objects.Allocated, alloc.GetResultType(), "expected allocated allocation to be returned")
 	assert.Equal(t, node2.NodeID, alloc.GetNodeID(), "expected allocation on node2 to be returned")
 	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 10000}))
 }
@@ -2518,7 +2518,7 @@ func TestScheduleRemoveReservedAsk(t *testing.T) {
 	// allocate the ask
 	for i := 1; i <= 4; i++ {
 		alloc := partition.tryAllocate()
-		if alloc == nil || alloc.GetResult() != objects.Allocated {
+		if alloc == nil || alloc.GetResultType() != objects.Allocated {
 			t.Fatalf("expected allocated allocation to be returned (step %d) %s", i, alloc)
 		}
 	}
@@ -2551,7 +2551,7 @@ func TestScheduleRemoveReservedAsk(t *testing.T) {
 	// Try to allocate one of the reservation. We go directly to the root queue not using the partition otherwise
 	// we confirm before we get back in the test code and cannot remove the ask
 	alloc := partition.root.TryReservedAllocate(partition.GetNodeIterator)
-	if alloc == nil || alloc.GetResult() != objects.AllocatedReserved {
+	if alloc == nil || alloc.GetResultType() != objects.AllocatedReserved {
 		t.Fatalf("expected allocatedReserved allocation to be returned %v", alloc)
 	}
 	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 20000}))
@@ -3094,7 +3094,7 @@ func TestPlaceholderBiggerThanReal(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation should have matched placeholder")
 	}
-	assert.Equal(t, objects.Replaced, alloc.GetResult(), "expected replacement result to be returned")
+	assert.Equal(t, objects.Replaced, alloc.GetResultType(), "expected replacement result type to be returned")
 	assert.Check(t, alloc.HasRelease(), "placeholder should have been linked")
 	// no updates yet on queue and node
 	assert.Assert(t, resources.Equals(phRes, app.GetQueue().GetAllocatedResource()), "placeholder size should still be allocated on queue")
@@ -3338,7 +3338,7 @@ func TestTryPlaceholderAllocate(t *testing.T) {
 	}
 	assert.Equal(t, node.GetAllocation(alloc.GetAllocationKey()), alloc, "placeholder allocation not found on node")
 	assert.Assert(t, alloc.IsPlaceholder(), "placeholder alloc should return a placeholder allocation")
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "placeholder alloc should return an allocated result")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "placeholder alloc should return an allocated result")
 	if !resources.Equals(app.GetPlaceholderResource(), res) {
 		t.Fatalf("placeholder allocation not updated as expected: got %s, expected %s", app.GetPlaceholderResource(), res)
 	}
@@ -3387,7 +3387,7 @@ func TestTryPlaceholderAllocate(t *testing.T) {
 	}
 	assert.Equal(t, 2, partition.GetTotalAllocationCount(), "placeholder replacement should not be counted as alloc")
 	assert.Equal(t, 2, partition.getPhAllocationCount(), "placeholder allocation should be registered")
-	assert.Equal(t, alloc.GetResult(), objects.Replaced, "result is not the expected allocated replaced")
+	assert.Equal(t, alloc.GetResultType(), objects.Replaced, "result type is not the expected allocated replaced")
 	assert.Check(t, alloc.HasRelease(), "released allocation should be present")
 	assertLimits(t, getTestUserGroup(), resources.Multiply(res, 2))
 	phAllocationKey := alloc.GetRelease().GetAllocationKey()
@@ -3462,7 +3462,7 @@ func TestFailReplacePlaceholder(t *testing.T) {
 	assert.Equal(t, partition.getPhAllocationCount(), 1, "placeholder allocation should be counted as placeholder")
 	assert.Equal(t, node.GetAllocation(alloc.GetAllocationKey()), alloc, "placeholder allocation not found on node")
 	assert.Assert(t, alloc.IsPlaceholder(), "placeholder alloc should return a placeholder allocation")
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "placeholder alloc should return an allocated result")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "placeholder alloc should return an allocated result type")
 	assert.Equal(t, alloc.GetNodeID(), nodeID1, "should be allocated on node-1")
 	assert.Assert(t, resources.Equals(app.GetPlaceholderResource(), res), "placeholder allocation not updated as expected: got %s, expected %s", app.GetPlaceholderResource(), res)
 	assertLimits(t, getTestUserGroup(), res)
@@ -3480,7 +3480,7 @@ func TestFailReplacePlaceholder(t *testing.T) {
 	}
 	assert.Equal(t, partition.GetTotalAllocationCount(), 1, "placeholder replacement should not be counted as alloc")
 	assert.Equal(t, partition.getPhAllocationCount(), 1, "placeholder allocation should not change")
-	assert.Equal(t, alloc.GetResult(), objects.Replaced, "result is not the expected allocated replaced")
+	assert.Equal(t, alloc.GetResultType(), objects.Replaced, "result type is not the expected allocated replaced")
 	assert.Check(t, alloc.HasRelease(), "released allocation should be present")
 	// allocation must be added as it is on a different node
 	assert.Equal(t, alloc.GetNodeID(), nodeID2, "should be allocated on node-2")
@@ -3761,7 +3761,7 @@ func TestTryAllocateMaxRunning(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 	assert.Check(t, !alloc.HasRelease(), "released allocation should not exist")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocKey, "expected ask alloc to be allocated")
@@ -3787,7 +3787,7 @@ func TestTryAllocateMaxRunning(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 	assert.Check(t, !alloc.HasRelease(), "released allocation should not exist")
 	assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), "alloc-2", "expected ask alloc-2 to be allocated")
@@ -3806,7 +3806,7 @@ func TestTryAllocateMaxRunning(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 	assert.Check(t, !alloc.HasRelease(), "released allocation should not exist")
 	assert.Equal(t, alloc.GetApplicationID(), appID2, "expected application app-2 to be allocated")
 	assert.Equal(t, alloc.GetAllocationKey(), allocKey, "expected ask alloc-1 to be allocated")
@@ -3876,7 +3876,7 @@ func TestUserHeadroom(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 
 	// app 2 allocation won't happen as there is no headroom for the user
 	alloc = partition.tryAllocate()
@@ -3898,7 +3898,7 @@ func TestUserHeadroom(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 
 	app4 := newApplication("app-4", "default", "root.leaf")
 	err = partition.AddApplication(app4)
@@ -3941,7 +3941,7 @@ func TestUserHeadroom(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, objects.AllocatedReserved, alloc.GetResult(), "allocation result should have been allocated")
+	assert.Equal(t, objects.AllocatedReserved, alloc.GetResultType(), "allocation result type should have been allocated")
 
 	// create a reservation and ensure reservation has not been allocated because there is no headroom for the user
 	ask = newAllocationAsk("alloc-2", "app-5", res)
@@ -3971,7 +3971,7 @@ func TestUserHeadroom(t *testing.T) {
 	if alloc == nil {
 		t.Fatal("allocation did not return any allocation")
 	}
-	assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+	assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 }
 
 func TestPlaceholderAllocationTracking(t *testing.T) {
@@ -4070,7 +4070,7 @@ func TestReservationTracking(t *testing.T) {
 
 	alloc := partition.tryAllocate() // ask1 occupies node1
 	allocationKey := alloc.GetAllocationKey()
-	assert.Equal(t, objects.Allocated, alloc.GetResult())
+	assert.Equal(t, objects.Allocated, alloc.GetResultType())
 	assert.Equal(t, "alloc-1", alloc.GetAllocationKey())
 	assert.Equal(t, 0, partition.getReservationCount())
 	alloc = partition.tryAllocate() // ask2 gets reserved
@@ -4224,7 +4224,7 @@ func TestLimitMaxApplications(t *testing.T) {
 			if alloc == nil {
 				t.Fatal("allocation did not return any allocation")
 			}
-			assert.Equal(t, alloc.GetResult(), objects.Allocated, "result is not the expected allocated")
+			assert.Equal(t, alloc.GetResultType(), objects.Allocated, "result type is not the expected allocated")
 			assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated")
 			assert.Equal(t, alloc.GetAllocationKey(), allocKey, "expected ask alloc-1 to be allocated")
 
@@ -4382,7 +4382,7 @@ func TestLimitMaxApplicationsForReservedAllocation(t *testing.T) {
 			if alloc == nil {
 				t.Fatal("allocation did not return any allocation")
 			}
-			assert.Equal(t, alloc.GetResult(), objects.AllocatedReserved, "result is not the expected allocated reserved")
+			assert.Equal(t, alloc.GetResultType(), objects.AllocatedReserved, "result type is not the expected allocated reserved")
 			assert.Equal(t, alloc.GetApplicationID(), appID1, "expected application app-1 to be allocated reserved")
 			assert.Equal(t, alloc.GetAllocationKey(), allocKey, "expected ask alloc-1 to be allocated reserved")
 
@@ -4505,7 +4505,7 @@ func TestPlaceholderAllocationAndReplacementAfterRecovery(t *testing.T) {
 	// get an allocation for "placeholder2"
 	alloc := partition.tryAllocate()
 	assert.Assert(t, alloc != nil, "no allocation occurred")
-	assert.Equal(t, objects.Allocated, alloc.GetResult())
+	assert.Equal(t, objects.Allocated, alloc.GetResultType())
 	assert.Equal(t, "placeholder2", alloc.GetAllocationKey())
 	assert.Equal(t, "tg-2", alloc.GetTaskGroup())
 	assert.Equal(t, "node-1", alloc.GetNodeID())
@@ -4513,7 +4513,7 @@ func TestPlaceholderAllocationAndReplacementAfterRecovery(t *testing.T) {
 	// real allocation gets replaced
 	alloc = partition.tryPlaceholderAllocate()
 	assert.Assert(t, alloc != nil, "no placeholder replacement occurred")
-	assert.Equal(t, objects.Replaced, alloc.GetResult())
+	assert.Equal(t, objects.Replaced, alloc.GetResultType())
 	assert.Equal(t, "real-alloc", alloc.GetAllocationKey())
 	assert.Equal(t, "tg-1", alloc.GetTaskGroup())
 


### PR DESCRIPTION
### What is this PR for?
In preparation for other refactorings, rename the AllocationResult enum to AllocationResultType.



### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2677

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
