### PR TITLE
[YUNIKORN-2780] Remove unnecessary node ExistingAllocations handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ module github.com/apache/yunikorn-core
 go 1.21
 
 require (
-	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240425182941-07f5695119a1
+	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240731203810-92032b13d586
 	github.com/google/btree v1.1.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240425182941-07f5695119a1 h1:v4J9L3MlW8BQfYnbq6FV2l3uyay3SqMS2Ffpo+SFat4=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240425182941-07f5695119a1/go.mod h1:WuHJpVk34t8N5+1ErYGj/5Qq33/cRzL4YtuoAsbMtWc=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240731203810-92032b13d586 h1:ZVpo9Qj2/gvwX6Rl44UxkZBm2pZWEJDYWTramc9hwF0=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240731203810-92032b13d586/go.mod h1:WuHJpVk34t8N5+1ErYGj/5Qq33/cRzL4YtuoAsbMtWc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -607,8 +607,7 @@ func (cc *ClusterContext) addNode(nodeInfo *si.NodeInfo, schedulable bool) error
 		return err
 	}
 
-	existingAllocations := cc.convertAllocations(nodeInfo.ExistingAllocations)
-	err := partition.AddNode(sn, existingAllocations)
+	err := partition.AddNode(sn)
 	sn.SendNodeAddedEvent()
 	if err != nil {
 		wrapped := errors.Join(errors.New("failure while adding new node, node rejected with error: "), err)
@@ -751,7 +750,7 @@ func (cc *ClusterContext) processAllocations(request *si.AllocationRequest) {
 		}
 
 		alloc := objects.NewAllocationFromSI(siAlloc)
-		if err := partition.addAllocation(alloc); err != nil {
+		if err := partition.AddAllocation(alloc); err != nil {
 			rejectedAllocs = append(rejectedAllocs, &si.RejectedAllocation{
 				AllocationKey: siAlloc.AllocationKey,
 				ApplicationID: siAlloc.ApplicationID,
@@ -853,16 +852,6 @@ func (cc *ClusterContext) processAllocationReleases(releases []*si.AllocationRel
 			}
 		}
 	}
-}
-
-// Convert the si allocation to a proposal to add to the node
-func (cc *ClusterContext) convertAllocations(allocations []*si.Allocation) []*objects.Allocation {
-	convert := make([]*objects.Allocation, len(allocations))
-	for current, allocation := range allocations {
-		convert[current] = objects.NewAllocationFromSI(allocation)
-	}
-
-	return convert
 }
 
 // Create a RM update event to notify RM of new allocations

--- a/pkg/scheduler/health_checker_test.go
+++ b/pkg/scheduler/health_checker_test.go
@@ -198,7 +198,7 @@ func TestGetSchedulerHealthStatusContext(t *testing.T) {
 		SchedulableResource: &si.Resource{
 			Resources: map[string]*si.Quantity{"memory": {Value: -10}},
 		},
-	}), []*objects.Allocation{})
+	}))
 	assert.NilError(t, err, "Unexpected error while adding a new node")
 	healthInfo = GetSchedulerHealthStatus(schedulerMetrics, schedulerContext)
 	assert.Assert(t, !healthInfo.Healthy, "Scheduler should not be healthy")

--- a/pkg/scheduler/tests/mock_rm_callback_test.go
+++ b/pkg/scheduler/tests/mock_rm_callback_test.go
@@ -174,15 +174,6 @@ func (m *mockRMCallback) waitForMinAcceptedNodes(tb testing.TB, minNumNode int, 
 	}
 }
 
-func (m *mockRMCallback) waitForRejectedNode(t *testing.T, nodeID string, timeoutMs int) {
-	err := common.WaitForCondition(10*time.Millisecond, time.Duration(timeoutMs)*time.Millisecond, func() bool {
-		m.RLock()
-		defer m.RUnlock()
-		return m.rejectedNodes[nodeID]
-	})
-	assert.NilError(t, err, "Failed to wait for node state to become rejected: %s, called from: %s", nodeID, caller())
-}
-
 func (m *mockRMCallback) waitForAllocations(t *testing.T, nAlloc int, timeoutMs int) {
 	var allocLen int
 	err := common.WaitForCondition(10*time.Millisecond, time.Duration(timeoutMs)*time.Millisecond, func() bool {

--- a/pkg/scheduler/tests/recovery_test.go
+++ b/pkg/scheduler/tests/recovery_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/entrypoint"
+	"github.com/apache/yunikorn-core/pkg/scheduler"
 	"github.com/apache/yunikorn-core/pkg/scheduler/objects"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
@@ -256,8 +257,7 @@ func TestSchedulerRecovery(t *testing.T) {
 						"vcore":  {Value: 20},
 					},
 				},
-				Action:              si.NodeInfo_CREATE,
-				ExistingAllocations: mockRM.nodeAllocations["node-1:1234"],
+				Action: si.NodeInfo_CREATE,
 			},
 			{
 				NodeID:     "node-2:1234",
@@ -268,8 +268,7 @@ func TestSchedulerRecovery(t *testing.T) {
 						"vcore":  {Value: 20},
 					},
 				},
-				Action:              si.NodeInfo_CREATE,
-				ExistingAllocations: mockRM.nodeAllocations["node-2:1234"],
+				Action: si.NodeInfo_CREATE,
 			},
 		},
 		RmID: "rm:123",
@@ -280,6 +279,15 @@ func TestSchedulerRecovery(t *testing.T) {
 
 	// verify partition info
 	part = ms.scheduler.GetClusterContext().GetPartition(ms.partitionName)
+
+	// add allocs to partition
+	node1Allocations := mockRM.nodeAllocations["node-1:1234"]
+	err = registerAllocations(part, node1Allocations)
+	assert.NilError(t, err)
+	node2Allocations := mockRM.nodeAllocations["node-2:1234"]
+	err = registerAllocations(part, node2Allocations)
+	assert.NilError(t, err)
+
 	// verify apps in this partition
 	assert.Equal(t, 1, len(part.GetApplications()))
 	assert.Equal(t, appID1, part.GetApplications()[0].ApplicationID)
@@ -289,8 +297,6 @@ func TestSchedulerRecovery(t *testing.T) {
 
 	// verify nodes
 	assert.Equal(t, 2, part.GetTotalNodeCount(), "incorrect recovered node count")
-	node1Allocations := mockRM.nodeAllocations["node-1:1234"]
-	node2Allocations := mockRM.nodeAllocations["node-2:1234"]
 
 	assert.Equal(t, len(node1Allocations), len(part.GetNode("node-1:1234").GetAllAllocations()), "allocations on node-1 not as expected")
 	assert.Equal(t, len(node2Allocations), len(part.GetNode("node-2:1234").GetAllAllocations()), "allocations on node-1 not as expected")
@@ -443,14 +449,17 @@ func TestSchedulerRecovery2Allocations(t *testing.T) {
 						"vcore":  {Value: 20},
 					},
 				},
-				Action:              si.NodeInfo_CREATE,
-				ExistingAllocations: mockRM.nodeAllocations["node-1:1234"],
+				Action: si.NodeInfo_CREATE,
 			},
 		},
 		RmID: "rm:123",
 	})
 	assert.NilError(t, err, "NodeRequest nodes and app for recovery failed")
 	ms.mockRM.waitForAcceptedNode(t, "node-1:1234", 1000)
+	allocs := mockRM.nodeAllocations["node-1:1234"]
+	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{Allocations: allocs, RmID: "rm:123"})
+	assert.NilError(t, err, "failed to update allocations")
+	ms.mockRM.waitForAllocations(t, len(allocs), 1000)
 	recoveredApp := ms.getApplication(appID1)
 	// verify app state
 	assert.Equal(t, recoveredApp.CurrentState(), objects.Running.String())
@@ -482,24 +491,6 @@ func TestSchedulerRecoveryWithoutAppInfo(t *testing.T) {
 					},
 				},
 				Action: si.NodeInfo_CREATE,
-				ExistingAllocations: []*si.Allocation{
-					{
-						AllocationKey: "allocation-key-01",
-						ApplicationID: "app-01",
-						PartitionName: "default",
-						NodeID:        "node-1:1234",
-						ResourcePerAlloc: &si.Resource{
-							Resources: map[string]*si.Quantity{
-								common.Memory: {
-									Value: 1024,
-								},
-								common.CPU: {
-									Value: 1,
-								},
-							},
-						},
-					},
-				},
 			},
 			{
 				NodeID:     "node-2:1234",
@@ -518,13 +509,36 @@ func TestSchedulerRecoveryWithoutAppInfo(t *testing.T) {
 	assert.NilError(t, err, "NodeRequest nodes and apps failed")
 
 	// waiting for recovery
-	// node-1 should be rejected as some of allocations cannot be recovered
-	ms.mockRM.waitForRejectedNode(t, "node-1:1234", 1000)
+	ms.mockRM.waitForAcceptedNode(t, "node-1:1234", 1000)
 	ms.mockRM.waitForAcceptedNode(t, "node-2:1234", 1000)
 
-	// verify partition resources
 	part := ms.scheduler.GetClusterContext().GetPartition("[rm:123]default")
-	assert.Equal(t, part.GetTotalNodeCount(), 1)
+	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
+		Allocations: []*si.Allocation{
+			{
+				AllocationKey: "allocation-key-01",
+				ApplicationID: "app-01",
+				PartitionName: "default",
+				NodeID:        "node-1:1234",
+				ResourcePerAlloc: &si.Resource{
+					Resources: map[string]*si.Quantity{
+						common.Memory: {
+							Value: 1024,
+						},
+						common.CPU: {
+							Value: 1,
+						},
+					},
+				},
+			},
+		},
+		RmID: "rm:123",
+	})
+
+	assert.NilError(t, err)
+
+	// verify partition resources
+	assert.Equal(t, part.GetTotalNodeCount(), 2)
 	assert.Equal(t, part.GetTotalAllocationCount(), 0)
 	assert.Equal(t, part.GetNode("node-2:1234").GetAllocatedResource().Resources[common.Memory],
 		resources.Quantity(0))
@@ -549,21 +563,27 @@ func TestSchedulerRecoveryWithoutAppInfo(t *testing.T) {
 					},
 				},
 				Action: si.NodeInfo_CREATE,
-				ExistingAllocations: []*si.Allocation{
-					{
-						AllocationKey: "allocation-key-01",
-						ApplicationID: "app-01",
-						PartitionName: "default",
-						NodeID:        "node-1:1234",
-						ResourcePerAlloc: &si.Resource{
-							Resources: map[string]*si.Quantity{
-								common.Memory: {
-									Value: 100,
-								},
-								common.CPU: {
-									Value: 1,
-								},
-							},
+			},
+		},
+		RmID: "rm:123",
+	})
+	assert.NilError(t, err, "NodeRequest re-register nodes and app failed")
+	ms.mockRM.waitForAcceptedNode(t, "node-1:1234", 1000)
+
+	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
+		Allocations: []*si.Allocation{
+			{
+				AllocationKey: "allocation-key-01",
+				ApplicationID: "app-01",
+				PartitionName: "default",
+				NodeID:        "node-1:1234",
+				ResourcePerAlloc: &si.Resource{
+					Resources: map[string]*si.Quantity{
+						common.Memory: {
+							Value: 100,
+						},
+						common.CPU: {
+							Value: 1,
 						},
 					},
 				},
@@ -571,8 +591,8 @@ func TestSchedulerRecoveryWithoutAppInfo(t *testing.T) {
 		},
 		RmID: "rm:123",
 	})
-	assert.NilError(t, err, "NodeRequest re-register nodes and app failed")
-	ms.mockRM.waitForAcceptedNode(t, "node-1:1234", 1000)
+	assert.NilError(t, err)
+	ms.mockRM.waitForAllocations(t, 1, 1000)
 
 	assert.Equal(t, part.GetTotalNodeCount(), 2)
 	assert.Equal(t, part.GetTotalAllocationCount(), 1)
@@ -921,8 +941,7 @@ partitions:
 						"vcore":  {Value: 20},
 					},
 				},
-				Action:              si.NodeInfo_CREATE,
-				ExistingAllocations: toRecover["node-1:1234"],
+				Action: si.NodeInfo_CREATE,
 			},
 			{
 				NodeID:     "node-2:1234",
@@ -933,8 +952,7 @@ partitions:
 						"vcore":  {Value: 20},
 					},
 				},
-				Action:              si.NodeInfo_CREATE,
-				ExistingAllocations: toRecover["node-2:1234"],
+				Action: si.NodeInfo_CREATE,
 			},
 		},
 		RmID: "rm:123",
@@ -946,6 +964,12 @@ partitions:
 	ms.mockRM.waitForAcceptedNode(t, "node-1:1234", 1000)
 	ms.mockRM.waitForAcceptedNode(t, "node-2:1234", 1000)
 	ms.mockRM.waitForAcceptedApplication(t, appID1, 1000)
+
+	err = registerAllocations(part, toRecover["node-1:1234"])
+	assert.NilError(t, err)
+	err = registerAllocations(part, toRecover["node-2:1234"])
+	assert.NilError(t, err)
+
 	// now the queue should have been created under root.app-1-namespace
 	assert.Equal(t, len(rootQ.GetCopyOfChildren()), 1)
 	appQueue = part.GetQueue("root.app-1-namespace")
@@ -1005,14 +1029,21 @@ func TestPlaceholderRecovery(t *testing.T) { //nolint:funlen
 						"vcore":  {Value: 20},
 					},
 				},
-				Action:              si.NodeInfo_CREATE,
-				ExistingAllocations: existingAllocations,
+				Action: si.NodeInfo_CREATE,
 			},
 		},
 		RmID: "rm:123",
 	})
 	assert.NilError(t, err, "NodeRequest nodes and app for recovery failed")
 	ms.mockRM.waitForAcceptedNode(t, "node-1:1234", 1000)
+
+	// Add existing allocations
+	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
+		Allocations: existingAllocations,
+		RmID:        "rm:123",
+	})
+	assert.NilError(t, err, "AllocationRequest failed for existing allocations")
+	ms.mockRM.waitForAllocations(t, len(existingAllocations), 1000)
 
 	// Add a new placeholder ask with a different task group
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
@@ -1033,7 +1064,7 @@ func TestPlaceholderRecovery(t *testing.T) { //nolint:funlen
 		RmID: "rm:123",
 	})
 	assert.NilError(t, err, "AllocationRequest failed for placeholder ask")
-	ms.mockRM.waitForAllocations(t, 1, 1000)
+	ms.mockRM.waitForAllocations(t, len(existingAllocations)+1, 1000)
 
 	// Add two real asks
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
@@ -1111,4 +1142,14 @@ func TestPlaceholderRecovery(t *testing.T) { //nolint:funlen
 	assert.NilError(t, err, "AllocationReleasesRequest failed for real allocations")
 
 	ms.mockRM.waitForApplicationState(t, appID1, "Completing", 1000)
+}
+
+func registerAllocations(partition *scheduler.PartitionContext, allocs []*si.Allocation) error {
+	for _, alloc := range allocs {
+		err := partition.AddAllocation(objects.NewAllocationFromSI(alloc))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/scheduler/utilities_test.go
+++ b/pkg/scheduler/utilities_test.go
@@ -619,9 +619,9 @@ func createQueuesNodes(t *testing.T) *PartitionContext {
 	var res *resources.Resource
 	res, err = resources.NewResourceFromConf(map[string]string{"vcore": "10"})
 	assert.NilError(t, err, "failed to create basic resource")
-	err = partition.AddNode(newNodeMaxResource("node-1", res), nil)
+	err = partition.AddNode(newNodeMaxResource("node-1", res))
 	assert.NilError(t, err, "test node1 add failed unexpected")
-	err = partition.AddNode(newNodeMaxResource("node-2", res), nil)
+	err = partition.AddNode(newNodeMaxResource("node-2", res))
 	assert.NilError(t, err, "test node2 add failed unexpected")
 	return partition
 }
@@ -639,9 +639,9 @@ func createPreemptionQueuesNodes(t *testing.T) *PartitionContext {
 	assert.NilError(t, err, "test partition create failed with error")
 	res, err := resources.NewResourceFromConf(map[string]string{"vcore": "10"})
 	assert.NilError(t, err, "failed to create basic resource")
-	err = partition.AddNode(newNodeMaxResource("node-1", res), nil)
+	err = partition.AddNode(newNodeMaxResource("node-1", res))
 	assert.NilError(t, err, "test node1 add failed unexpected")
-	err = partition.AddNode(newNodeMaxResource("node-2", res), nil)
+	err = partition.AddNode(newNodeMaxResource("node-2", res))
 	assert.NilError(t, err, "test node2 add failed unexpected")
 	return partition
 }

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -623,9 +623,12 @@ func TestGetClusterUtilJSON(t *testing.T) {
 	ask2 := objects.NewAllocationAsk("alloc-2", appID, resAlloc2)
 	alloc1 := markAllocated(nodeID, ask1)
 	alloc2 := markAllocated(nodeID, ask2)
-	allocs := []*objects.Allocation{alloc1, alloc2}
-	err = partition.AddNode(node1, allocs)
+	err = partition.AddNode(node1)
 	assert.NilError(t, err, "add node to partition should not have failed")
+	err = partition.AddAllocation(alloc1)
+	assert.NilError(t, err, "failed to add alloc1")
+	err = partition.AddAllocation(alloc2)
+	assert.NilError(t, err, "failed to add alloc2")
 
 	// set expected result
 	utilMem := &dao.ClusterUtilDAOInfo{
@@ -684,12 +687,16 @@ func TestGetNodesUtilJSON(t *testing.T) {
 	ask1 := objects.NewAllocationAsk("alloc-1", app.ApplicationID, resAlloc1)
 	ask2 := objects.NewAllocationAsk("alloc-2", app.ApplicationID, resAlloc2)
 	allocs := []*objects.Allocation{markAllocated(node1.NodeID, ask1)}
-	err = partition.AddNode(node1, allocs)
+	err = partition.AddNode(node1)
 	assert.NilError(t, err, "add node to partition should not have failed")
+	err = partition.AddAllocation(allocs[0])
+	assert.NilError(t, err, "add alloc-1 should not have failed")
 	allocs = []*objects.Allocation{markAllocated(node2.NodeID, ask2)}
-	err = partition.AddNode(node2, allocs)
+	err = partition.AddNode(node2)
 	assert.NilError(t, err, "add node to partition should not have failed")
-	err = partition.AddNode(node3, nil)
+	err = partition.AddAllocation(allocs[0])
+	assert.NilError(t, err, "add alloc-2 should not have failed")
+	err = partition.AddNode(node3)
 	assert.NilError(t, err, "add node to partition should not have failed")
 
 	// two nodes advertise memory: must show up in the list
@@ -800,7 +807,7 @@ func TestGetNodeUtilisation(t *testing.T) {
 func addNode(t *testing.T, partition *scheduler.PartitionContext, nodeId string, resource *resources.Resource) *objects.Node {
 	nodeRes := resource.ToProto()
 	node := objects.NewNode(&si.NodeInfo{NodeID: nodeId, SchedulableResource: nodeRes})
-	err := partition.AddNode(node, nil)
+	err := partition.AddNode(node)
 	assert.NilError(t, err, "adding node to partition should not fail")
 	return node
 }
@@ -1009,11 +1016,15 @@ func TestPartitions(t *testing.T) {
 	ask1 := objects.NewAllocationAsk("alloc-1", app5.ApplicationID, resAlloc1)
 	ask2 := objects.NewAllocationAsk("alloc-2", app2.ApplicationID, resAlloc2)
 	allocs := []*objects.Allocation{markAllocated(node1ID, ask1)}
-	err = defaultPartition.AddNode(node1, allocs)
+	err = defaultPartition.AddNode(node1)
 	assert.NilError(t, err, "add node to partition should not have failed")
+	err = defaultPartition.AddAllocation(allocs[0])
+	assert.NilError(t, err, "add alloc-1 should not have failed")
 	allocs = []*objects.Allocation{markAllocated(node2ID, ask2)}
-	err = defaultPartition.AddNode(node2, allocs)
+	err = defaultPartition.AddNode(node2)
 	assert.NilError(t, err, "add node to partition should not have failed")
+	err = defaultPartition.AddAllocation(allocs[0])
+	assert.NilError(t, err, "add alloc-2 should not have failed")
 
 	req, err = http.NewRequest("GET", "/ws/v1/partitions", strings.NewReader(""))
 	assert.NilError(t, err, "App Handler request failed")
@@ -1285,11 +1296,16 @@ func TestGetPartitionNodes(t *testing.T) {
 	ask1 := objects.NewAllocationAsk("alloc-1", appID, resAlloc1)
 	ask2 := objects.NewAllocationAsk("alloc-2", appID, resAlloc2)
 	allocs := []*objects.Allocation{markAllocated(node1ID, ask1)}
-	err = partition.AddNode(node1, allocs)
+	err = partition.AddNode(node1)
 	assert.NilError(t, err, "add node to partition should not have failed")
+	err = partition.AddAllocation(allocs[0])
+	assert.NilError(t, err, "add alloc-1 should not have failed")
+
 	allocs = []*objects.Allocation{markAllocated(node2ID, ask2)}
-	err = partition.AddNode(node2, allocs)
+	err = partition.AddNode(node2)
 	assert.NilError(t, err, "add node to partition should not have failed")
+	err = partition.AddAllocation(allocs[0])
+	assert.NilError(t, err, "add alloc-2 should not have failed")
 
 	NewWebApp(schedulerContext, nil)
 


### PR DESCRIPTION
### What is this PR for?
With node recovery simplified, the shim never sends ExistingAllocations on node registration. Remove code related to this as it will never be executed.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2780

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
