### PR TITLE
[YUNIKORN-2775] Update inaccurate comment regarding regexp

### DIFF
--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -72,7 +72,9 @@ var DefaultPreemptionDelay = 30 * time.Second
 var QueueNameRegExp = regexp.MustCompile(`^[a-zA-Z0-9_:#/@-]{1,64}$`)
 
 // User and group name check: systems allow different things POSIX is the base but we need to be lenient and allow more.
-// allow upper and lower case, add the @ and . (dot) and officially no length.
+// first char: allow an underscore or a letter
+// middle: allow letters (uppercase or lowercase), digits, or :, ., _, @, -
+// end: allow $.
 var UserRegExp = regexp.MustCompile(`^[_a-zA-Z][a-zA-Z0-9:#/_.@-]*[$]?$`)
 
 // Groups should have a slightly more restrictive regexp (no @ . or $ at the end)

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -72,12 +72,11 @@ var DefaultPreemptionDelay = 30 * time.Second
 var QueueNameRegExp = regexp.MustCompile(`^[a-zA-Z0-9_:#/@-]{1,64}$`)
 
 // User and group name check: systems allow different things POSIX is the base but we need to be lenient and allow more.
-// first char: allow an underscore or a letter
-// middle: allow letters (uppercase or lowercase), digits, or :, ., _, @, -
-// end: allow $.
+// A username must start with a letter(uppercase or lowercase),
+// followed by any number of letter(uppercase or lowercase), digits, ':', '#', '/', '_', '.', '@', '-', and may end with '$'.
 var UserRegExp = regexp.MustCompile(`^[_a-zA-Z][a-zA-Z0-9:#/_.@-]*[$]?$`)
 
-// Groups should have a slightly more restrictive regexp (no @ . or $ at the end)
+// Groups should have a slightly more restrictive regexp (no # / @ or $ at the end)
 var GroupRegExp = regexp.MustCompile(`^[_a-zA-Z][a-zA-Z0-9:_.-]*$`)
 
 // all characters that make a name different from a regexp


### PR DESCRIPTION
### What is this PR for?
After the crowdstrike incident, we know regrex is important for the codebase.
After several code change, comment in this line no longer valid:
https://github.com/apache/yunikorn-core/blob/master/pkg/common/configs/configvalidator.go#L75
suggest change from:
```
// allow upper and lower case, add the @ and . (dot) and officially no length.
```
To:
```
// first char: allow an underscore or a letter, middle: allow letters (uppercase or lowercase), digits, or :, ., _, @, - , allow $ at the end.
```

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2775

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
