### PR TITLE
[YUNIKORN-2722] Expose the IsOriginator flag in REST

### DIFF
--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -73,6 +73,7 @@ type Allocation struct {
 	applicationID     string
 	taskGroupName     string // task group this allocation belongs to
 	placeholder       bool   // is this a placeholder allocation
+	originator        bool   // is this an originator allocation
 	nodeID            string
 	priority          int32
 	tags              map[string]string
@@ -104,6 +105,7 @@ func NewAllocation(nodeID string, ask *AllocationAsk) *Allocation {
 		allocatedResource: ask.GetAllocatedResource().Clone(),
 		taskGroupName:     ask.GetTaskGroup(),
 		placeholder:       ask.IsPlaceholder(),
+		originator:        ask.IsOriginator(),
 	}
 }
 
@@ -197,7 +199,7 @@ func (a *Allocation) NewSIFromAllocation() *si.Allocation {
 		ResourcePerAlloc: a.GetAllocatedResource().ToProto(), // needed in tests for restore
 		TaskGroupName:    a.GetTaskGroup(),
 		Placeholder:      a.IsPlaceholder(),
-		Originator:       a.GetAsk().IsOriginator(),
+		Originator:       a.IsOriginator(),
 		PreemptionPolicy: &si.PreemptionPolicy{
 			AllowPreemptSelf:  a.GetAsk().IsAllowPreemptSelf(),
 			AllowPreemptOther: a.GetAsk().IsAllowPreemptOther(),
@@ -283,6 +285,11 @@ func (a *Allocation) SetPlaceholderCreateTime(placeholderCreateTime time.Time) {
 // IsPlaceholder returns whether the allocation is a placeholder
 func (a *Allocation) IsPlaceholder() bool {
 	return a.placeholder
+}
+
+// IsOriginator returns whether the allocation is an originator
+func (a *Allocation) IsOriginator() bool {
+	return a.originator
 }
 
 // GetNodeID gets the node this allocation is assigned to

--- a/pkg/scheduler/objects/allocation_test.go
+++ b/pkg/scheduler/objects/allocation_test.go
@@ -174,10 +174,10 @@ func TestSIFromAlloc(t *testing.T) {
 		},
 	}
 	ask := newAllocationAsk("ask-1", "app-1", res)
-	alloc := NewAllocation("node-1", ask)
 	ask.originator = true
 	ask.allowPreemptSelf = false
 	ask.allowPreemptOther = true
+	alloc := NewAllocation("node-1", ask)
 	if alloc == nil {
 		t.Fatal("NewAllocation create failed while it should not")
 	}
@@ -190,7 +190,7 @@ func TestSIFromAlloc(t *testing.T) {
 	assert.Check(t, !allocSI.PreemptionPolicy.AllowPreemptSelf, "allowPreemptSelf flag should not be set")
 	assert.Check(t, allocSI.PreemptionPolicy.AllowPreemptOther, "aloowPreemptOther flag should be set")
 
-	alloc.ask.originator = false
+	alloc.originator = false
 	alloc.ask.allowPreemptSelf = true
 	alloc.ask.allowPreemptOther = false
 	allocSI = alloc.NewSIFromAllocation()

--- a/pkg/scheduler/objects/allocation_test.go
+++ b/pkg/scheduler/objects/allocation_test.go
@@ -235,10 +235,12 @@ func TestNewAllocFromSI(t *testing.T) {
 	allocSI.TaskGroupName = "testgroup"
 	alloc = NewAllocationFromSI(allocSI)
 	assert.Assert(t, alloc != nilAlloc, "placeholder ask creation failed unexpectedly")
-	assert.Assert(t, alloc.IsPlaceholder(), "ask should have been a placeholder")
+	assert.Assert(t, alloc.GetAsk().IsPlaceholder(), "ask should have been a placeholder")
+	assert.Assert(t, alloc.IsPlaceholder(), "allocation should have been a placeholder")
 	assert.Equal(t, alloc.GetTaskGroup(), "testgroup", "TaskGroupName not set as expected")
 	assert.Equal(t, alloc.GetAsk().GetCreateTime(), time.Unix(past, 0)) //nolint:staticcheck
-	assert.Assert(t, alloc.IsOriginator(), "ask should have been an originator")
+	assert.Assert(t, alloc.GetAsk().IsOriginator(), "ask should have been an originator")
+	assert.Assert(t, alloc.IsOriginator(), "allocation should have been an originator")
 	assert.Assert(t, !alloc.GetAsk().IsAllowPreemptSelf(), "ask should not have allow-preempt-self set")
 	assert.Assert(t, alloc.GetAsk().IsAllowPreemptOther(), "ask should have allow-preempt-other set")
 
@@ -251,7 +253,8 @@ func TestNewAllocFromSI(t *testing.T) {
 	endTime := time.Now().Unix()
 	assert.Assert(t, alloc.GetAsk().GetCreateTime().Unix() >= startTime, "alloc create time is too early")
 	assert.Assert(t, alloc.GetAsk().GetCreateTime().Unix() <= endTime, "alloc create time is too late")
-	assert.Assert(t, !alloc.IsOriginator(), "ask should not have been an originator")
+	assert.Assert(t, !alloc.GetAsk().IsOriginator(), "ask should not have been an originator")
+	assert.Assert(t, !alloc.IsOriginator(), "allocation should not have been an originator")
 	assert.Assert(t, alloc.GetAsk().IsAllowPreemptSelf(), "ask should have allow-preempt-self set")
 	assert.Assert(t, !alloc.GetAsk().IsAllowPreemptOther(), "ask should not have allow-preempt-other set")
 

--- a/pkg/scheduler/objects/allocation_test.go
+++ b/pkg/scheduler/objects/allocation_test.go
@@ -238,7 +238,7 @@ func TestNewAllocFromSI(t *testing.T) {
 	assert.Assert(t, alloc.IsPlaceholder(), "ask should have been a placeholder")
 	assert.Equal(t, alloc.GetTaskGroup(), "testgroup", "TaskGroupName not set as expected")
 	assert.Equal(t, alloc.GetAsk().GetCreateTime(), time.Unix(past, 0)) //nolint:staticcheck
-	assert.Assert(t, alloc.GetAsk().IsOriginator(), "ask should have been an originator")
+	assert.Assert(t, alloc.IsOriginator(), "ask should have been an originator")
 	assert.Assert(t, !alloc.GetAsk().IsAllowPreemptSelf(), "ask should not have allow-preempt-self set")
 	assert.Assert(t, alloc.GetAsk().IsAllowPreemptOther(), "ask should have allow-preempt-other set")
 
@@ -251,7 +251,7 @@ func TestNewAllocFromSI(t *testing.T) {
 	endTime := time.Now().Unix()
 	assert.Assert(t, alloc.GetAsk().GetCreateTime().Unix() >= startTime, "alloc create time is too early")
 	assert.Assert(t, alloc.GetAsk().GetCreateTime().Unix() <= endTime, "alloc create time is too late")
-	assert.Assert(t, !alloc.GetAsk().IsOriginator(), "ask should not have been an originator")
+	assert.Assert(t, !alloc.IsOriginator(), "ask should not have been an originator")
 	assert.Assert(t, alloc.GetAsk().IsAllowPreemptSelf(), "ask should have allow-preempt-self set")
 	assert.Assert(t, !alloc.GetAsk().IsAllowPreemptOther(), "ask should not have allow-preempt-other set")
 

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -683,7 +683,7 @@ func (pcr *predicateCheckResult) getSolutionScore(allocationsByNode map[string][
 	}
 	for i := 0; i <= pcr.index; i++ {
 		allocation := allocations[i]
-		if allocation.GetAsk().IsOriginator() {
+		if allocation.IsOriginator() {
 			score |= scoreOriginator
 		}
 		if !allocation.GetAsk().IsAllowPreemptSelf() {
@@ -878,7 +878,7 @@ func compareAllocationLess(left *Allocation, right *Allocation) bool {
 // application originators.
 func scoreAllocation(allocation *Allocation) uint64 {
 	var score uint64 = 0
-	if allocation.GetAsk().IsOriginator() {
+	if allocation.IsOriginator() {
 		score |= scoreOriginator
 	}
 	if !allocation.GetAsk().IsAllowPreemptSelf() {

--- a/pkg/webservice/dao/allocation_info.go
+++ b/pkg/webservice/dao/allocation_info.go
@@ -32,4 +32,5 @@ type AllocationDAOInfo struct {
 	PlaceholderUsed  bool              `json:"placeholderUsed,omitempty"`
 	TaskGroupName    string            `json:"taskGroupName,omitempty"`
 	Preempted        bool              `json:"preempted,omitempty"`
+	Originator       bool              `json:"originator,omitempty"`
 }

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -243,6 +243,7 @@ func getAllocationDAO(alloc *objects.Allocation) *dao.AllocationDAOInfo {
 		NodeID:           alloc.GetNodeID(),
 		ApplicationID:    alloc.GetApplicationID(),
 		Preempted:        alloc.IsPreempted(),
+		Originator:       alloc.IsOriginator(),
 	}
 	return allocDAO
 }


### PR DESCRIPTION
### What is this PR for?

Add the `Originator` field to the `Allocation` and `AllocationDAOInfo` structs


### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
<https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-2722>

### How should this be tested?

### Screenshots (if appropriate)
![image](https://github.com/apache/yunikorn-core/assets/46772690/fddd5698-b176-4f95-a8a1-2d60ef5376bd)


### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
