### PR TITLE
[YUNIKORN-2729] cleanup remaining lint warnings in order to remove --new-from-rev from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ lint: $(GOLANGCI_LINT_BIN)
 	@git symbolic-ref -q HEAD && REV="origin/HEAD" || REV="HEAD^" ; \
 	headSHA=$$(git rev-parse --short=12 $${REV}) ; \
 	echo "checking against commit sha $${headSHA}" ; \
-	"${GOLANGCI_LINT_BIN}" run --new-from-rev=$${headSHA}
+	"${GOLANGCI_LINT_BIN}" run
 
 # Check scripts
 .PHONY: check_scripts

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -664,7 +664,8 @@ func checkQueues(queue *QueueConfig, level int) error {
 	}
 
 	// recurse into the depth if this level passed
-	for _, child := range queue.Queues {
+	for _, q := range queue.Queues {
+		child := q
 		err = checkQueues(&child, level+1)
 		if err != nil {
 			return err

--- a/pkg/common/configs/configvalidator_test.go
+++ b/pkg/common/configs/configvalidator_test.go
@@ -2007,8 +2007,10 @@ func TestCheckLimits(t *testing.T) { //nolint:funlen
 	}
 
 	for _, testCase := range testCases {
+		config := testCase.config
+
 		t.Run(testCase.name, func(t *testing.T) {
-			err := checkLimits(testCase.config.Limits, testCase.config.Name, &testCase.config)
+			err := checkLimits(testCase.config.Limits, testCase.config.Name, &config)
 			if testCase.errMsg != "" {
 				assert.ErrorContains(t, err, testCase.errMsg)
 			} else {
@@ -2194,7 +2196,6 @@ func TestCheckQueuesStructure(t *testing.T) {
 			if tc.validateFunc != nil {
 				tc.validateFunc(t, tc.partition)
 			}
-
 		})
 	}
 }

--- a/pkg/common/configs/configvalidator_test.go
+++ b/pkg/common/configs/configvalidator_test.go
@@ -2008,7 +2008,6 @@ func TestCheckLimits(t *testing.T) { //nolint:funlen
 
 	for _, testCase := range testCases {
 		config := testCase.config
-
 		t.Run(testCase.name, func(t *testing.T) {
 			err := checkLimits(testCase.config.Limits, testCase.config.Name, &config)
 			if testCase.errMsg != "" {

--- a/pkg/common/security/usergroup.go
+++ b/pkg/common/security/usergroup.go
@@ -71,7 +71,6 @@ type UserGroup struct {
 // * NO resolver: default, no user or group resolution just return the info (k8s use case)
 // * OS resolver: uses the OS libraries to resolve user and group memberships
 // * Test resolver: fake resolution for testing
-// TODO need to make this fully configurable and look at reflection etc
 func GetUserGroupCache(resolver string) *UserGroupCache {
 	once.Do(func() {
 		switch resolver {

--- a/pkg/common/security/usergroup_test.go
+++ b/pkg/common/security/usergroup_test.go
@@ -39,6 +39,7 @@ func TestGetUserGroupCache(t *testing.T) {
 }
 
 func TestGetUserGroup(t *testing.T) {
+	const TestUser1 = "testuser1"
 	testCache := GetUserGroupCache("test")
 	testCache.resetCache()
 	// test cache should be empty now
@@ -46,28 +47,27 @@ func TestGetUserGroup(t *testing.T) {
 		t.Fatalf("Cache not empty: %v", testCache.ugs)
 	}
 
-	ug, err := testCache.GetUserGroup("testuser1")
+	ug, err := testCache.GetUserGroup(TestUser1)
 	assert.NilError(t, err, "Lookup should not have failed: testuser1")
 	if ug.failed {
-		t.Errorf("lookup failed which should not have: %t", ug.failed)
+		t.Fatalf("lookup failed which should not have: %t", ug.failed)
 	}
 	if len(testCache.ugs) != 1 {
-		t.Errorf("Cache not updated should have 1 entry %d", len(testCache.ugs))
+		t.Fatalf("Cache not updated should have 1 entry %d", len(testCache.ugs))
 	}
 	// check returned info: primary and secondary groups etc
-	const Testuser1 = "testuser1"
-	if ug.User != Testuser1 || len(ug.Groups) != 2 || ug.resolved == 0 || ug.failed {
-		t.Errorf("User 'testuser1' not resolved correctly: %v", ug)
+	if ug.User != TestUser1 || len(ug.Groups) != 2 || ug.resolved == 0 || ug.failed {
+		t.Fatalf("User 'testuser1' not resolved correctly: %v", ug)
 	}
-	cachedUG := testCache.ugs["testuser1"]
+	cachedUG := testCache.ugs[TestUser1]
 	if ug.resolved != cachedUG.resolved {
-		t.Errorf("User 'testuser1' not cached correctly resolution time differs: %d got %d", ug.resolved, cachedUG.resolved)
+		t.Fatalf("User 'testuser1' not cached correctly resolution time differs: %d got %d", ug.resolved, cachedUG.resolved)
 	}
 	// click over the clock: if we do not get the cached version the new time will differ from the cache update
 	cachedUG.resolved -= 5
-	ug, err = testCache.GetUserGroup("testuser1")
+	ug, err = testCache.GetUserGroup(TestUser1)
 	if err != nil || ug.resolved != cachedUG.resolved {
-		t.Errorf("User 'testuser1' not returned from Cache, resolution time differs: %d got %d (err = %v)", ug.resolved, cachedUG.resolved, err)
+		t.Fatalf("User 'testuser1' not returned from Cache, resolution time differs: %d got %d (err = %v)", ug.resolved, cachedUG.resolved, err)
 	}
 }
 

--- a/pkg/common/security/usergroup_test.go
+++ b/pkg/common/security/usergroup_test.go
@@ -183,16 +183,20 @@ func TestGetUserGroupFail(t *testing.T) {
 	}
 
 	// resolve a non existing user
-	ug, err = testCache.GetUserGroup("unknown")
+	ugi := &si.UserGroupInformation{
+		User:   "unknown",
+		Groups: nil,
+	}
+	ug, err = testCache.GetUserGroup(ugi.User)
 	if err == nil {
 		t.Error("Lookup should have failed: unknown user")
 	}
 	// ug is partially filled and failed flag is set
-	if ug.User != "unknown" || len(ug.Groups) != 0 || !ug.failed {
+	if ug.User != ugi.User || len(ug.Groups) != 0 || !ug.failed {
 		t.Errorf("UserGroup is not empty: %v", ug)
 	}
 
-	ug, err = testCache.GetUserGroup("unknown")
+	ug, err = testCache.GetUserGroup(ugi.User)
 	if err == nil {
 		t.Error("Lookup should have failed: unknown user")
 	}

--- a/pkg/common/security/usergroup_test.go
+++ b/pkg/common/security/usergroup_test.go
@@ -88,9 +88,7 @@ func TestGetUserGroup(t *testing.T) {
 	testCache := GetUserGroupCache("test")
 	testCache.resetCache()
 	// test cache should be empty now
-	if len(testCache.ugs) != 0 {
-		t.Fatalf("Cache not empty: %v", testCache.ugs)
-	}
+	assert.Equal(t, 0, testCache.getUGsize(), "Cache is not empty: %v", testCache.getUGmap())
 	ugi := &si.UserGroupInformation{
 		User:   "testuser1",
 		Groups: nil,

--- a/pkg/common/security/usergroup_test.go
+++ b/pkg/common/security/usergroup_test.go
@@ -55,7 +55,8 @@ func TestGetUserGroup(t *testing.T) {
 		t.Errorf("Cache not updated should have 1 entry %d", len(testCache.ugs))
 	}
 	// check returned info: primary and secondary groups etc
-	if ug.User != "testuser1" || len(ug.Groups) != 2 || ug.resolved == 0 || ug.failed {
+	const Testuser1 = "testuser1"
+	if ug.User != Testuser1 || len(ug.Groups) != 2 || ug.resolved == 0 || ug.failed {
 		t.Errorf("User 'testuser1' not resolved correctly: %v", ug)
 	}
 	cachedUG := testCache.ugs["testuser1"]

--- a/pkg/common/security/usergroup_test.go
+++ b/pkg/common/security/usergroup_test.go
@@ -39,35 +39,37 @@ func TestGetUserGroupCache(t *testing.T) {
 }
 
 func TestGetUserGroup(t *testing.T) {
-	const TestUser1 = "testuser1"
 	testCache := GetUserGroupCache("test")
 	testCache.resetCache()
 	// test cache should be empty now
 	if len(testCache.ugs) != 0 {
 		t.Fatalf("Cache not empty: %v", testCache.ugs)
 	}
-
-	ug, err := testCache.GetUserGroup(TestUser1)
+	ugi := &si.UserGroupInformation{
+		User:   "testuser1",
+		Groups: nil,
+	}
+	ug, err := testCache.GetUserGroup(ugi.User)
 	assert.NilError(t, err, "Lookup should not have failed: testuser1")
 	if ug.failed {
-		t.Fatalf("lookup failed which should not have: %t", ug.failed)
+		t.Errorf("lookup failed which should not have: %t", ug.failed)
 	}
 	if len(testCache.ugs) != 1 {
-		t.Fatalf("Cache not updated should have 1 entry %d", len(testCache.ugs))
+		t.Errorf("Cache not updated should have 1 entry %d", len(testCache.ugs))
 	}
 	// check returned info: primary and secondary groups etc
-	if ug.User != TestUser1 || len(ug.Groups) != 2 || ug.resolved == 0 || ug.failed {
-		t.Fatalf("User 'testuser1' not resolved correctly: %v", ug)
+	if ug.User != ugi.User || len(ug.Groups) != 2 || ug.resolved == 0 || ug.failed {
+		t.Errorf("User 'testuser1' not resolved correctly: %v", ug)
 	}
-	cachedUG := testCache.ugs[TestUser1]
+	cachedUG := testCache.ugs[ugi.User]
 	if ug.resolved != cachedUG.resolved {
-		t.Fatalf("User 'testuser1' not cached correctly resolution time differs: %d got %d", ug.resolved, cachedUG.resolved)
+		t.Errorf("User 'testuser1' not cached correctly resolution time differs: %d got %d", ug.resolved, cachedUG.resolved)
 	}
 	// click over the clock: if we do not get the cached version the new time will differ from the cache update
 	cachedUG.resolved -= 5
-	ug, err = testCache.GetUserGroup(TestUser1)
+	ug, err = testCache.GetUserGroup(ugi.User)
 	if err != nil || ug.resolved != cachedUG.resolved {
-		t.Fatalf("User 'testuser1' not returned from Cache, resolution time differs: %d got %d (err = %v)", ug.resolved, cachedUG.resolved, err)
+		t.Errorf("User 'testuser1' not returned from Cache, resolution time differs: %d got %d (err = %v)", ug.resolved, cachedUG.resolved, err)
 	}
 }
 

--- a/pkg/common/security/usergroup_test_resolver.go
+++ b/pkg/common/security/usergroup_test_resolver.go
@@ -41,7 +41,8 @@ func GetUserGroupCacheTest() *UserGroupCache {
 // test function only
 func lookup(userName string) (*user.User, error) {
 	// 1st test user: all OK
-	if userName == "testuser1" {
+	const Testuser1 = "testuser1"
+	if userName == Testuser1 {
 		return &user.User{
 			Uid:      "1000",
 			Gid:      "1000",
@@ -49,7 +50,8 @@ func lookup(userName string) (*user.User, error) {
 		}, nil
 	}
 	// 2nd test user: primary group does not resolve
-	if userName == "testuser2" {
+	const Testuser2 = "testuser2"
+	if userName == Testuser2 {
 		return &user.User{
 			Uid:      "100",
 			Gid:      "100",
@@ -85,7 +87,8 @@ func lookupGroupID(gid string) (*user.Group, error) {
 
 // test function only
 func groupIds(osUser *user.User) ([]string, error) {
-	if osUser.Username == "testuser1" {
+	const Testuser1 = "testuser1"
+	if osUser.Username == Testuser1 {
 		return []string{"1001"}, nil
 	}
 	if osUser.Username == "testuser2" {

--- a/pkg/common/security/usergroup_test_resolver.go
+++ b/pkg/common/security/usergroup_test_resolver.go
@@ -25,6 +25,12 @@ import (
 	"time"
 )
 
+const (
+	Testuser1 = "testuser1"
+	Testuser2 = "testuser2"
+	Testuser3 = "testuser3"
+)
+
 // Get the cache with a test resolver
 // cleaner runs every second
 func GetUserGroupCacheTest() *UserGroupCache {
@@ -41,10 +47,6 @@ func GetUserGroupCacheTest() *UserGroupCache {
 // test function only
 func lookup(userName string) (*user.User, error) {
 	// 1st test user: all OK
-	const (
-		Testuser1 = "testuser1"
-		Testuser2 = "testuser2"
-	)
 	if userName == Testuser1 {
 		return &user.User{
 			Uid:      "1000",
@@ -60,7 +62,7 @@ func lookup(userName string) (*user.User, error) {
 			Username: "testuser2",
 		}, nil
 	}
-	if userName == "testuser3" {
+	if userName == Testuser3 {
 		return &user.User{
 			Uid:      "1001",
 			Gid:      "1001",
@@ -89,15 +91,14 @@ func lookupGroupID(gid string) (*user.Group, error) {
 
 // test function only
 func groupIds(osUser *user.User) ([]string, error) {
-	const Testuser1 = "testuser1"
 	if osUser.Username == Testuser1 {
 		return []string{"1001"}, nil
 	}
-	if osUser.Username == "testuser2" {
+	if osUser.Username == Testuser2 {
 		return []string{"1001", "1002"}, nil
 	}
 	// group list might return primary group ID also
-	if osUser.Username == "testuser3" {
+	if osUser.Username == Testuser3 {
 		return []string{"1002", "1001", "1003", "1004"}, nil
 	}
 	return nil, fmt.Errorf("lookup failed for user: %s", osUser.Username)

--- a/pkg/common/security/usergroup_test_resolver.go
+++ b/pkg/common/security/usergroup_test_resolver.go
@@ -41,7 +41,10 @@ func GetUserGroupCacheTest() *UserGroupCache {
 // test function only
 func lookup(userName string) (*user.User, error) {
 	// 1st test user: all OK
-	const Testuser1 = "testuser1"
+	const (
+		Testuser1 = "testuser1"
+		Testuser2 = "testuser2"
+	)
 	if userName == Testuser1 {
 		return &user.User{
 			Uid:      "1000",
@@ -50,7 +53,6 @@ func lookup(userName string) (*user.User, error) {
 		}, nil
 	}
 	// 2nd test user: primary group does not resolve
-	const Testuser2 = "testuser2"
 	if userName == Testuser2 {
 		return &user.User{
 			Uid:      "100",

--- a/pkg/events/event_system.go
+++ b/pkg/events/event_system.go
@@ -35,7 +35,6 @@ import (
 
 // need to change for testing
 var defaultEventChannelSize = 100000
-var defaultRingBufferSize uint64 = 100000
 
 var once sync.Once
 var ev EventSystem

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -555,7 +555,6 @@ func (cc *ClusterContext) handleRMUpdateApplicationEvent(event *rmevent.RMUpdate
 	// Update metrics with removed applications
 	if len(request.Remove) > 0 {
 		metrics.GetSchedulerMetrics().SubTotalApplicationsRunning(len(request.Remove))
-		// ToDO: need to improve this once we have state in YuniKorn for apps.
 		metrics.GetSchedulerMetrics().AddTotalApplicationsCompleted(len(request.Remove))
 		for _, app := range request.Remove {
 			partition := cc.GetPartition(app.PartitionName)

--- a/pkg/scheduler/objects/allocation_ask.go
+++ b/pkg/scheduler/objects/allocation_ask.go
@@ -87,7 +87,6 @@ func NewAllocationAsk(allocationKey string, applicationID string, allocatedResou
 }
 
 func NewAllocationAskFromSI(ask *si.AllocationAsk) *AllocationAsk {
-
 	var createTime time.Time
 	siCreationTime, err := strconv.ParseInt(ask.Tags[siCommon.CreationTime], 10, 64)
 	if err != nil {

--- a/pkg/scheduler/objects/allocation_ask_test.go
+++ b/pkg/scheduler/objects/allocation_ask_test.go
@@ -117,9 +117,6 @@ func TestPreemptCheckTime(t *testing.T) {
 }
 
 func TestPlaceHolder(t *testing.T) {
-	const (
-		testGroupName = "testgroup"
-	)
 	siAsk := &si.AllocationAsk{
 		AllocationKey: "ask1",
 		ApplicationID: "app1",
@@ -140,11 +137,11 @@ func TestPlaceHolder(t *testing.T) {
 	var nilAsk *AllocationAsk
 	assert.Equal(t, ask, nilAsk, "placeholder ask created without a TaskGroupName")
 
-	siAsk.TaskGroupName = testGroupName
+	siAsk.TaskGroupName = "TestPlaceHolder"
 	ask = NewAllocationAskFromSI(siAsk)
 	assert.Assert(t, ask != nilAsk, "placeholder ask creation failed unexpectedly")
 	assert.Assert(t, ask.IsPlaceholder(), "ask should have been a placeholder")
-	assert.Equal(t, ask.GetTaskGroup(), testGroupName, "TaskGroupName not set as expected")
+	assert.Equal(t, ask.GetTaskGroup(), siAsk.TaskGroupName, "TaskGroupName not set as expected")
 }
 
 func TestGetRequiredNode(t *testing.T) {

--- a/pkg/scheduler/objects/allocation_ask_test.go
+++ b/pkg/scheduler/objects/allocation_ask_test.go
@@ -137,7 +137,13 @@ func TestPlaceHolder(t *testing.T) {
 	var nilAsk *AllocationAsk
 	assert.Equal(t, ask, nilAsk, "placeholder ask created without a TaskGroupName")
 
-	siAsk.TaskGroupName = "TestPlaceHolder"
+	siAsk = &si.AllocationAsk{
+		AllocationKey: "ask1",
+		ApplicationID: "app1",
+		PartitionName: "default",
+		TaskGroupName: "testgroup",
+		Placeholder:   true,
+	}
 	ask = NewAllocationAskFromSI(siAsk)
 	assert.Assert(t, ask != nilAsk, "placeholder ask creation failed unexpectedly")
 	assert.Assert(t, ask.IsPlaceholder(), "ask should have been a placeholder")

--- a/pkg/scheduler/objects/allocation_ask_test.go
+++ b/pkg/scheduler/objects/allocation_ask_test.go
@@ -138,13 +138,7 @@ func TestPlaceHolder(t *testing.T) {
 	var nilAsk *AllocationAsk
 	assert.Equal(t, ask, nilAsk, "placeholder ask created without a TaskGroupName")
 
-	siAsk = &si.AllocationAsk{
-		AllocationKey: "ask1",
-		ApplicationID: "app1",
-		PartitionName: "default",
-		TaskGroupName: "testgroup",
-		Placeholder:   true,
-	}
+	siAsk.TaskGroupName = "TestPlaceHolder"
 	ask = NewAllocationAskFromSI(siAsk)
 	assert.Assert(t, ask != nilAsk, "placeholder ask creation failed unexpectedly")
 	assert.Assert(t, ask.IsPlaceholder(), "ask should have been a placeholder")

--- a/pkg/scheduler/objects/allocation_ask_test.go
+++ b/pkg/scheduler/objects/allocation_ask_test.go
@@ -117,7 +117,9 @@ func TestPreemptCheckTime(t *testing.T) {
 }
 
 func TestPlaceHolder(t *testing.T) {
-	const testGroupName = "testgroup"
+	const (
+		testGroupName = "testgroup"
+	)
 	siAsk := &si.AllocationAsk{
 		AllocationKey: "ask1",
 		ApplicationID: "app1",

--- a/pkg/scheduler/objects/allocation_ask_test.go
+++ b/pkg/scheduler/objects/allocation_ask_test.go
@@ -117,6 +117,7 @@ func TestPreemptCheckTime(t *testing.T) {
 }
 
 func TestPlaceHolder(t *testing.T) {
+	const testGroupName = "testgroup"
 	siAsk := &si.AllocationAsk{
 		AllocationKey: "ask1",
 		ApplicationID: "app1",
@@ -125,6 +126,7 @@ func TestPlaceHolder(t *testing.T) {
 	ask := NewAllocationAskFromSI(siAsk)
 	assert.Assert(t, !ask.IsPlaceholder(), "standard ask should not be a placeholder")
 	assert.Equal(t, ask.GetTaskGroup(), "", "standard ask should not have a TaskGroupName")
+
 	siAsk = &si.AllocationAsk{
 		AllocationKey: "ask1",
 		ApplicationID: "app1",
@@ -135,11 +137,12 @@ func TestPlaceHolder(t *testing.T) {
 	ask = NewAllocationAskFromSI(siAsk)
 	var nilAsk *AllocationAsk
 	assert.Equal(t, ask, nilAsk, "placeholder ask created without a TaskGroupName")
-	siAsk.TaskGroupName = "testgroup"
+
+	siAsk.TaskGroupName = testGroupName
 	ask = NewAllocationAskFromSI(siAsk)
 	assert.Assert(t, ask != nilAsk, "placeholder ask creation failed unexpectedly")
 	assert.Assert(t, ask.IsPlaceholder(), "ask should have been a placeholder")
-	assert.Equal(t, ask.GetTaskGroup(), "testgroup", "TaskGroupName not set as expected")
+	assert.Equal(t, ask.GetTaskGroup(), testGroupName, "TaskGroupName not set as expected")
 }
 
 func TestGetRequiredNode(t *testing.T) {

--- a/pkg/scheduler/objects/allocation_test.go
+++ b/pkg/scheduler/objects/allocation_test.go
@@ -230,14 +230,15 @@ func TestNewAllocFromSI(t *testing.T) {
 		},
 	}
 	var nilAlloc *Allocation
+	const Testgroup = "testgroup"
 	alloc := NewAllocationFromSI(allocSI)
 	assert.Equal(t, alloc, nilAlloc, "placeholder allocation created without a TaskGroupName")
-	allocSI.TaskGroupName = "testgroup"
+	allocSI.TaskGroupName = Testgroup
 	alloc = NewAllocationFromSI(allocSI)
 	assert.Assert(t, alloc != nilAlloc, "placeholder ask creation failed unexpectedly")
 	assert.Assert(t, alloc.GetAsk().IsPlaceholder(), "ask should have been a placeholder")
 	assert.Assert(t, alloc.IsPlaceholder(), "allocation should have been a placeholder")
-	assert.Equal(t, alloc.GetTaskGroup(), "testgroup", "TaskGroupName not set as expected")
+	assert.Equal(t, alloc.GetTaskGroup(), Testgroup, "TaskGroupName not set as expected")
 	assert.Equal(t, alloc.GetAsk().GetCreateTime(), time.Unix(past, 0)) //nolint:staticcheck
 	assert.Assert(t, alloc.GetAsk().IsOriginator(), "ask should have been an originator")
 	assert.Assert(t, alloc.IsOriginator(), "allocation should have been an originator")

--- a/pkg/scheduler/objects/allocation_test.go
+++ b/pkg/scheduler/objects/allocation_test.go
@@ -238,20 +238,7 @@ func TestNewAllocFromSI(t *testing.T) {
 	var nilAlloc *Allocation
 	alloc := NewAllocationFromSI(allocSI)
 	assert.Equal(t, alloc, nilAlloc, "placeholder allocation created without a TaskGroupName")
-	allocSI = &si.Allocation{
-		AllocationKey:    "ask-1",
-		NodeID:           "node-1",
-		ApplicationID:    "app-1",
-		ResourcePerAlloc: res.ToProto(),
-		TaskGroupName:    "testgroup",
-		Placeholder:      true,
-		AllocationTags:   tags,
-		Originator:       true,
-		PreemptionPolicy: &si.PreemptionPolicy{
-			AllowPreemptSelf:  false,
-			AllowPreemptOther: true,
-		},
-	}
+	allocSI.TaskGroupName = "TestNewAllocFromSI"
 	alloc = NewAllocationFromSI(allocSI)
 	assert.Assert(t, alloc != nilAlloc, "placeholder ask creation failed unexpectedly")
 	assert.Assert(t, alloc.GetAsk().IsPlaceholder(), "ask should have been a placeholder")

--- a/pkg/scheduler/objects/allocation_test.go
+++ b/pkg/scheduler/objects/allocation_test.go
@@ -230,15 +230,27 @@ func TestNewAllocFromSI(t *testing.T) {
 		},
 	}
 	var nilAlloc *Allocation
-	const Testgroup = "testgroup"
 	alloc := NewAllocationFromSI(allocSI)
 	assert.Equal(t, alloc, nilAlloc, "placeholder allocation created without a TaskGroupName")
-	allocSI.TaskGroupName = Testgroup
+	allocSI = &si.Allocation{
+		AllocationKey:    "ask-1",
+		NodeID:           "node-1",
+		ApplicationID:    "app-1",
+		ResourcePerAlloc: res.ToProto(),
+		TaskGroupName:    "testgroup",
+		Placeholder:      true,
+		AllocationTags:   tags,
+		Originator:       true,
+		PreemptionPolicy: &si.PreemptionPolicy{
+			AllowPreemptSelf:  false,
+			AllowPreemptOther: true,
+		},
+	}
 	alloc = NewAllocationFromSI(allocSI)
 	assert.Assert(t, alloc != nilAlloc, "placeholder ask creation failed unexpectedly")
 	assert.Assert(t, alloc.GetAsk().IsPlaceholder(), "ask should have been a placeholder")
 	assert.Assert(t, alloc.IsPlaceholder(), "allocation should have been a placeholder")
-	assert.Equal(t, alloc.GetTaskGroup(), Testgroup, "TaskGroupName not set as expected")
+	assert.Equal(t, alloc.GetTaskGroup(), allocSI.TaskGroupName, "TaskGroupName not set as expected")
 	assert.Equal(t, alloc.GetAsk().GetCreateTime(), time.Unix(past, 0)) //nolint:staticcheck
 	assert.Assert(t, alloc.GetAsk().IsOriginator(), "ask should have been an originator")
 	assert.Assert(t, alloc.IsOriginator(), "allocation should have been an originator")

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -1445,7 +1445,6 @@ func (sa *Application) tryNodes(ask *AllocationAsk, iterator NodeIterator) *Allo
 			return false
 		}
 		// nothing allocated should we look at a reservation?
-		// TODO make this smarter a hardcoded delay is not the right thing
 		askAge := time.Since(ask.GetCreateTime())
 		if allowReserve && askAge > reservationDelay {
 			log.Log(log.SchedApplication).Debug("app reservation check",

--- a/pkg/scheduler/objects/node_test.go
+++ b/pkg/scheduler/objects/node_test.go
@@ -107,8 +107,6 @@ func TestCheckConditions(t *testing.T) {
 	if !node.preAllocateConditions(ask) {
 		t.Error("node with scheduling set to true no plugins should allow allocation")
 	}
-
-	// TODO add mock for plugin to extend tests
 }
 
 func TestPreAllocateCheck(t *testing.T) {

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -127,7 +127,6 @@ func (pc *PartitionContext) initialPartitionFromConfig(conf configs.PartitionCon
 	// Placing an application will not have a lock on the partition context.
 	pc.placementManager = placement.NewPlacementManager(conf.PlacementRules, pc.GetQueue)
 	// get the user group cache for the partition
-	// TODO get the resolver from the config
 	pc.userGroupCache = security.GetUserGroupCache("")
 	pc.updateNodeSortingPolicy(conf)
 	pc.updatePreemption(conf)

--- a/pkg/scheduler/partition_manager.go
+++ b/pkg/scheduler/partition_manager.go
@@ -123,7 +123,6 @@ func (manager *partitionManager) cleanQueues(queue *objects.Queue) {
 					zap.String("queue", queue.QueuePath))
 			}
 		} else {
-			// TODO time out waiting for draining and removal
 			log.Log(log.SchedPartition).Debug("skip removing the queue",
 				zap.String("reason", "there are existing assigned apps or leaf queues"),
 				zap.String("queue", queue.QueuePath),

--- a/pkg/scheduler/placement/filter_test.go
+++ b/pkg/scheduler/placement/filter_test.go
@@ -316,71 +316,63 @@ func TestFilterGroup(t *testing.T) {
 // test allowing user access with user list
 func TestAllowUser(t *testing.T) {
 	// user object to test with
-	userObj := security.UserGroup{
-		User:   "",
+	user1Obj := security.UserGroup{
+		User:   "user1",
+		Groups: nil,
+	}
+	user2Obj := security.UserGroup{
+		User:   "user2",
 		Groups: nil,
 	}
 	// test deny user list
-	const (
-		testUser1 = "user1"
-	)
 	conf := configs.Filter{}
 	conf.Type = filterDeny
-	conf.Users = []string{testUser1}
-
+	conf.Users = []string{user1Obj.User}
 	filter := newFilter(conf)
-	userObj.User = testUser1
-	if filter.allowUser(userObj) {
+	if filter.allowUser(user1Obj) {
 		t.Error("deny filter did not deny user 'user1' while in list")
 	}
-	userObj.User = "user2"
-	if !filter.allowUser(userObj) {
+	if !filter.allowUser(user2Obj) {
 		t.Error("deny filter did deny user 'user2' while not in list")
 	}
 
 	// test allow user list
 	conf = configs.Filter{}
 	conf.Type = filterAllow
-	conf.Users = []string{testUser1}
+	conf.Users = []string{user1Obj.User}
 
 	filter = newFilter(conf)
-	userObj.User = testUser1
-	if !filter.allowUser(userObj) {
+	if !filter.allowUser(user1Obj) {
 		t.Error("allow filter did not allow user 'user1' while in list")
 	}
-	userObj.User = "user2"
-	if filter.allowUser(userObj) {
-		t.Error("allow filter did allow user 'user1' while not in list")
+	if filter.allowUser(user2Obj) {
+		t.Error("allow filter did allow user 'user2' while not in list")
 	}
 
 	// test deny user exp
 	conf = configs.Filter{}
 	conf.Type = filterDeny
-	conf.Users = []string{"user[0-9]"}
+	conf.Users = []string{"user[0-1]"}
 
 	filter = newFilter(conf)
-	userObj.User = "user1"
-	if filter.allowUser(userObj) {
+	if filter.allowUser(user1Obj) {
 		t.Error("deny filter did not deny user 'user1' while in expression")
 	}
-	userObj.User = "nomatch"
-	if !filter.allowUser(userObj) {
-		t.Error("deny filter did deny user 'nomatch' while not in expression")
+	if !filter.allowUser(user2Obj) {
+		t.Error("deny filter did deny user 'user2' while not in expression")
 	}
 
 	// test allow user exp
 	conf = configs.Filter{}
 	conf.Type = filterAllow
-	conf.Users = []string{"user[0-9]"}
+	conf.Users = []string{"user[0-1]"}
 
 	filter = newFilter(conf)
-	userObj.User = "user1"
-	if !filter.allowUser(userObj) {
+	if !filter.allowUser(user1Obj) {
 		t.Error("allow filter did not allow user 'user1' while in expression")
 	}
-	userObj.User = "nomatch"
-	if filter.allowUser(userObj) {
-		t.Error("allow filter did allow user 'nomatch' while not in expression")
+	if filter.allowUser(user2Obj) {
+		t.Error("allow filter did allow user 'user2' while not in expression")
 	}
 }
 

--- a/pkg/scheduler/placement/filter_test.go
+++ b/pkg/scheduler/placement/filter_test.go
@@ -321,12 +321,13 @@ func TestAllowUser(t *testing.T) {
 		Groups: nil,
 	}
 	// test deny user list
+	const testUser1 = "user1"
 	conf := configs.Filter{}
 	conf.Type = filterDeny
-	conf.Users = []string{"user1"}
+	conf.Users = []string{testUser1}
 
 	filter := newFilter(conf)
-	userObj.User = "user1"
+	userObj.User = testUser1
 	if filter.allowUser(userObj) {
 		t.Error("deny filter did not deny user 'user1' while in list")
 	}
@@ -338,10 +339,10 @@ func TestAllowUser(t *testing.T) {
 	// test allow user list
 	conf = configs.Filter{}
 	conf.Type = filterAllow
-	conf.Users = []string{"user1"}
+	conf.Users = []string{testUser1}
 
 	filter = newFilter(conf)
-	userObj.User = "user1"
+	userObj.User = testUser1
 	if !filter.allowUser(userObj) {
 		t.Error("allow filter did not allow user 'user1' while in list")
 	}

--- a/pkg/scheduler/placement/filter_test.go
+++ b/pkg/scheduler/placement/filter_test.go
@@ -321,7 +321,9 @@ func TestAllowUser(t *testing.T) {
 		Groups: nil,
 	}
 	// test deny user list
-	const testUser1 = "user1"
+	const (
+		testUser1 = "user1"
+	)
 	conf := configs.Filter{}
 	conf.Type = filterDeny
 	conf.Users = []string{testUser1}

--- a/pkg/scheduler/placement/fixed_rule_test.go
+++ b/pkg/scheduler/placement/fixed_rule_test.go
@@ -61,17 +61,7 @@ func TestFixedRule(t *testing.T) {
 }
 
 func TestFixedRulePlace(t *testing.T) {
-	// Create the structure for the test
-	const data = `
-partitions:
-  - name: default
-    queues:
-      - name: testqueue
-      - name: testparent
-        queues:
-          - name: testchild
-`
-	err := initQueueStructure([]byte(data))
+	err := initQueueStructure([]byte(confTestQueue))
 	assert.NilError(t, err, "setting up the queue config failed")
 
 	user := security.UserGroup{

--- a/pkg/scheduler/placement/fixed_rule_test.go
+++ b/pkg/scheduler/placement/fixed_rule_test.go
@@ -62,7 +62,7 @@ func TestFixedRule(t *testing.T) {
 
 func TestFixedRulePlace(t *testing.T) {
 	// Create the structure for the test
-	data := `
+	const data = `
 partitions:
   - name: default
     queues:

--- a/pkg/scheduler/placement/placement_test.go
+++ b/pkg/scheduler/placement/placement_test.go
@@ -193,7 +193,8 @@ func TestManagerBuildRule(t *testing.T) {
 		t.Errorf("test rule build should not have failed and created 2 top level rule, err: %v, rules: %v", err, ruleObjs)
 	} else {
 		parent := ruleObjs[0].getParent()
-		if parent == nil || parent.getName() != "test" {
+		const Test = "test"
+		if parent == nil || parent.getName() != Test {
 			t.Error("test rule build should have created 2 rules: parent not found")
 		}
 	}
@@ -260,7 +261,8 @@ partitions:
 	// user rule existing queue, acl allowed
 	err = man.PlaceApplication(app)
 	queueName := app.GetQueuePath()
-	if err != nil || queueName != "root.testparent.testchild" {
+	const TestQueueName = "root.testparent.testchild"
+	if err != nil || queueName != TestQueueName {
 		t.Errorf("leaf exist: app should have been placed in user queue, queue: '%s', error: %v", queueName, err)
 	}
 	user = security.UserGroup{

--- a/pkg/scheduler/placement/placement_test.go
+++ b/pkg/scheduler/placement/placement_test.go
@@ -168,13 +168,9 @@ func TestManagerUpdate(t *testing.T) {
 }
 
 func TestManagerBuildRule(t *testing.T) {
-	const (
-		Test = "test"
-		User = "user"
-	)
 	// basic with 1 rule
 	rules := []configs.PlacementRule{
-		{Name: Test},
+		{Name: "test"},
 	}
 	ruleObjs, err := buildRules(rules)
 	if err != nil {
@@ -186,9 +182,9 @@ func TestManagerBuildRule(t *testing.T) {
 
 	// rule with a parent rule should only be 1 rule in the list
 	rules = []configs.PlacementRule{
-		{Name: Test,
+		{Name: "test",
 			Parent: &configs.PlacementRule{
-				Name: Test,
+				Name: "test",
 			},
 		},
 	}
@@ -197,20 +193,20 @@ func TestManagerBuildRule(t *testing.T) {
 		t.Errorf("test rule build should not have failed and created 2 top level rule, err: %v, rules: %v", err, ruleObjs)
 	} else {
 		parent := ruleObjs[0].getParent()
-		if parent == nil || parent.getName() != Test {
+		if parent == nil || parent.getName() != rules[0].Name {
 			t.Error("test rule build should have created 2 rules: parent not found")
 		}
 	}
 
 	// two rules in order: cannot use the same rule names as we can not check them
 	rules = []configs.PlacementRule{
-		{Name: User},
-		{Name: Test},
+		{Name: "user"},
+		{Name: "test"},
 	}
 	ruleObjs, err = buildRules(rules)
 	if err != nil || len(ruleObjs) != 3 {
 		t.Errorf("rule build should not have failed and created 3 rules, err: %v, rules: %v", err, ruleObjs)
-	} else if ruleObjs[0].getName() != User || ruleObjs[1].getName() != Test || ruleObjs[2].getName() != "recovery" {
+	} else if ruleObjs[0].getName() != rules[0].Name || ruleObjs[1].getName() != rules[1].Name || ruleObjs[2].getName() != "recovery" {
 		t.Errorf("rule build order is not preserved: %v", ruleObjs)
 	}
 }

--- a/pkg/scheduler/placement/placement_test.go
+++ b/pkg/scheduler/placement/placement_test.go
@@ -168,9 +168,13 @@ func TestManagerUpdate(t *testing.T) {
 }
 
 func TestManagerBuildRule(t *testing.T) {
+	const (
+		Test = "test"
+		User = "user"
+	)
 	// basic with 1 rule
 	rules := []configs.PlacementRule{
-		{Name: "test"},
+		{Name: Test},
 	}
 	ruleObjs, err := buildRules(rules)
 	if err != nil {
@@ -182,9 +186,9 @@ func TestManagerBuildRule(t *testing.T) {
 
 	// rule with a parent rule should only be 1 rule in the list
 	rules = []configs.PlacementRule{
-		{Name: "test",
+		{Name: Test,
 			Parent: &configs.PlacementRule{
-				Name: "test",
+				Name: Test,
 			},
 		},
 	}
@@ -193,9 +197,6 @@ func TestManagerBuildRule(t *testing.T) {
 		t.Errorf("test rule build should not have failed and created 2 top level rule, err: %v, rules: %v", err, ruleObjs)
 	} else {
 		parent := ruleObjs[0].getParent()
-		const (
-			Test = "test"
-		)
 		if parent == nil || parent.getName() != Test {
 			t.Error("test rule build should have created 2 rules: parent not found")
 		}
@@ -203,13 +204,13 @@ func TestManagerBuildRule(t *testing.T) {
 
 	// two rules in order: cannot use the same rule names as we can not check them
 	rules = []configs.PlacementRule{
-		{Name: "user"},
-		{Name: "test"},
+		{Name: User},
+		{Name: Test},
 	}
 	ruleObjs, err = buildRules(rules)
 	if err != nil || len(ruleObjs) != 3 {
 		t.Errorf("rule build should not have failed and created 3 rules, err: %v, rules: %v", err, ruleObjs)
-	} else if ruleObjs[0].getName() != "user" || ruleObjs[1].getName() != "test" || ruleObjs[2].getName() != "recovery" {
+	} else if ruleObjs[0].getName() != User || ruleObjs[1].getName() != Test || ruleObjs[2].getName() != "recovery" {
 		t.Errorf("rule build order is not preserved: %v", ruleObjs)
 	}
 }
@@ -330,6 +331,7 @@ partitions:
 	}
 }
 
+//nolint:funlen
 func TestForcePlaceApp(t *testing.T) {
 	const (
 		def  = "default"

--- a/pkg/scheduler/placement/placement_test.go
+++ b/pkg/scheduler/placement/placement_test.go
@@ -260,10 +260,8 @@ partitions:
 	// user rule existing queue, acl allowed
 	err = man.PlaceApplication(app)
 	queueName := app.GetQueuePath()
-	const TestQueueName = "root.testparent.testchild"
-	if err != nil || queueName != TestQueueName {
-		t.Errorf("leaf exist: app should have been placed in user queue, queue: '%s', error: %v", queueName, err)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, "root.testparent.testchild", queueName)
 	user = security.UserGroup{
 		User:   "other-user",
 		Groups: []string{},

--- a/pkg/scheduler/placement/placement_test.go
+++ b/pkg/scheduler/placement/placement_test.go
@@ -193,7 +193,9 @@ func TestManagerBuildRule(t *testing.T) {
 		t.Errorf("test rule build should not have failed and created 2 top level rule, err: %v, rules: %v", err, ruleObjs)
 	} else {
 		parent := ruleObjs[0].getParent()
-		const Test = "test"
+		const (
+			Test = "test"
+		)
 		if parent == nil || parent.getName() != Test {
 			t.Error("test rule build should have created 2 rules: parent not found")
 		}

--- a/pkg/scheduler/placement/provided_rule_test.go
+++ b/pkg/scheduler/placement/provided_rule_test.go
@@ -119,7 +119,8 @@ partitions:
 	// unqualified queue with parent rule that exists directly in hierarchy
 	appInfo = newApplication("app1", "default", "testchild", user, tags, nil, "")
 	queue, err = pr.placeApplication(appInfo, queueFunc)
-	if queue != "root.testparent.testchild" || err != nil {
+	const TestQueueName = "root.testparent.testchild"
+	if queue != TestQueueName || err != nil {
 		t.Errorf("provided rule failed to place queue in correct queue '%s', err %v", queue, err)
 	}
 

--- a/pkg/scheduler/placement/provided_rule_test.go
+++ b/pkg/scheduler/placement/provided_rule_test.go
@@ -119,10 +119,8 @@ partitions:
 	// unqualified queue with parent rule that exists directly in hierarchy
 	appInfo = newApplication("app1", "default", "testchild", user, tags, nil, "")
 	queue, err = pr.placeApplication(appInfo, queueFunc)
-	const TestQueueName = "root.testparent.testchild"
-	if queue != TestQueueName || err != nil {
-		t.Errorf("provided rule failed to place queue in correct queue '%s', err %v", queue, err)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, "root.testparent.testchild", queue)
 
 	// qualified queue with parent rule (parent rule ignored)
 	appInfo = newApplication("app1", "default", "root.testparent", user, tags, nil, "")

--- a/pkg/scheduler/placement/recovery_rule_test.go
+++ b/pkg/scheduler/placement/recovery_rule_test.go
@@ -41,18 +41,7 @@ func TestRecoveryRuleInitialise(t *testing.T) {
 
 func TestRecoveryRulePlace(t *testing.T) {
 	rr := &recoveryRule{}
-
-	// Create the structure for the test
-	data := `
-partitions:
-  - name: default
-    queues:
-      - name: testqueue
-      - name: testparent
-        queues:
-          - name: testchild
-`
-	err := initQueueStructure([]byte(data))
+	err := initQueueStructure([]byte(confTestQueue))
 	assert.NilError(t, err, "setting up the queue config failed")
 
 	// verify that non-forced app is not recovered

--- a/pkg/scheduler/placement/rule.go
+++ b/pkg/scheduler/placement/rule.go
@@ -72,12 +72,13 @@ func (r *basicRule) getParent() rule {
 	return r.parent
 }
 
+const unnamedRuleName = "unnamed rule"
+
 // getName returns the name if not overwritten by the rule.
 // Marked as nolint as rules should override this.
 //
 //nolint:unused
 func (r *basicRule) getName() string {
-	const unnamedRuleName = "unnamed rule"
 	return unnamedRuleName
 }
 

--- a/pkg/scheduler/placement/rule.go
+++ b/pkg/scheduler/placement/rule.go
@@ -77,7 +77,8 @@ func (r *basicRule) getParent() rule {
 //
 //nolint:unused
 func (r *basicRule) getName() string {
-	return "unnamed rule"
+	const unnamedRuleName = "unnamed rule"
+	return unnamedRuleName
 }
 
 // ruleDAO returns the RuleDAO object if not overwritten by the rule.

--- a/pkg/scheduler/placement/rule_test.go
+++ b/pkg/scheduler/placement/rule_test.go
@@ -118,12 +118,12 @@ func TestReplaceDot(t *testing.T) {
 
 func TestBasicRule(t *testing.T) {
 	rule := &basicRule{}
-	if name := rule.getName(); name != "unnamed rule" {
+	if name := rule.getName(); name != unnamedRuleName {
 		t.Errorf("expected %s, got %s", "unnamed rule", name)
 	}
 
 	dao := rule.ruleDAO()
-	if dao.Name != "unnamed rule" {
+	if dao.Name != unnamedRuleName {
 		t.Errorf("expected %s, got %s", "unnamed rule", dao.Name)
 	}
 }

--- a/pkg/scheduler/placement/tag_rule_test.go
+++ b/pkg/scheduler/placement/tag_rule_test.go
@@ -62,17 +62,7 @@ func TestTagRule(t *testing.T) {
 
 //nolint:funlen
 func TestTagRulePlace(t *testing.T) {
-	// Create the structure for the test
-	data := `
-partitions:
-  - name: default
-    queues:
-      - name: testqueue
-      - name: testparent
-        queues:
-          - name: testchild
-`
-	err := initQueueStructure([]byte(data))
+	err := initQueueStructure([]byte(confTestQueue))
 	assert.NilError(t, err, "setting up the queue config failed")
 
 	user := security.UserGroup{

--- a/pkg/scheduler/placement/testrule_test.go
+++ b/pkg/scheduler/placement/testrule_test.go
@@ -43,6 +43,17 @@ partitions:
 `
 const nameParentChild = "root.testparentnew.testchild"
 
+// Create the structure for the test
+const confTestQueue = `
+partitions:
+  - name: default
+    queues:
+      - name: testqueue
+      - name: testparent
+        queues:
+          - name: testchild
+`
+
 var root *objects.Queue
 
 // Mocked up function to mimic the partition getQueue function

--- a/pkg/scheduler/tests/reservation_test.go
+++ b/pkg/scheduler/tests/reservation_test.go
@@ -95,7 +95,7 @@ func TestBasicReservation(t *testing.T) {
 	nodes := createNodes(t, ms, 2, 50000000, 50000)
 	ms.mockRM.waitForMinAcceptedNodes(t, 2, 1000)
 
-	queueName := "root.leaf-1"
+	const queueName = "root.leaf-1"
 	err = ms.addApp(appID1, queueName, "default")
 	assert.NilError(t, err, "adding app to scheduler failed")
 
@@ -171,7 +171,7 @@ func TestReservationForTwoQueues(t *testing.T) {
 	ms.mockRM.waitForMinAcceptedNodes(t, 2, 1000)
 
 	// add the first scheduling app
-	leaf1Name := "root.leaf-1"
+	const leaf1Name = "root.leaf-1"
 	err = ms.addApp(appID1, leaf1Name, "default")
 	assert.NilError(t, err, "adding app 1 to scheduler failed")
 
@@ -274,7 +274,7 @@ func TestRemoveReservedNode(t *testing.T) {
 	nodes := createNodes(t, ms, 2, 50000000, 50000)
 	ms.mockRM.waitForMinAcceptedNodes(t, 2, 1000)
 
-	queueName := "root.leaf-1"
+	const queueName = "root.leaf-1"
 	err = ms.addApp(appID1, queueName, "default")
 	assert.NilError(t, err, "adding app to scheduler failed")
 

--- a/pkg/scheduler/tests/smoke_test.go
+++ b/pkg/scheduler/tests/smoke_test.go
@@ -168,7 +168,7 @@ func TestBasicScheduler(t *testing.T) {
 	err := ms.Init(configDataSmokeTest, false, false)
 	assert.NilError(t, err, "RegisterResourceManager failed")
 
-	leafName := "root.singleleaf"
+	const leafName = "root.singleleaf"
 	// Check queues of cache and scheduler.
 	part := ms.scheduler.GetClusterContext().GetPartition(partition)
 	assert.Assert(t, part.GetTotalPartitionResource() == nil, "partition info max resource nil")
@@ -639,7 +639,7 @@ partitions:
 	err := ms.Init(configData, false, false)
 	assert.NilError(t, err, "RegisterResourceManager failed")
 
-	leafName := "root.leaf"
+	const leafName = "root.leaf"
 	app1ID := appID1
 	app2ID := appID2
 

--- a/pkg/scheduler/tests/smoke_test.go
+++ b/pkg/scheduler/tests/smoke_test.go
@@ -33,7 +33,8 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
-const configDataSmokeTest = `
+const (
+	configDataSmokeTest = `
 partitions:
   - name: default
     queues:
@@ -46,6 +47,8 @@ partitions:
                 memory: 150M
                 vcore: 20
 `
+	leafName = "root.singleleaf"
+)
 
 // Test scheduler reconfiguration
 func TestConfigScheduler(t *testing.T) {
@@ -168,7 +171,6 @@ func TestBasicScheduler(t *testing.T) {
 	err := ms.Init(configDataSmokeTest, false, false)
 	assert.NilError(t, err, "RegisterResourceManager failed")
 
-	const leafName = "root.singleleaf"
 	// Check queues of cache and scheduler.
 	part := ms.scheduler.GetClusterContext().GetPartition(partition)
 	assert.Assert(t, part.GetTotalPartitionResource() == nil, "partition info max resource nil")
@@ -417,7 +419,6 @@ func TestBasicSchedulerAutoAllocation(t *testing.T) {
 	err := ms.Init(configDataSmokeTest, true, false)
 	assert.NilError(t, err, "RegisterResourceManager failed")
 
-	leafName := "root.singleleaf"
 	appID := appID1
 
 	// Register a node, and add apps
@@ -1295,7 +1296,6 @@ func TestDupReleasesInGangScheduling(t *testing.T) {
 	err := ms.Init(configDataSmokeTest, false, false)
 	assert.NilError(t, err, "RegisterResourceManager failed")
 
-	leafName := "root.singleleaf"
 	part := ms.scheduler.GetClusterContext().GetPartition(partition)
 	root := part.GetQueue("root")
 	leaf := part.GetQueue(leafName)

--- a/pkg/scheduler/tests/smoke_test.go
+++ b/pkg/scheduler/tests/smoke_test.go
@@ -41,13 +41,13 @@ partitions:
       - name: root
         submitacl: "*"
         queues:
-          - name: singleleaf
+          - name: leaf
             resources:
               max:
                 memory: 150M
                 vcore: 20
 `
-	leafName = "root.singleleaf"
+	leafName = "root.leaf"
 )
 
 // Test scheduler reconfiguration

--- a/pkg/scheduler/tests/smoke_test.go
+++ b/pkg/scheduler/tests/smoke_test.go
@@ -639,7 +639,9 @@ partitions:
 	err := ms.Init(configData, false, false)
 	assert.NilError(t, err, "RegisterResourceManager failed")
 
-	const leafName = "root.leaf"
+	const (
+		leafName = "root.leaf"
+	)
 	app1ID := appID1
 	app2ID := appID2
 

--- a/pkg/scheduler/tests/smoke_test.go
+++ b/pkg/scheduler/tests/smoke_test.go
@@ -640,9 +640,6 @@ partitions:
 	err := ms.Init(configData, false, false)
 	assert.NilError(t, err, "RegisterResourceManager failed")
 
-	const (
-		leafName = "root.leaf"
-	)
 	app1ID := appID1
 	app2ID := appID2
 

--- a/pkg/scheduler/ugm/group_tracker.go
+++ b/pkg/scheduler/ugm/group_tracker.go
@@ -137,13 +137,6 @@ func (gt *GroupTracker) canBeRemoved() bool {
 	return gt.queueTracker.canBeRemoved()
 }
 
-func (gt *GroupTracker) getName() string {
-	if gt == nil {
-		return common.Empty
-	}
-	return gt.groupName
-}
-
 func (gt *GroupTracker) decreaseAllTrackedResourceUsage(hierarchy []string) map[string]string {
 	if gt == nil {
 		return nil

--- a/pkg/webservice/handler_mock_test.go
+++ b/pkg/webservice/handler_mock_test.go
@@ -1,19 +1,19 @@
 /*
- Licensed to the Apache Software Foundation (ASF) under one
- or more contributor license agreements.  See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership.  The ASF licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package webservice
 

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -666,19 +666,21 @@ func TestGetNodesUtilJSON(t *testing.T) {
 	partition := setup(t, configDefault, 1)
 
 	// create test application
-	const appID = "app1"
+	const (
+		appID   = "app1"
+		node1ID = "node-1"
+		node2ID = "node-2"
+		node3ID = "node-3"
+	)
 	app := newApplication(appID, partition.Name, queueName, rmID, security.UserGroup{})
 	err := partition.AddApplication(app)
 	assert.NilError(t, err, "add application to partition should not have failed")
 
 	// create test nodes
 	nodeRes := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000}).ToProto()
-	const node1ID = "node-1"
 	node1 := objects.NewNode(&si.NodeInfo{NodeID: node1ID, SchedulableResource: nodeRes})
-	const node2ID = "node-2"
 	nodeRes2 := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000, "GPU": 10}).ToProto()
 	node2 := objects.NewNode(&si.NodeInfo{NodeID: node2ID, SchedulableResource: nodeRes2})
-	const node3ID = "node-3"
 	nodeCPU := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1000}).ToProto()
 	node3 := objects.NewNode(&si.NodeInfo{NodeID: node3ID, SchedulableResource: nodeCPU})
 
@@ -753,8 +755,10 @@ func TestGetNodeUtilisation(t *testing.T) {
 	assert.Assert(t, confirmNodeCount(utilisation.NodesUtil, 0), "unexpected number of nodes returned should be 0")
 
 	// create test nodes
-	const node1ID = "node-1"
-	const node2ID = "node-2"
+	const (
+		node1ID = "node-1"
+		node2ID = "node-2"
+	)
 	node1 := addNode(t, partition, node1ID, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10}))
 	node2 := addNode(t, partition, node2ID, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "second": 5}))
 
@@ -840,10 +844,11 @@ func TestGetPartitionNodesUtilJSON(t *testing.T) {
 	// setup
 	partition := setup(t, configDefault, 1)
 	appID := "app1"
-	const node1ID = "node-1"
-	const node2ID = "node-2"
-	const node3ID = "node-3"
-
+	const (
+		node1ID = "node-1"
+		node2ID = "node-2"
+		node3ID = "node-3"
+	)
 	// create test nodes
 	node1 := addNode(t, partition, node1ID, resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000}))
 	node2 := addNode(t, partition, node2ID, resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000, "GPU": 10}))

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -666,19 +666,19 @@ func TestGetNodesUtilJSON(t *testing.T) {
 	partition := setup(t, configDefault, 1)
 
 	// create test application
-	appID := "app1"
+	const appID = "app1"
 	app := newApplication(appID, partition.Name, queueName, rmID, security.UserGroup{})
 	err := partition.AddApplication(app)
 	assert.NilError(t, err, "add application to partition should not have failed")
 
 	// create test nodes
 	nodeRes := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000}).ToProto()
-	node1ID := "node-1"
+	const node1ID = "node-1"
 	node1 := objects.NewNode(&si.NodeInfo{NodeID: node1ID, SchedulableResource: nodeRes})
-	node2ID := "node-2"
+	const node2ID = "node-2"
 	nodeRes2 := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000, "GPU": 10}).ToProto()
 	node2 := objects.NewNode(&si.NodeInfo{NodeID: node2ID, SchedulableResource: nodeRes2})
-	node3ID := "node-3"
+	const node3ID = "node-3"
 	nodeCPU := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1000}).ToProto()
 	node3 := objects.NewNode(&si.NodeInfo{NodeID: node3ID, SchedulableResource: nodeCPU})
 
@@ -753,8 +753,8 @@ func TestGetNodeUtilisation(t *testing.T) {
 	assert.Assert(t, confirmNodeCount(utilisation.NodesUtil, 0), "unexpected number of nodes returned should be 0")
 
 	// create test nodes
-	node1ID := "node-1"
-	node2ID := "node-2"
+	const node1ID = "node-1"
+	const node2ID = "node-2"
 	node1 := addNode(t, partition, node1ID, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10}))
 	node2 := addNode(t, partition, node2ID, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "second": 5}))
 
@@ -840,9 +840,9 @@ func TestGetPartitionNodesUtilJSON(t *testing.T) {
 	// setup
 	partition := setup(t, configDefault, 1)
 	appID := "app1"
-	node1ID := "node-1"
-	node2ID := "node-2"
-	node3ID := "node-3"
+	const node1ID = "node-1"
+	const node2ID = "node-2"
+	const node3ID = "node-3"
 
 	// create test nodes
 	node1 := addNode(t, partition, node1ID, resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000}))
@@ -2655,9 +2655,9 @@ func TestCheckHealthStatus(t *testing.T) {
 }
 
 func runHealthCheckTest(t *testing.T, expected *dao.SchedulerHealthDAOInfo) {
-	schedulerContext := &scheduler.ClusterContext{}
-	schedulerContext.SetLastHealthCheckResult(expected)
-	NewWebApp(schedulerContext, nil)
+	testSchedulerContext := &scheduler.ClusterContext{}
+	testSchedulerContext.SetLastHealthCheckResult(expected)
+	NewWebApp(testSchedulerContext, nil)
 
 	req, err := http.NewRequest("GET", "/ws/v1/scheduler/healthcheck", strings.NewReader(""))
 	assert.NilError(t, err, "Error while creating the healthcheck request")

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -834,15 +834,11 @@ func TestGetPartitionNodesUtilJSON(t *testing.T) {
 	// setup
 	partition := setup(t, configDefault, 1)
 	appID := "app1"
-	const (
-		node1ID = "node-1"
-		node2ID = "node-2"
-		node3ID = "node-3"
-	)
+
 	// create test nodes
-	node1 := addNode(t, partition, node1ID, resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000}))
-	node2 := addNode(t, partition, node2ID, resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000, "GPU": 10}))
-	addNode(t, partition, node3ID, resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1000}))
+	node1 := addNode(t, partition, "node-1", resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000}))
+	node2 := addNode(t, partition, "node-2", resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000, "GPU": 10}))
+	node3 := addNode(t, partition, "node-3", resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1000}))
 
 	// create test allocations
 	addAllocatedResource(t, node1, "alloc-1", appID, map[string]resources.Quantity{siCommon.Memory: 500, siCommon.CPU: 300})
@@ -858,22 +854,22 @@ func TestGetPartitionNodesUtilJSON(t *testing.T) {
 	memoryNodesUtil := getNodesUtilByType(t, result.NodesUtilList, siCommon.Memory)
 	assert.Equal(t, memoryNodesUtil.NodesUtil[2].NumOfNodes, int64(1))
 	assert.Equal(t, memoryNodesUtil.NodesUtil[4].NumOfNodes, int64(1))
-	assert.Equal(t, memoryNodesUtil.NodesUtil[2].NodeNames[0], node2ID)
-	assert.Equal(t, memoryNodesUtil.NodesUtil[4].NodeNames[0], node1ID)
+	assert.Equal(t, memoryNodesUtil.NodesUtil[2].NodeNames[0], node2.NodeID)
+	assert.Equal(t, memoryNodesUtil.NodesUtil[4].NodeNames[0], node1.NodeID)
 
 	// three nodes advertise cpu: must show up in the list
 	cpuNodesUtil := getNodesUtilByType(t, result.NodesUtilList, siCommon.CPU)
 	assert.Equal(t, cpuNodesUtil.NodesUtil[0].NumOfNodes, int64(1))
-	assert.Equal(t, cpuNodesUtil.NodesUtil[0].NodeNames[0], node3ID)
+	assert.Equal(t, cpuNodesUtil.NodesUtil[0].NodeNames[0], node3.NodeID)
 	assert.Equal(t, cpuNodesUtil.NodesUtil[2].NumOfNodes, int64(1))
-	assert.Equal(t, cpuNodesUtil.NodesUtil[2].NodeNames[0], node1ID)
+	assert.Equal(t, cpuNodesUtil.NodesUtil[2].NodeNames[0], node1.NodeID)
 	assert.Equal(t, cpuNodesUtil.NodesUtil[4].NumOfNodes, int64(1))
-	assert.Equal(t, cpuNodesUtil.NodesUtil[4].NodeNames[0], node2ID)
+	assert.Equal(t, cpuNodesUtil.NodesUtil[4].NodeNames[0], node2.NodeID)
 
 	// one node advertise GPU: must show up in the list
 	gpuNodesUtil := getNodesUtilByType(t, result.NodesUtilList, "GPU")
 	assert.Equal(t, gpuNodesUtil.NodesUtil[4].NumOfNodes, int64(1))
-	assert.Equal(t, gpuNodesUtil.NodesUtil[4].NodeNames[0], node2ID)
+	assert.Equal(t, gpuNodesUtil.NodesUtil[4].NodeNames[0], node2.NodeID)
 }
 
 func TestGetNodeUtilisations(t *testing.T) {

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -666,33 +666,27 @@ func TestGetNodesUtilJSON(t *testing.T) {
 	partition := setup(t, configDefault, 1)
 
 	// create test application
-	const (
-		appID   = "app1"
-		node1ID = "node-1"
-		node2ID = "node-2"
-		node3ID = "node-3"
-	)
-	app := newApplication(appID, partition.Name, queueName, rmID, security.UserGroup{})
+	app := newApplication("app1", partition.Name, queueName, rmID, security.UserGroup{})
 	err := partition.AddApplication(app)
 	assert.NilError(t, err, "add application to partition should not have failed")
 
 	// create test nodes
 	nodeRes := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000}).ToProto()
-	node1 := objects.NewNode(&si.NodeInfo{NodeID: node1ID, SchedulableResource: nodeRes})
+	node1 := objects.NewNode(&si.NodeInfo{NodeID: "node-1", SchedulableResource: nodeRes})
 	nodeRes2 := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 1000, siCommon.CPU: 1000, "GPU": 10}).ToProto()
-	node2 := objects.NewNode(&si.NodeInfo{NodeID: node2ID, SchedulableResource: nodeRes2})
+	node2 := objects.NewNode(&si.NodeInfo{NodeID: "node-2", SchedulableResource: nodeRes2})
 	nodeCPU := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1000}).ToProto()
-	node3 := objects.NewNode(&si.NodeInfo{NodeID: node3ID, SchedulableResource: nodeCPU})
+	node3 := objects.NewNode(&si.NodeInfo{NodeID: "node-3", SchedulableResource: nodeCPU})
 
 	// create test allocations
 	resAlloc1 := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 500, siCommon.CPU: 300})
 	resAlloc2 := resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.Memory: 300, siCommon.CPU: 500, "GPU": 5})
-	ask1 := objects.NewAllocationAsk("alloc-1", appID, resAlloc1)
-	ask2 := objects.NewAllocationAsk("alloc-2", appID, resAlloc2)
-	allocs := []*objects.Allocation{objects.NewAllocation(node1ID, ask1)}
+	ask1 := objects.NewAllocationAsk("alloc-1", app.ApplicationID, resAlloc1)
+	ask2 := objects.NewAllocationAsk("alloc-2", app.ApplicationID, resAlloc2)
+	allocs := []*objects.Allocation{objects.NewAllocation(node1.NodeID, ask1)}
 	err = partition.AddNode(node1, allocs)
 	assert.NilError(t, err, "add node to partition should not have failed")
-	allocs = []*objects.Allocation{objects.NewAllocation(node2ID, ask2)}
+	allocs = []*objects.Allocation{objects.NewAllocation(node2.NodeID, ask2)}
 	err = partition.AddNode(node2, allocs)
 	assert.NilError(t, err, "add node to partition should not have failed")
 	err = partition.AddNode(node3, nil)
@@ -704,26 +698,26 @@ func TestGetNodesUtilJSON(t *testing.T) {
 	assert.Equal(t, result.ResourceType, siCommon.Memory)
 	assert.Equal(t, subResult[2].NumOfNodes, int64(1))
 	assert.Equal(t, subResult[4].NumOfNodes, int64(1))
-	assert.Equal(t, subResult[2].NodeNames[0], node2ID)
-	assert.Equal(t, subResult[4].NodeNames[0], node1ID)
+	assert.Equal(t, subResult[2].NodeNames[0], node2.NodeID)
+	assert.Equal(t, subResult[4].NodeNames[0], node1.NodeID)
 
 	// three nodes advertise cpu: must show up in the list
 	result = getNodesUtilJSON(partition, siCommon.CPU)
 	subResult = result.NodesUtil
 	assert.Equal(t, result.ResourceType, siCommon.CPU)
 	assert.Equal(t, subResult[0].NumOfNodes, int64(1))
-	assert.Equal(t, subResult[0].NodeNames[0], node3ID)
+	assert.Equal(t, subResult[0].NodeNames[0], node3.NodeID)
 	assert.Equal(t, subResult[2].NumOfNodes, int64(1))
-	assert.Equal(t, subResult[2].NodeNames[0], node1ID)
+	assert.Equal(t, subResult[2].NodeNames[0], node1.NodeID)
 	assert.Equal(t, subResult[4].NumOfNodes, int64(1))
-	assert.Equal(t, subResult[4].NodeNames[0], node2ID)
+	assert.Equal(t, subResult[4].NodeNames[0], node2.NodeID)
 
 	// one node advertise GPU: must show up in the list
 	result = getNodesUtilJSON(partition, "GPU")
 	subResult = result.NodesUtil
 	assert.Equal(t, result.ResourceType, "GPU")
 	assert.Equal(t, subResult[4].NumOfNodes, int64(1))
-	assert.Equal(t, subResult[4].NodeNames[0], node2ID)
+	assert.Equal(t, subResult[4].NodeNames[0], node2.NodeID)
 
 	result = getNodesUtilJSON(partition, "non-exist")
 	subResult = result.NodesUtil
@@ -755,12 +749,8 @@ func TestGetNodeUtilisation(t *testing.T) {
 	assert.Assert(t, confirmNodeCount(utilisation.NodesUtil, 0), "unexpected number of nodes returned should be 0")
 
 	// create test nodes
-	const (
-		node1ID = "node-1"
-		node2ID = "node-2"
-	)
-	node1 := addNode(t, partition, node1ID, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10}))
-	node2 := addNode(t, partition, node2ID, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "second": 5}))
+	node1 := addNode(t, partition, "node-1", resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10}))
+	node2 := addNode(t, partition, "node-2", resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "second": 5}))
 
 	// get nodes utilization
 	resp = &MockResponseWriter{}
@@ -774,7 +764,7 @@ func TestGetNodeUtilisation(t *testing.T) {
 
 	resAlloc := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
 	ask := objects.NewAllocationAsk("alloc-1", "app", resAlloc)
-	alloc := objects.NewAllocation(node1ID, ask)
+	alloc := objects.NewAllocation(node1.NodeID, ask)
 	assert.Assert(t, node1.AddAllocation(alloc), "unexpected failure adding allocation to node")
 	rootQ := partition.GetQueue("root")
 	err = rootQ.IncAllocatedResource(resAlloc, false)
@@ -792,7 +782,7 @@ func TestGetNodeUtilisation(t *testing.T) {
 	// make second type dominant by using all
 	resAlloc = resources.NewResourceFromMap(map[string]resources.Quantity{"second": 5})
 	ask = objects.NewAllocationAsk("alloc-2", "app", resAlloc)
-	alloc = objects.NewAllocation(node2ID, ask)
+	alloc = objects.NewAllocation(node2.NodeID, ask)
 	assert.Assert(t, node2.AddAllocation(alloc), "unexpected failure adding allocation to node")
 	err = rootQ.IncAllocatedResource(resAlloc, false)
 	assert.NilError(t, err, "unexpected error returned setting allocated resource on queue")

--- a/pkg/webservice/webservice.go
+++ b/pkg/webservice/webservice.go
@@ -62,7 +62,6 @@ func loggingHandler(inner http.Handler, name string) http.HandlerFunc {
 }
 
 // StartWebApp starts the web app on the default port.
-// TODO we need the port to be configurable
 func (m *WebService) StartWebApp() {
 	router := newRouter()
 	m.httpServer = &http.Server{


### PR DESCRIPTION
### What is this PR for?
fix lint error
### What type of PR is it?
* [ ] - Bug Fix
* [X] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] [YUNIKORN-2739](https://issues.apache.org/jira/browse/YUNIKORN-2739)
* [ ] [YUNIKORN-2740](https://issues.apache.org/jira/browse/YUNIKORN-2740)
* [ ] [YUNIKORN-2741](https://issues.apache.org/jira/browse/YUNIKORN-2741)
* [ ] [YUNIKORN-2742](https://issues.apache.org/jira/browse/YUNIKORN-2742)
* [ ] [YUNIKORN-2743](https://issues.apache.org/jira/browse/YUNIKORN-2743)
* [ ] [YUNIKORN-2744](https://issues.apache.org/jira/browse/YUNIKORN-2744)


### What is the Jira issue?
[YUNIKORN-2729](https://issues.apache.org/jira/browse/YUNIKORN-2729)
### How should this be tested?
remove `--new-from-rev` from Makefile
`make lint`
