### PR TITLE
[YUNIKORN-2699] Preemption e2e tests fail in latest master

### DIFF
--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -641,7 +641,7 @@ func (p *Preemptor) TryPreemption() (*AllocationResult, bool) {
 	p.ask.MarkTriggeredPreemption()
 
 	// notify RM that victims should be released
-	p.application.notifyRMAllocationReleased(victims, si.TerminationType_PREEMPTED_BY_SCHEDULER,
+	p.application.notifyRMAllocationReleased(finalVictims, si.TerminationType_PREEMPTED_BY_SCHEDULER,
 		"preempting allocations to free up resources to run ask: "+p.ask.GetAllocationKey())
 
 	// reserve the selected node for the new allocation if it will fit


### PR DESCRIPTION
### What is this PR for?
Incorrect victims list has been sent to shim for preemption. Fixed the issue by sending the correct list. 
Once victims has been chosen finally, there is one more round of filtering step to do further filter in TryPreemption(). After this filtering step, final list has been prepared. Instead of sending the final list to shim, earlier list has been sent. Hence, some victims has been preempted unnecessarily.

### What type of PR is it?
* [ ] - Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2699

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
