### PR TITLE
[YUNIKORN-2769] Preemption fails between two siblings when preemptor …

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -615,12 +615,11 @@ func compareShares(lshares, rshares []float64) int {
 	return 0
 }
 
-// Compare the resources equal returns the specific values for following cases:
-// left  right  return
-// nil   nil    true
-// nil   <set>  false
-// <set> nil    false
-// <set> <set>  true/false  *based on the individual Quantity values
+// Equals Compare the resources based on common resource type available in both left and right Resource
+// Resource type available in left Resource but not in right Resource and vice versa is not taken into account
+// False in case anyone of the resources is nil
+// False in case resource type value differs
+// True in case when resource type values of left Resource matches with right Resource if resource type is available
 func Equals(left, right *Resource) bool {
 	if left == right {
 		return true
@@ -635,22 +634,20 @@ func Equals(left, right *Resource) bool {
 			return false
 		}
 	}
-
 	for k, v := range right.Resources {
 		if left.Resources[k] != v {
 			return false
 		}
 	}
-
 	return true
 }
 
-// DeepEquals Compare the resources equal returns the specific values for following cases:
-// left  right  return
-// nil   nil    true
-// nil   <set>  false
-// <set> nil    false
-// <set> <set>  true/false  *based on the individual resource type presence and its Quantity values
+// DeepEquals Compare the resources based on resource type existence and its values as well
+// False in case anyone of the resources is nil
+// False in case resource length differs
+// False in case resource type existed in left Resource not exist in right Resource
+// False in case resource type value differs
+// True in case when all resource type and its values of left Resource matches with right Resource
 func DeepEquals(left, right *Resource) bool {
 	if left == right {
 		return true
@@ -658,17 +655,11 @@ func DeepEquals(left, right *Resource) bool {
 	if left == nil || right == nil {
 		return false
 	}
+	if len(right.Resources) != len(left.Resources) {
+		return false
+	}
 	for k, v := range left.Resources {
 		if val, ok := right.Resources[k]; ok {
-			if val != v {
-				return false
-			}
-		} else {
-			return false
-		}
-	}
-	for k, v := range right.Resources {
-		if val, ok := left.Resources[k]; ok {
 			if val != v {
 				return false
 			}

--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -918,11 +918,11 @@ func ComponentWiseMinPermissive(left, right *Resource) *Resource {
 	return out
 }
 
-// ComponentWiseMinPermissiveWithPrecedence Returns a new Resource by giving higher precedence for resource type values present in left when
-// it is present at right as well. Resource type not present in left and present in right would be included too.
+// MergeIfNotPresent Returns a new Resource by merging resource type values present in right with left
+// only if resource type not present in left.
 // If either Resource passed in is nil the other Resource is returned
 // If a Resource type is missing from one of the Resource, it is considered empty and the quantity from the other Resource is returned
-func ComponentWiseMinPermissiveWithPrecedence(left, right *Resource) *Resource {
+func MergeIfNotPresent(left, right *Resource) *Resource {
 	if right == nil && left == nil {
 		return nil
 	}

--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -923,7 +923,7 @@ func MergeIfNotPresent(left, right *Resource) *Resource {
 	if right == nil {
 		return left.Clone()
 	}
-	out := left
+	out := left.Clone()
 	for k, v := range right.Resources {
 		if _, ok := left.Resources[k]; !ok {
 			out.Resources[k] = v

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -622,7 +622,7 @@ func TestComponentWiseMinPermissiveWithPrecedence(t *testing.T) {
 			expected = NewResourceFromMap(tc.expected)
 		}
 		t.Run(tc.name, func(t *testing.T) {
-			result := ComponentWiseMinPermissiveWithPrecedence(left, right)
+			result := MergeIfNotPresent(left, right)
 			assert.DeepEqual(t, result, expected)
 		})
 	}

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -588,6 +588,46 @@ func TestComponentWiseMinOnlyExisting(t *testing.T) {
 	}
 }
 
+func TestComponentWiseMinPermissiveWithPrecedence(t *testing.T) {
+	testCases := []struct {
+		name     string
+		left     map[string]Quantity
+		right    map[string]Quantity
+		expected map[string]Quantity
+	}{
+		{"Min of nil resources should be nil", nil, nil, nil},
+		{"Min of empty resources should be empty resource ", map[string]Quantity{}, map[string]Quantity{}, map[string]Quantity{}},
+		{"Min of positive resource and nil resource", map[string]Quantity{"first": 5}, nil, map[string]Quantity{"first": 5}},
+		{"Min of nil resource and positive resource", nil, map[string]Quantity{"first": 5}, map[string]Quantity{"first": 5}},
+		{"Min of two positive resources", map[string]Quantity{"first": 5}, map[string]Quantity{"first": 10}, map[string]Quantity{"first": 5}},
+		{"Min of two positive resources", map[string]Quantity{"first": 10}, map[string]Quantity{"first": 5}, map[string]Quantity{"first": 10}},
+		{"Min of positive resource and negative resource", map[string]Quantity{"first": 5}, map[string]Quantity{"first": -5}, map[string]Quantity{"first": 5}},
+		{"Min of positive resource and negative resource", map[string]Quantity{"first": -5}, map[string]Quantity{"first": 5}, map[string]Quantity{"first": -5}},
+		{"Min of two positive resources with extra resource types", map[string]Quantity{"first": 10}, map[string]Quantity{"first": 5, "second": 15}, map[string]Quantity{"first": 10, "second": 15}},
+		{"Min of two positive resources with extra resource types", map[string]Quantity{"first": 5, "second": 15}, map[string]Quantity{"first": 10}, map[string]Quantity{"first": 5, "second": 15}},
+		{"Min of positive resource and negative resource with extra resource types", map[string]Quantity{"first": 10}, map[string]Quantity{"first": -5, "second": 15}, map[string]Quantity{"first": 10, "second": 15}},
+		{"Min of positive resource and negative resource with extra resource types", map[string]Quantity{"first": -5, "second": 15}, map[string]Quantity{"first": 10}, map[string]Quantity{"first": -5, "second": 15}},
+	}
+	for _, tc := range testCases {
+		var left *Resource
+		var right *Resource
+		var expected *Resource
+		if tc.left != nil {
+			left = NewResourceFromMap(tc.left)
+		}
+		if tc.right != nil {
+			right = NewResourceFromMap(tc.right)
+		}
+		if tc.expected != nil {
+			expected = NewResourceFromMap(tc.expected)
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			result := ComponentWiseMinPermissiveWithPrecedence(left, right)
+			assert.DeepEqual(t, result, expected)
+		})
+	}
+}
+
 func TestComponentWiseMax(t *testing.T) {
 	type inputs struct {
 		res1    map[string]Quantity
@@ -1174,6 +1214,29 @@ func TestEqualsOrEmpty(t *testing.T) {
 
 	for _, tt := range tests {
 		if got := EqualsOrEmpty(tt.left, tt.right); got != tt.want {
+			t.Errorf("got %v, want %v", got, tt.want)
+		}
+	}
+}
+
+func TestDeepEquals(t *testing.T) {
+	var tests = []struct {
+		left, right *Resource
+		want        bool
+	}{
+		{nil, nil, true},
+		{nil, NewResourceFromMap(map[string]Quantity{"a": 0, "b": 1}), false},
+		{NewResourceFromMap(map[string]Quantity{"a": 0, "b": 1}), nil, false},
+		{nil, NewResource(), false},
+		{NewResource(), nil, false},
+		{NewResourceFromMap(map[string]Quantity{"a": 0, "b": 1}), NewResourceFromMap(map[string]Quantity{"a": 0, "b": 1}), true},
+		{NewResourceFromMap(map[string]Quantity{"a": 0, "c": 1}), NewResourceFromMap(map[string]Quantity{"a": 0, "d": 3}), false},
+		{NewResourceFromMap(map[string]Quantity{"a": 0}), NewResourceFromMap(map[string]Quantity{"d": 0}), false},
+		{NewResourceFromMap(map[string]Quantity{"a": 0}), NewResourceFromMap(map[string]Quantity{"a": 0}), true},
+	}
+
+	for _, tt := range tests {
+		if got := DeepEquals(tt.left, tt.right); got != tt.want {
 			t.Errorf("got %v, want %v", got, tt.want)
 		}
 	}

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -1229,10 +1229,12 @@ func TestDeepEquals(t *testing.T) {
 		{NewResourceFromMap(map[string]Quantity{"a": 0, "b": 1}), nil, false},
 		{nil, NewResource(), false},
 		{NewResource(), nil, false},
+		{NewResourceFromMap(map[string]Quantity{"a": 0}), NewResourceFromMap(map[string]Quantity{"a": 0}), true},
 		{NewResourceFromMap(map[string]Quantity{"a": 0, "b": 1}), NewResourceFromMap(map[string]Quantity{"a": 0, "b": 1}), true},
+		{NewResourceFromMap(map[string]Quantity{"a": 0}), NewResourceFromMap(map[string]Quantity{"b": 0, "c": 1}), false},
+		{NewResourceFromMap(map[string]Quantity{"a": 0, "b": 1}), NewResourceFromMap(map[string]Quantity{"a": 1, "b": 1}), false},
 		{NewResourceFromMap(map[string]Quantity{"a": 0, "c": 1}), NewResourceFromMap(map[string]Quantity{"a": 0, "d": 3}), false},
 		{NewResourceFromMap(map[string]Quantity{"a": 0}), NewResourceFromMap(map[string]Quantity{"d": 0}), false},
-		{NewResourceFromMap(map[string]Quantity{"a": 0}), NewResourceFromMap(map[string]Quantity{"a": 0}), true},
 	}
 
 	for _, tt := range tests {

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -588,7 +588,7 @@ func TestComponentWiseMinOnlyExisting(t *testing.T) {
 	}
 }
 
-func TestComponentWiseMinPermissiveWithPrecedence(t *testing.T) {
+func TestMergeIfNotPresent(t *testing.T) {
 	testCases := []struct {
 		name     string
 		left     map[string]Quantity

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -69,7 +69,6 @@ type QueuePreemptionSnapshot struct {
 	MaxResource        *resources.Resource      // maximum resources for this queue
 	GuaranteedResource *resources.Resource      // guaranteed resources for this queue
 	PotentialVictims   []*Allocation            // list of allocations which could be preempted
-	AskQueuePath       string                   // fully qualified path of ask or preemptor queue
 	AskQueue           *QueuePreemptionSnapshot // snapshot of ask or preemptor queue
 }
 
@@ -762,7 +761,6 @@ func (qps *QueuePreemptionSnapshot) Duplicate(copy map[string]*QueuePreemptionSn
 		MaxResource:        qps.MaxResource.Clone(),
 		GuaranteedResource: qps.GuaranteedResource.Clone(),
 		PotentialVictims:   qps.PotentialVictims,
-		AskQueuePath:       qps.AskQueuePath,
 		AskQueue:           qps.AskQueue,
 	}
 	copy[qps.QueuePath] = snapshot

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -830,7 +830,7 @@ func (qps *QueuePreemptionSnapshot) GetRemainingGuaranteedResource() *resources.
 	if qps.AskQueue != nil {
 		// In case ask queue has guaranteed set, its own values carries higher precedence over the parent or ancestor
 		if qps.AskQueue.QueuePath == qps.QueuePath && !remainingGuaranteed.IsEmpty() {
-			return remainingGuaranteed
+			return resources.ComponentWiseMinPermissiveWithPrecedence(remainingGuaranteed, parent)
 		}
 	}
 	return resources.ComponentWiseMinPermissive(remainingGuaranteed, parent)

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -830,7 +830,7 @@ func (qps *QueuePreemptionSnapshot) GetRemainingGuaranteedResource() *resources.
 	if qps.AskQueue != nil {
 		// In case ask queue has guaranteed set, its own values carries higher precedence over the parent or ancestor
 		if qps.AskQueue.QueuePath == qps.QueuePath && !remainingGuaranteed.IsEmpty() {
-			return resources.ComponentWiseMinPermissiveWithPrecedence(remainingGuaranteed, parent)
+			return resources.MergeIfNotPresent(remainingGuaranteed, parent)
 		}
 	}
 	return resources.ComponentWiseMinPermissive(remainingGuaranteed, parent)

--- a/pkg/scheduler/objects/preemption_queue_test.go
+++ b/pkg/scheduler/objects/preemption_queue_test.go
@@ -238,10 +238,10 @@ func TestGetRemainingGuaranteedResource(t *testing.T) {
 	}
 }
 
-func setup(t *testing.T) (*Queue, *Queue, *Queue, *Queue, *Queue) {
+func setup(t *testing.T) (rootQ, parentQ, childQ1, childQ2, childQ3 *Queue) {
 	rootQ, err := createRootQueue(map[string]string{})
 	assert.NilError(t, err)
-	var parentQ, childQ1, childQ2, parent1Q, childQ3 *Queue
+	var parent1Q *Queue
 	parentQ, err = createManagedQueue(rootQ, "parent", true, map[string]string{})
 	assert.NilError(t, err)
 	parent1Q, err = createManagedQueue(rootQ, "parent1", true, map[string]string{})
@@ -252,8 +252,9 @@ func setup(t *testing.T) (*Queue, *Queue, *Queue, *Queue, *Queue) {
 	assert.NilError(t, err)
 	childQ3, err = createManagedQueue(parent1Q, "child3", false, map[string]string{})
 	assert.NilError(t, err)
-	return rootQ, parentQ, childQ1, childQ2, childQ3
+	return
 }
+
 func assertZeroRemaining(t *testing.T, rootRemaining *resources.Resource, pRemaining *resources.Resource, cRemaining1 *resources.Resource, cRemaining2 *resources.Resource) {
 	assert.Assert(t, resources.IsZero(rootRemaining), "guaranteed and max res not set, so no remaining")
 	assert.Assert(t, resources.IsZero(pRemaining), "guaranteed and max res not set, so no remaining")

--- a/pkg/scheduler/objects/preemption_queue_test.go
+++ b/pkg/scheduler/objects/preemption_queue_test.go
@@ -123,113 +123,185 @@ func TestGetPreemptableResource(t *testing.T) {
 
 func TestGetRemainingGuaranteedResource(t *testing.T) {
 	// no guaranteed and no usage. so no remaining
+	rootQ, parentQ, childQ1, childQ2, childQ3 := setup(t)
+	smallestRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})
+	childRes := resources.NewResourceFromMap(map[string]resources.Quantity{"second": 5})
+	expectedSmallestRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 3})
+	expectedSmallestRes1 := smallestRes.Clone()
+	expectedSmallestRes1.MultiplyTo(float64(0))
+	var tests = []struct {
+		testName          string
+		askQueue          *Queue
+		childQ2Remaining  *resources.Resource
+		childQ2Remaining1 *resources.Resource
+	}{
+		{"UnderGuaranteedChildQueue_Under_OverGuaranteedParentQueue_Does_Not_Have_Higher_Precedence_When_AskQueue_Is_Different_From_UnderGuaranteedChildQueue", childQ3,
+			resources.Multiply(smallestRes, -1), resources.Add(expectedSmallestRes1, resources.Multiply(childRes, -1))},
+		{"UnderGuaranteedChildQueue_Under_OverGuaranteedParentQueue_Has_Higher_Precedence_When_AskQueue_Is_Same_As_UnderGuaranteedChildQueue", childQ2,
+			resources.Multiply(smallestRes, 0), resources.Add(expectedSmallestRes, resources.Multiply(childRes, -1))},
+	}
+	for _, tt := range tests {
+		var rootRemaining, pRemaining, cRemaining1, cRemaining2 *resources.Resource
+		resetQueueResources(rootQ, parentQ, childQ1, childQ2)
+		rootRemaining, pRemaining, cRemaining1, cRemaining2 = setAndGetRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2, map[string]*resources.Resource{rootQ.QueuePath: nil, parentQ.QueuePath: nil, childQ1.QueuePath: nil, childQ2.QueuePath: nil}, tt.askQueue)
+		assertZeroRemaining(t, rootRemaining, pRemaining, cRemaining1, cRemaining2)
+
+		// no guaranteed and no usage, but max res set. so min of guaranteed and max should be remaining
+		smallestRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})
+		rootQ.maxResource = resources.Multiply(smallestRes, 4)
+		parentQ.maxResource = resources.Multiply(smallestRes, 2)
+		childQ1.maxResource = smallestRes
+		childQ2.maxResource = smallestRes
+		rootRemaining, pRemaining, cRemaining1, cRemaining2 = setAndGetRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2, map[string]*resources.Resource{rootQ.QueuePath: nil, parentQ.QueuePath: nil, childQ1.QueuePath: nil, childQ2.QueuePath: nil}, tt.askQueue)
+		assertZeroRemaining(t, rootRemaining, pRemaining, cRemaining1, cRemaining2)
+
+		// guaranteed set only for queue at specific levels but no usage.
+		// so remaining for queues without guaranteed quota inherits from parent queue based on min perm calculation
+		rootRemaining, pRemaining, cRemaining1, cRemaining2 = setAndGetRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2, map[string]*resources.Resource{rootQ.QueuePath: resources.Multiply(smallestRes, 2), parentQ.QueuePath: nil, childQ1.QueuePath: childRes, childQ2.QueuePath: nil}, tt.askQueue)
+		assert.Assert(t, resources.Equals(rootRemaining, resources.Multiply(smallestRes, 2)), "guaranteed set, but no usage. so all guaranteed should be in remaining")
+		assert.Assert(t, resources.Equals(pRemaining, resources.Multiply(smallestRes, 2)), "guaranteed not set, also no usage. However, parent's remaining should be used")
+		assert.Assert(t, resources.Equals(cRemaining1, resources.Add(resources.Multiply(smallestRes, 2), childRes)), "guaranteed not set, also no usage. However, parent's remaining should be used")
+		assert.Assert(t, resources.Equals(cRemaining2, resources.Multiply(smallestRes, 2)), "guaranteed not set, also no usage. However, parent's remaining should be used")
+
+		// guaranteed set but no usage. so nothing to preempt
+		// clean start for the snapshot: whole hierarchy with guarantee
+		queueRes := map[string]*resources.Resource{rootQ.QueuePath: resources.Multiply(smallestRes, 2), parentQ.QueuePath: smallestRes, childQ1.QueuePath: childRes, childQ2.QueuePath: smallestRes}
+		rootRemaining, pRemaining, cRemaining1, cRemaining2 = setAndGetRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2, queueRes, tt.askQueue)
+		assert.Assert(t, resources.Equals(rootRemaining, resources.Multiply(smallestRes, 2)), "guaranteed set, but no usage. so all guaranteed should be in remaining")
+		assert.Assert(t, resources.Equals(pRemaining, smallestRes), "guaranteed set, but no usage. so all guaranteed should be in remaining")
+		assert.Assert(t, resources.Equals(cRemaining1, resources.Add(smallestRes, childRes)), "guaranteed set, but no usage. so all guaranteed + parent remaining guaranteed should be in remaining")
+		assert.Assert(t, resources.Equals(cRemaining2, smallestRes), "guaranteed set, but no usage. so all its guaranteed (because it is lesser than parent's guaranteed) should be in remaining")
+
+		// clean start for the snapshot: all set guaranteed
+		// add usage to parent + root: use all guaranteed at parent level
+		// add usage to child2: use all guaranteed set
+		// child2 remaining behaviour changes based on the ask queue.
+		// When ask queue is child2, its own values has higher precedence over the parent or ancestor for common resource types.
+		// for extra resources available in parent or ancestor, it can simply inherit.
+		// When ask queue is child3 (diverged from very earlier branch, not sharing any common queue path), its remaining is min permissive of its own values and parent or ancestor values.
+		rootQ.allocatedResource = resources.Multiply(smallestRes, 2)
+		parentQ.allocatedResource = resources.Multiply(smallestRes, 2)
+		childQ2.allocatedResource = resources.Multiply(smallestRes, 1)
+		rootRemaining, pRemaining, cRemaining1, cRemaining2 = setAndGetRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2, queueRes, tt.askQueue)
+		assert.Assert(t, resources.IsZero(rootRemaining), "guaranteed set, used completely. so all guaranteed should be in remaining")
+		assert.Assert(t, resources.Equals(pRemaining, resources.Multiply(smallestRes, -1)), "guaranteed set, used double than guaranteed. so remaining should be in -ve")
+		assert.Assert(t, resources.Equals(cRemaining1, resources.Add(resources.Multiply(smallestRes, -1), childRes)), "guaranteed set, but no usage. However remaining should include its all guaranteed + parent remaining guaranteed")
+		assert.Assert(t, resources.Equals(cRemaining2, tt.childQ2Remaining), "guaranteed set, used all guaranteed. remaining should be based on ask queue")
+
+		// clean start for the snapshot: all set guaranteed
+		// add usage for all: use exactly guaranteed at parent and child level
+		// parent guarantee used for one type child guarantee used for second type
+		bothRes := resources.Multiply(smallestRes, 2)
+		bothRes.AddTo(childRes)
+		rootQ.allocatedResource = bothRes
+		bothRes = resources.Add(smallestRes, childRes)
+		parentQ.allocatedResource = bothRes
+		childQ1.allocatedResource = childRes
+		childQ2.allocatedResource = smallestRes
+		rootRemaining, pRemaining, cRemaining1, cRemaining2 = setAndGetRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2, queueRes, tt.askQueue)
+		assert.Assert(t, resources.IsZero(rootRemaining), "guaranteed set, used completely. usage also has extra resource types. However, no remaining")
+		assert.Assert(t, resources.IsZero(pRemaining), "guaranteed set, used completely. usage also has extra resource types. However, no remaining")
+		assert.Assert(t, resources.IsZero(cRemaining1), "guaranteed set, used completely. so, no remaining")
+		assert.Assert(t, resources.IsZero(cRemaining2), "guaranteed set, but no usage. Still, no remaining in guaranteed because of its parent queue")
+
+		// clean start for the snapshot: all set guaranteed
+		// add usage for root + parent: use exactly guaranteed at parent and child level
+		// add usage to child1: use double than guaranteed
+		// parent guarantee used for one type child guarantee used for second type
+		bothRes = resources.Multiply(smallestRes, 2)
+		bothRes.AddTo(resources.Multiply(childRes, 2))
+		rootQ.allocatedResource = bothRes
+		bothRes = resources.Add(smallestRes, resources.Multiply(childRes, 2))
+		parentQ.allocatedResource = bothRes
+		childQ1.allocatedResource = resources.Multiply(childRes, 2)
+		childQ2.allocatedResource = smallestRes
+		rootRemaining, pRemaining, cRemaining1, cRemaining2 = setAndGetRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2, queueRes, tt.askQueue)
+		assert.Assert(t, resources.IsZero(rootRemaining), "guaranteed set, used completely. usage also has extra resource types. However, no remaining")
+		assert.Assert(t, resources.IsZero(pRemaining), "guaranteed set, used completely. usage also has extra resource types. However, no remaining")
+		assert.Assert(t, resources.Equals(cRemaining1, resources.Multiply(childRes, -1)), "guaranteed set, used double than guaranteed. so remaining should be in -ve")
+		assert.Assert(t, resources.IsZero(cRemaining2), "guaranteed set, but no usage. Still, no remaining in guaranteed because of its parent queue")
+
+		// clean start for the snapshot: all set guaranteed
+		// add usage for root + parent: use exactly guaranteed for one resource and over guaranteed for another resource at parent level
+		// add usage to child1: use double than guaranteed
+		// add usage to child2: use lesser than guaranteed.
+		// child2 remaining behaviour changes based on the ask queue.
+		// When ask queue is child2, its own values has higher precedence over the parent or ancestor for common resource types.
+		// for extra resources available in parent or ancestor, it can simply inherit.
+		// When ask queue is child3 (diverged from very earlier branch, not sharing any common queue path), its remaining is min permissive of its own values and parent or ancestor values.
+		childQ2.allocatedResource = resources.NewResourceFromMap(map[string]resources.Quantity{"first": 2})
+		rootRemaining, pRemaining, cRemaining1, cRemaining2 = setAndGetRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2, map[string]*resources.Resource{rootQ.QueuePath: resources.Multiply(smallestRes, 2), parentQ.QueuePath: resources.Add(smallestRes, resources.Multiply(childRes, 1)), childQ1.QueuePath: childRes, childQ2.QueuePath: smallestRes}, tt.askQueue)
+		assert.Assert(t, resources.IsZero(rootRemaining), "guaranteed set, used completely. usage also has extra resource types. However, no remaining")
+		assert.Assert(t, resources.DeepEquals(pRemaining, resources.Add(expectedSmallestRes1, resources.Multiply(childRes, -1))), "guaranteed set, one resource type used completely. usage also has another resource types which is used bit more. remaining should have zero for one resource type and -ve for another")
+		assert.Assert(t, resources.DeepEquals(cRemaining1, resources.Add(expectedSmallestRes1, resources.Multiply(childRes, -1))), "guaranteed set, used double than guaranteed. so remaining should be in -ve")
+		assert.Assert(t, resources.DeepEquals(cRemaining2, tt.childQ2Remaining1), "guaranteed set, used bit lesser. parent's usage also has extra resource types. remaining should be based on ask queue")
+	}
+}
+
+func setup(t *testing.T) (*Queue, *Queue, *Queue, *Queue, *Queue) {
 	rootQ, err := createRootQueue(map[string]string{})
 	assert.NilError(t, err)
-	var parentQ, childQ1, childQ2 *Queue
+	var parentQ, childQ1, childQ2, parent1Q, childQ3 *Queue
 	parentQ, err = createManagedQueue(rootQ, "parent", true, map[string]string{})
+	assert.NilError(t, err)
+	parent1Q, err = createManagedQueue(rootQ, "parent1", true, map[string]string{})
 	assert.NilError(t, err)
 	childQ1, err = createManagedQueue(parentQ, "child1", false, map[string]string{})
 	assert.NilError(t, err)
 	childQ2, err = createManagedQueue(parentQ, "child2", false, map[string]string{})
 	assert.NilError(t, err)
-	rootRemaining, pRemaining, cRemaining1, cRemaining2 := getRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2)
+	childQ3, err = createManagedQueue(parent1Q, "child3", false, map[string]string{})
+	assert.NilError(t, err)
+	return rootQ, parentQ, childQ1, childQ2, childQ3
+}
+func assertZeroRemaining(t *testing.T, rootRemaining *resources.Resource, pRemaining *resources.Resource, cRemaining1 *resources.Resource, cRemaining2 *resources.Resource) {
 	assert.Assert(t, resources.IsZero(rootRemaining), "guaranteed and max res not set, so no remaining")
 	assert.Assert(t, resources.IsZero(pRemaining), "guaranteed and max res not set, so no remaining")
 	assert.Assert(t, resources.IsZero(cRemaining1), "guaranteed and max res not set, so no remaining")
 	assert.Assert(t, resources.IsZero(cRemaining2), "guaranteed and max res not set, so no remaining")
-
-	// no guaranteed and no usage, but max res set. so min of guaranteed and max should be remaining
-	smallestRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})
-	rootQ.maxResource = resources.Multiply(smallestRes, 4)
-	parentQ.maxResource = resources.Multiply(smallestRes, 2)
-	childQ1.maxResource = smallestRes
-	childQ2.maxResource = smallestRes
-	rootRemaining, pRemaining, cRemaining1, cRemaining2 = getRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2)
-	assert.Assert(t, resources.IsZero(rootRemaining), "guaranteed and max res not set, so no remaining")
-	assert.Assert(t, resources.IsZero(pRemaining), "guaranteed and max res not set, so no remaining")
-	assert.Assert(t, resources.IsZero(cRemaining1), "guaranteed and max res not set, so no remaining")
-	assert.Assert(t, resources.IsZero(cRemaining2), "guaranteed and max res not set, so no remaining")
-
-	// guaranteed set only for queue at specific levels but no usage.
-	// so remaining for queues without guaranteed quota inherits from parent queue based on min perm calculation
-	childRes := resources.NewResourceFromMap(map[string]resources.Quantity{"second": 5})
-	rootQ.guaranteedResource = resources.Multiply(smallestRes, 2)
-	childQ1.guaranteedResource = childRes
-	rootRemaining, pRemaining, cRemaining1, cRemaining2 = getRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2)
-	assert.Assert(t, resources.Equals(rootRemaining, resources.Multiply(smallestRes, 2)), "guaranteed set, but no usage. so all guaranteed should be in remaining")
-	assert.Assert(t, resources.Equals(pRemaining, resources.Multiply(smallestRes, 2)), "guaranteed not set, also no usage. However, parent's remaining should be used")
-	assert.Assert(t, resources.Equals(cRemaining1, resources.Add(resources.Multiply(smallestRes, 2), childRes)), "guaranteed not set, also no usage. However, parent's remaining should be used")
-	assert.Assert(t, resources.Equals(cRemaining2, resources.Multiply(smallestRes, 2)), "guaranteed not set, also no usage. However, parent's remaining should be used")
-
-	// guaranteed set but no usage. so nothing to preempt
-	// clean start for the snapshot: whole hierarchy with guarantee
-	rootQ.guaranteedResource = resources.Multiply(smallestRes, 2)
-	parentQ.guaranteedResource = smallestRes
-	childQ2.guaranteedResource = smallestRes
-	childQ1.guaranteedResource = childRes
-	rootRemaining, pRemaining, cRemaining1, cRemaining2 = getRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2)
-	assert.Assert(t, resources.Equals(rootRemaining, resources.Multiply(smallestRes, 2)), "guaranteed set, but no usage. so all guaranteed should be in remaining")
-	assert.Assert(t, resources.Equals(pRemaining, smallestRes), "guaranteed set, but no usage. so all guaranteed should be in remaining")
-	assert.Assert(t, resources.Equals(cRemaining1, resources.Add(smallestRes, childRes)), "guaranteed set, but no usage. so all guaranteed + parent remaining guaranteed should be in remaining")
-	assert.Assert(t, resources.Equals(cRemaining2, smallestRes), "guaranteed set, but no usage. so all its guaranteed (because it is lesser than parent's guaranteed) should be in remaining")
-
-	// clean start for the snapshot: all set guaranteed
-	// add usage to parent + root: use all guaranteed at parent level
-	// add usage to child2: use double than guaranteed
-	rootQ.allocatedResource = resources.Multiply(smallestRes, 2)
-	parentQ.allocatedResource = resources.Multiply(smallestRes, 2)
-	childQ2.allocatedResource = resources.Multiply(smallestRes, 2)
-	rootRemaining, pRemaining, cRemaining1, cRemaining2 = getRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2)
-	assert.Assert(t, resources.IsZero(rootRemaining), "guaranteed set, used completely. so all guaranteed should be in remaining")
-	assert.Assert(t, resources.Equals(pRemaining, resources.Multiply(smallestRes, -1)), "guaranteed set, used double than guaranteed. so remaining should be in -ve")
-	assert.Assert(t, resources.Equals(cRemaining1, resources.Add(resources.Multiply(smallestRes, -1), childRes)), "guaranteed set, but no usage. However remaining should include its all guaranteed + parent remaining guaranteed")
-	assert.Assert(t, resources.Equals(cRemaining2, resources.Multiply(smallestRes, -1)), "guaranteed set, used double than guaranteed. so remaining should be in -ve")
-
-	// clean start for the snapshot: all set guaranteed
-	// add usage for all: use exactly guaranteed at parent and child level
-	// parent guarantee used for one type child guarantee used for second type
-	bothRes := resources.Multiply(smallestRes, 2)
-	bothRes.AddTo(childRes)
-	rootQ.allocatedResource = bothRes
-	bothRes = resources.Add(smallestRes, childRes)
-	parentQ.allocatedResource = bothRes
-	childQ1.allocatedResource = childRes
-	childQ2.allocatedResource = smallestRes
-	rootRemaining, pRemaining, cRemaining1, cRemaining2 = getRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2)
-	assert.Assert(t, resources.IsZero(rootRemaining), "guaranteed set, used completely. usage also has extra resource types. However, no remaining")
-	assert.Assert(t, resources.IsZero(pRemaining), "guaranteed set, used completely. usage also has extra resource types. However, no remaining")
-	assert.Assert(t, resources.IsZero(cRemaining1), "guaranteed set, used completely. so, no remaining")
-	assert.Assert(t, resources.IsZero(cRemaining2), "guaranteed set, but no usage. Still, no remaining in guaranteed because of its parent queue")
-
-	// clean start for the snapshot: all set guaranteed
-	// add usage for root + parent: use exactly guaranteed at parent and child level
-	// add usage to child1: use double than guaranteed
-	// parent guarantee used for one type child guarantee used for second type
-	bothRes = resources.Multiply(smallestRes, 2)
-	bothRes.AddTo(resources.Multiply(childRes, 2))
-	rootQ.allocatedResource = bothRes
-	bothRes = resources.Add(smallestRes, resources.Multiply(childRes, 2))
-	parentQ.allocatedResource = bothRes
-	childQ1.allocatedResource = resources.Multiply(childRes, 2)
-	childQ2.allocatedResource = smallestRes
-	rootRemaining, pRemaining, cRemaining1, cRemaining2 = getRemainingGuaranteed(rootQ, parentQ, childQ1, childQ2)
-	assert.Assert(t, resources.IsZero(rootRemaining), "guaranteed set, used completely. usage also has extra resource types. However, no remaining")
-	assert.Assert(t, resources.IsZero(pRemaining), "guaranteed set, used completely. usage also has extra resource types. However, no remaining")
-	assert.Assert(t, resources.Equals(cRemaining1, resources.Multiply(childRes, -1)), "guaranteed set, used double than guaranteed. so remaining should be in -ve")
-	assert.Assert(t, resources.IsZero(cRemaining2), "guaranteed set, but no usage. Still, no remaining in guaranteed because of its parent queue")
 }
 
-func createQPSCache(rootQ *Queue, parentQ *Queue, childQ1 *Queue, childQ2 *Queue) (*QueuePreemptionSnapshot, *QueuePreemptionSnapshot, *QueuePreemptionSnapshot, *QueuePreemptionSnapshot) {
+func resetQueueResources(rootQ *Queue, parentQ *Queue, childQ1 *Queue, childQ2 *Queue) {
+	rootQ.guaranteedResource = nil
+	parentQ.guaranteedResource = nil
+	childQ1.guaranteedResource = nil
+	childQ2.guaranteedResource = nil
+	rootQ.allocatedResource = nil
+	parentQ.allocatedResource = nil
+	childQ1.allocatedResource = nil
+	childQ2.allocatedResource = nil
+	rootQ.preemptingResource = nil
+	parentQ.preemptingResource = nil
+	childQ1.preemptingResource = nil
+	childQ2.preemptingResource = nil
+}
+
+func createQPSCache(rootQ *Queue, parentQ *Queue, childQ1 *Queue, childQ2 *Queue, askQueue *Queue) (*QueuePreemptionSnapshot, *QueuePreemptionSnapshot, *QueuePreemptionSnapshot, *QueuePreemptionSnapshot) {
 	cache := make(map[string]*QueuePreemptionSnapshot)
-	qpsRoot := rootQ.createPreemptionSnapshot(cache, "")
-	qpsParent := parentQ.createPreemptionSnapshot(cache, "")
-	qpsChild1 := childQ1.createPreemptionSnapshot(cache, "")
-	qpsChild2 := childQ2.createPreemptionSnapshot(cache, "")
+	askQueuePath := ""
+	if askQueue != nil {
+		askQueuePath = askQueue.QueuePath
+		askQueue.createPreemptionSnapshot(cache, askQueue.QueuePath)
+		c := askQueue
+		// set the ask queue for all queues in the ask queue hierarchy
+		for c.parent != nil {
+			cache[c.QueuePath].AskQueue = cache[askQueue.QueuePath]
+			c = c.parent
+		}
+	}
+	qpsRoot := rootQ.createPreemptionSnapshot(cache, askQueuePath)
+	qpsParent := parentQ.createPreemptionSnapshot(cache, askQueuePath)
+	qpsChild1 := childQ1.createPreemptionSnapshot(cache, askQueuePath)
+	qpsChild2 := childQ2.createPreemptionSnapshot(cache, askQueuePath)
 	return qpsRoot, qpsParent, qpsChild1, qpsChild2
 }
 
-func getRemainingGuaranteed(rootQ *Queue, parentQ *Queue, childQ1 *Queue, childQ2 *Queue) (*resources.Resource, *resources.Resource, *resources.Resource, *resources.Resource) {
-	qpsRoot, qpsParent, qpsChild1, qpsChild2 := createQPSCache(rootQ, parentQ, childQ1, childQ2)
+func setAndGetRemainingGuaranteed(rootQ *Queue, parentQ *Queue, childQ1 *Queue, childQ2 *Queue, queueRes map[string]*resources.Resource, askQueue *Queue) (*resources.Resource, *resources.Resource, *resources.Resource, *resources.Resource) {
+	rootQ.guaranteedResource = queueRes[rootQ.QueuePath]
+	parentQ.guaranteedResource = queueRes[parentQ.QueuePath]
+	childQ2.guaranteedResource = queueRes[childQ2.QueuePath]
+	childQ1.guaranteedResource = queueRes[childQ1.QueuePath]
+	qpsRoot, qpsParent, qpsChild1, qpsChild2 := createQPSCache(rootQ, parentQ, childQ1, childQ2, askQueue)
 	rootRemaining := qpsRoot.GetRemainingGuaranteedResource()
 	pRemaining := qpsParent.GetRemainingGuaranteedResource()
 	cRemaining1 := qpsChild1.GetRemainingGuaranteedResource()
@@ -238,7 +310,7 @@ func getRemainingGuaranteed(rootQ *Queue, parentQ *Queue, childQ1 *Queue, childQ
 }
 
 func getPreemptableResource(rootQ *Queue, parentQ *Queue, childQ1 *Queue, childQ2 *Queue) (*resources.Resource, *resources.Resource, *resources.Resource, *resources.Resource) {
-	qpsRoot, qpsParent, qpsChild1, qpsChild2 := createQPSCache(rootQ, parentQ, childQ1, childQ2)
+	qpsRoot, qpsParent, qpsChild1, qpsChild2 := createQPSCache(rootQ, parentQ, childQ1, childQ2, nil)
 	rootRemaining := qpsRoot.GetPreemptableResource()
 	pRemaining := qpsParent.GetPreemptableResource()
 	cRemaining1 := qpsChild1.GetPreemptableResource()

--- a/pkg/scheduler/objects/preemption_queue_test.go
+++ b/pkg/scheduler/objects/preemption_queue_test.go
@@ -221,10 +221,10 @@ func TestGetRemainingGuaranteedResource(t *testing.T) {
 
 func createQPSCache(rootQ *Queue, parentQ *Queue, childQ1 *Queue, childQ2 *Queue) (*QueuePreemptionSnapshot, *QueuePreemptionSnapshot, *QueuePreemptionSnapshot, *QueuePreemptionSnapshot) {
 	cache := make(map[string]*QueuePreemptionSnapshot)
-	qpsRoot := rootQ.createPreemptionSnapshot(cache)
-	qpsParent := parentQ.createPreemptionSnapshot(cache)
-	qpsChild1 := childQ1.createPreemptionSnapshot(cache)
-	qpsChild2 := childQ2.createPreemptionSnapshot(cache)
+	qpsRoot := rootQ.createPreemptionSnapshot(cache, "")
+	qpsParent := parentQ.createPreemptionSnapshot(cache, "")
+	qpsChild1 := childQ1.createPreemptionSnapshot(cache, "")
+	qpsChild2 := childQ2.createPreemptionSnapshot(cache, "")
 	return qpsRoot, qpsParent, qpsChild1, qpsChild2
 }
 

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -324,12 +324,12 @@ func TestTryPreemptionOnNodeWithOGParentAndUGPreemptor(t *testing.T) {
 		if i%2 == 0 {
 			alloc1 := markAllocated(nodeID1, ask1)
 			app1.AddAllocation(alloc1)
-			assert.Check(t, node1.AddAllocation(alloc1), "node alloc1 failed")
+			assert.Check(t, node1.TryAddAllocation(alloc1), "node alloc1 failed")
 			assert.NilError(t, childQ1.IncAllocatedResource(ask1.GetAllocatedResource(), false))
 		} else {
 			alloc1 := markAllocated(nodeID2, ask1)
 			app1.AddAllocation(alloc1)
-			assert.Check(t, node2.AddAllocation(alloc1), "node alloc1 failed")
+			assert.Check(t, node2.TryAddAllocation(alloc1), "node alloc1 failed")
 			assert.NilError(t, childQ1.IncAllocatedResource(ask1.GetAllocatedResource(), false))
 		}
 	}

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -317,18 +317,17 @@ func TestTryPreemptionOnNodeWithOGParentAndUGPreemptor(t *testing.T) {
 	app1.SetQueue(childQ1)
 	childQ1.applications[appID1] = app1
 
-	//var alloc1, alloc2 *Allocation
 	for i := 1; i <= 6; i++ {
 		ask1 := newAllocationAsk("alloc"+strconv.Itoa(i), appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1}))
 		ask1.createTime = time.Now().Add(time.Duration(i*-1) * time.Minute)
 		assert.NilError(t, app1.AddAllocationAsk(ask1))
 		if i%2 == 0 {
-			alloc1 := NewAllocation(nodeID1, ask1)
+			alloc1 := markAllocated(nodeID1, ask1)
 			app1.AddAllocation(alloc1)
 			assert.Check(t, node1.AddAllocation(alloc1), "node alloc1 failed")
 			assert.NilError(t, childQ1.IncAllocatedResource(ask1.GetAllocatedResource(), false))
 		} else {
-			alloc1 := NewAllocation(nodeID2, ask1)
+			alloc1 := markAllocated(nodeID2, ask1)
 			app1.AddAllocation(alloc1)
 			assert.Check(t, node2.AddAllocation(alloc1), "node alloc1 failed")
 			assert.NilError(t, childQ1.IncAllocatedResource(ask1.GetAllocatedResource(), false))
@@ -353,7 +352,7 @@ func TestTryPreemptionOnNodeWithOGParentAndUGPreemptor(t *testing.T) {
 	result, ok := preemptor.TryPreemption()
 	assert.Assert(t, result != nil, "no result")
 	assert.Assert(t, ok, "no victims found")
-	assert.Equal(t, "alloc7", result.Ask.GetAllocationKey(), "wrong alloc")
+	assert.Equal(t, "alloc7", result.Request.allocationKey, "wrong alloc")
 	assert.Equal(t, nodeID2, result.NodeID, "wrong node")
 	assert.Check(t, node2.GetAllocation("alloc1").IsPreempted(), "alloc1 preempted")
 }

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -1755,7 +1755,6 @@ func (sq *Queue) createPreemptionSnapshot(cache map[string]*QueuePreemptionSnaps
 		MaxResource:        sq.maxResource.Clone(),
 		GuaranteedResource: sq.guaranteedResource.Clone(),
 		PotentialVictims:   make([]*Allocation, 0),
-		AskQueuePath:       askQueuePath,
 		AskQueue:           cache[askQueuePath],
 	}
 	cache[sq.QueuePath] = snapshot

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -1717,6 +1717,15 @@ func (sq *Queue) FindEligiblePreemptionVictims(queuePath string, ask *Allocation
 		return nil
 	}
 
+	// create snapshot for ask or preemptor queue
+	sq.createPreemptionSnapshot(results, queuePath)
+	c := sq
+	// set the ask queue for all queues in the ask queue hierarchy
+	for c.parent != nil {
+		results[c.QueuePath].AskQueue = results[queuePath]
+		c = c.parent
+	}
+
 	// walk the subtree contained within the preemption fence and collect potential victims organized by nodeID
 	fence.findEligiblePreemptionVictims(results, queuePath, ask, priorityMap, queuePriority, false)
 
@@ -1724,7 +1733,7 @@ func (sq *Queue) FindEligiblePreemptionVictims(queuePath string, ask *Allocation
 }
 
 // createPreemptionSnapshot is used to create a snapshot of the current queue's resource usage and potential preemption victims
-func (sq *Queue) createPreemptionSnapshot(cache map[string]*QueuePreemptionSnapshot) *QueuePreemptionSnapshot {
+func (sq *Queue) createPreemptionSnapshot(cache map[string]*QueuePreemptionSnapshot, askQueuePath string) *QueuePreemptionSnapshot {
 	if sq == nil {
 		return nil
 	}
@@ -1734,7 +1743,7 @@ func (sq *Queue) createPreemptionSnapshot(cache map[string]*QueuePreemptionSnaps
 		return snapshot
 	}
 
-	parentSnapshot := sq.parent.createPreemptionSnapshot(cache)
+	parentSnapshot := sq.parent.createPreemptionSnapshot(cache, askQueuePath)
 	sq.RLock()
 	defer sq.RUnlock()
 	snapshot = &QueuePreemptionSnapshot{
@@ -1746,6 +1755,8 @@ func (sq *Queue) createPreemptionSnapshot(cache map[string]*QueuePreemptionSnaps
 		MaxResource:        sq.maxResource.Clone(),
 		GuaranteedResource: sq.guaranteedResource.Clone(),
 		PotentialVictims:   make([]*Allocation, 0),
+		AskQueuePath:       askQueuePath,
+		AskQueue:           cache[askQueuePath],
 	}
 	cache[sq.QueuePath] = snapshot
 	return snapshot
@@ -1755,20 +1766,13 @@ func (sq *Queue) findEligiblePreemptionVictims(results map[string]*QueuePreempti
 	if sq == nil {
 		return
 	}
-
-	// if this is the target queue, return it but with an empty victim list so we can use it in calculations
-	if sq.QueuePath == queuePath {
-		sq.createPreemptionSnapshot(results)
-		return
-	}
-
 	if sq.IsLeafQueue() {
 		// leaf queue, skip queue if preemption is disabled
 		if sq.GetPreemptionPolicy() == policies.DisabledPreemptionPolicy {
 			return
 		}
 
-		victims := sq.createPreemptionSnapshot(results)
+		victims := sq.createPreemptionSnapshot(results, queuePath)
 
 		// skip this queue if we are within guaranteed limits
 		remaining := results[sq.QueuePath].GetRemainingGuaranteedResource()


### PR DESCRIPTION
…is UG and parent is above OG

### What is this PR for?
Ask queue starving for resources (under guaranteed) located under parent who is over guaranteed because of another child usage should be able to preempt victims from sibling as it is deserve to get resources for its pending pods.

### What type of PR is it?
* [ ] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2769

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
