### PR TITLE
[YUNIKORN-2182] Set ReadHeaderTimeout in http server

### DIFF
--- a/pkg/webservice/webservice.go
+++ b/pkg/webservice/webservice.go
@@ -65,7 +65,11 @@ func loggingHandler(inner http.Handler, name string) http.HandlerFunc {
 // TODO we need the port to be configurable
 func (m *WebService) StartWebApp() {
 	router := newRouter()
-	m.httpServer = &http.Server{Addr: ":9080", Handler: router}
+	m.httpServer = &http.Server{
+		Addr:              ":9080",
+		Handler:           router,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
 
 	log.Log(log.REST).Info("web-app started", zap.Int("port", 9080))
 	go func() {


### PR DESCRIPTION
### What is this PR for?
Set `ReadHeaderTimeout` in the HTTP server. Currently, no timeout configuration is set, which may expose the server to the risk of a Slowloris attack. This attack depletes server resources by maintaining numerous long-idle connections.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
[YUNIKORN-2182](https://issues.apache.org/jira/browse/YUNIKORN-2182)

### How should this be tested?
make test
