### PR TITLE
[YUNIKORN-2718] Assert invalid user name in Get User REST API

### DIFF
--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -1102,7 +1102,7 @@ func getUserResourceUsage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !configs.UserRegExp.MatchString(unescapedUser) {
-		buildJSONErrorResponse(w, InvalidUserName, http.StatusNotFound)
+		buildJSONErrorResponse(w, InvalidUserName, http.StatusBadRequest)
 		return
 	}
 	userTracker := ugm.GetUserManager().GetUserTracker(unescapedUser)

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -56,6 +56,7 @@ const (
 	PartitionDoesNotExists   = "Partition not found"
 	MissingParamsName        = "Missing parameters"
 	QueueDoesNotExists       = "Queue not found"
+	InvalidUserName          = "Invalid user name"
 	UserDoesNotExists        = "User not found"
 	GroupDoesNotExists       = "Group not found"
 	UserNameMissing          = "User name is missing"
@@ -1098,6 +1099,10 @@ func getUserResourceUsage(w http.ResponseWriter, r *http.Request) {
 	unescapedUser, err := url.QueryUnescape(user)
 	if err != nil {
 		buildJSONErrorResponse(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !configs.UserRegExp.MatchString(unescapedUser) {
+		buildJSONErrorResponse(w, InvalidUserName, http.StatusNotFound)
 		return
 	}
 	userTracker := ugm.GetUserManager().GetUserTracker(unescapedUser)

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1978,12 +1978,12 @@ func TestSpecificUserResourceUsage(t *testing.T) {
 	assert.NilError(t, err)
 	resp = &MockResponseWriter{}
 	getUserResourceUsage(resp, req)
-	assert.Equal(t, http.StatusNotFound, resp.statusCode)
+	assert.Equal(t, http.StatusBadRequest, resp.statusCode)
 	var invalidUserError dao.YAPIError
 	err = json.Unmarshal(resp.outputBytes, &invalidUserError)
 	assert.NilError(t, err, unmarshalError)
 	assert.Equal(t, InvalidUserName, invalidUserError.Message)
-	assert.Equal(t, http.StatusNotFound, invalidUserError.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, invalidUserError.StatusCode)
 }
 
 func TestSpecificGroupResourceUsage(t *testing.T) {

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1971,6 +1971,19 @@ func TestSpecificUserResourceUsage(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.statusCode, statusCodeError)
 	assert.Equal(t, errInfo.Message, "invalid URL escape \"%Zt\"", jsonMessageError)
 	assert.Equal(t, errInfo.StatusCode, http.StatusBadRequest)
+
+	// Test invalid user name that does not match UserRegExp
+	invalidUserName := "1InvalidUser"
+	req, err = createRequest(t, "/ws/v1/partition/default/usage/user/", map[string]string{"user": invalidUserName, "group": "testgroup"})
+	assert.NilError(t, err)
+	resp = &MockResponseWriter{}
+	getUserResourceUsage(resp, req)
+	assert.Equal(t, http.StatusNotFound, resp.statusCode)
+	var invalidUserError dao.YAPIError
+	err = json.Unmarshal(resp.outputBytes, &invalidUserError)
+	assert.NilError(t, err, unmarshalError)
+	assert.Equal(t, InvalidUserName, invalidUserError.Message)
+	assert.Equal(t, http.StatusNotFound, invalidUserError.StatusCode)
 }
 
 func TestSpecificGroupResourceUsage(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
Assert invalid user name in Get User REST API. 
In the pkg/webservice/handler.go file, we see in the func getUserResourceUsage, it didn't check whether the userName is valid or not. So in this PR, it check the UserRegExp to see if the user name is valid or not, and send back the InvalidUserName response.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2718

### How should this be tested?
It passed all test cases locally.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
