### PR TITLE
[YUNIKORN-2756] Consider moving event_system#defaultEventChannelSize to configs#const

### DIFF
--- a/pkg/common/configs/configs.go
+++ b/pkg/common/configs/configs.go
@@ -45,6 +45,7 @@ const (
 	DefaultEventTrackingEnabled    = true
 	DefaultEventRequestCapacity    = 1000
 	DefaultEventRingBufferCapacity = 100000
+	DefaultEventChannelSize        = 100000
 	DefaultMaxStreams              = uint64(100)
 	DefaultMaxStreamsPerHost       = uint64(15)
 	DefaultRESTResponseSize        = uint64(10000)

--- a/pkg/events/event_system.go
+++ b/pkg/events/event_system.go
@@ -33,9 +33,6 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
-// need to change for testing
-var defaultEventChannelSize = 100000
-
 var once sync.Once
 var ev EventSystem
 
@@ -150,7 +147,7 @@ func Init() {
 	buffer := newEventRingBuffer(getRingBufferCapacity())
 	ev = &EventSystemImpl{
 		Store:         store,
-		channel:       make(chan *si.EventRecord, defaultEventChannelSize),
+		channel:       make(chan *si.EventRecord, configs.DefaultEventChannelSize),
 		stop:          make(chan bool),
 		stopped:       false,
 		eventBuffer:   buffer,


### PR DESCRIPTION
### What is this PR for?
This PR moves the defaultEventChannelSize to configs#const to consolidate all configurations in one place.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
[YUNIKORN-2756](https://issues.apache.org/jira/browse/YUNIKORN-2756)

### How should this be tested?
make test
