### PR TITLE
[YUNIKORN-2795] Handle Preemption cases between two siblings without …

### DIFF
--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -835,8 +835,8 @@ func (qps *QueuePreemptionSnapshot) GetRemainingGuaranteedResource() *resources.
 		// Overall, this increases the chance of choosing victims for preemptor from siblings without causing preemption storm or loop.
 		askQueueRemainingGuaranteed := qps.AskQueue.GuaranteedResource.Clone()
 		askQueueUsed := qps.AskQueue.AllocatedResource.Clone()
-		resources.SubOnlyExisting(askQueueUsed, qps.AskQueue.PreemptingResource)
-		resources.SubOnlyExisting(askQueueRemainingGuaranteed, askQueueUsed)
+		askQueueUsed = resources.SubOnlyExisting(askQueueUsed, qps.AskQueue.PreemptingResource)
+		askQueueRemainingGuaranteed = resources.SubOnlyExisting(askQueueRemainingGuaranteed, askQueueUsed)
 		if !remainingGuaranteed.IsEmpty() && strings.HasPrefix(qps.AskQueue.QueuePath, qps.QueuePath) && !askQueueRemainingGuaranteed.IsEmpty() {
 			return nil
 		}

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -835,8 +835,8 @@ func (qps *QueuePreemptionSnapshot) GetRemainingGuaranteedResource() *resources.
 		// Overall, this increases the chance of choosing victims for preemptor from siblings without causing preemption storm or loop.
 		askQueueRemainingGuaranteed := qps.AskQueue.GuaranteedResource.Clone()
 		askQueueUsed := qps.AskQueue.AllocatedResource.Clone()
-		askQueueUsed.SubOnlyExisting(qps.AskQueue.PreemptingResource)
-		askQueueRemainingGuaranteed.SubOnlyExisting(askQueueUsed)
+		resources.SubOnlyExisting(askQueueUsed, qps.AskQueue.PreemptingResource)
+		resources.SubOnlyExisting(askQueueRemainingGuaranteed, askQueueUsed)
 		if !remainingGuaranteed.IsEmpty() && strings.HasPrefix(qps.AskQueue.QueuePath, qps.QueuePath) && !askQueueRemainingGuaranteed.IsEmpty() {
 			return nil
 		}

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -20,6 +20,7 @@ package objects
 
 import (
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -826,6 +827,18 @@ func (qps *QueuePreemptionSnapshot) GetRemainingGuaranteedResource() *resources.
 		// In case ask queue has guaranteed set, its own values carries higher precedence over the parent or ancestor
 		if qps.AskQueue.QueuePath == qps.QueuePath && !remainingGuaranteed.IsEmpty() {
 			return resources.MergeIfNotPresent(remainingGuaranteed, parent)
+		}
+		// Queue (potential victim queue path) being processed currently sharing common ancestors or parent with ask queue should not propagate its
+		// actual remaining guaranteed to rest of queue's in the queue hierarchy downwards to let them use their own remaining guaranteed only if guaranteed
+		// has been set. Otherwise, propagating the remaining guaranteed downwards would give wrong perception and those queues might not be chosen
+		// as victims for sibling ( who is under guaranteed and starving for resources) in the same level.
+		// Overall, this increases the chance of choosing victims for preemptor from siblings without causing preemption storm or loop.
+		askQueueRemainingGuaranteed := qps.AskQueue.GuaranteedResource.Clone()
+		askQueueUsed := qps.AskQueue.AllocatedResource.Clone()
+		askQueueUsed.SubOnlyExisting(qps.AskQueue.PreemptingResource)
+		askQueueRemainingGuaranteed.SubOnlyExisting(askQueueUsed)
+		if !remainingGuaranteed.IsEmpty() && strings.HasPrefix(qps.AskQueue.QueuePath, qps.QueuePath) && !askQueueRemainingGuaranteed.IsEmpty() {
+			return nil
 		}
 	}
 	return resources.ComponentWiseMin(remainingGuaranteed, parent)

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -1572,6 +1572,225 @@ func TestTryPreemption_OnNode_AskResTypesSame_GuaranteedSetOnVictimAndPreemptorS
 	assert.Check(t, alloc3.IsPreempted(), "alloc3 not preempted")
 }
 
+// TestTryPreemption_OnNode_UGParent_With_UGPreemptorChild_GNotSetOnVictimChild_As_Siblings Test try preemption with 2 level queue hierarchy. Since Node doesn't have enough resources to accomodate, preemption happens because of node resource constraint.
+// Under guaranteed parent with 2 child queues. Victim Child1 queue doesn't have guaranteed set. Under guaranteed Preemptor Child2 queue is starving for resources.
+// Ask (Preemptor) resource type matches with the victim's resource type. Needs to be preempted because matching resource type has been configured as guaranteed.
+// Setup:
+// Nodes are Node1. Node is full, doesn't enough space to accommodate the ask.
+// root.parent.parent1.child1. Guaranteed not set directly, but set on root.parent.parent1, vcores: 10. 2 Allocations (belongs to two diff apps) are running. Each Allocation usage is vcores:1. Total usage is vcores:2.
+// root.parent.parent1.child2. Guaranteed set, vcores: 1. Ask of vcores: 1 is waiting for resources.
+// root.parent.parent2.child3. No usage, no guaranteed set
+// 1 Allocation on root.parent.parent1.child1 should be preempted to free up resources for ask arrived in root.parent.parent1.child2. Also, it won't lead to preemption storm or loop.
+func TestTryPreemption_OnNode_UGParent_With_UGPreemptorChild_GNotSetOnVictimChild_As_Siblings(t *testing.T) {
+	node := newNode(nodeID1, map[string]resources.Quantity{"vcores": 2})
+	iterator := getNodeIteratorFn(node)
+	rootQ, err := createRootQueue(nil)
+	assert.NilError(t, err)
+	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"vcores": "20"}, nil)
+	assert.NilError(t, err)
+	parentQ1, err := createManagedQueueGuaranteed(parentQ, "parent1", true, nil, map[string]string{"vcores": "10"})
+	assert.NilError(t, err)
+	parentQ2, err := createManagedQueueGuaranteed(parentQ, "parent2", true, nil, nil)
+	assert.NilError(t, err)
+
+	childQ1, err := createManagedQueueGuaranteed(parentQ1, "child1", false, nil, nil)
+	assert.NilError(t, err)
+	childQ2, err := createManagedQueueGuaranteed(parentQ1, "child2", false, nil, map[string]string{"vcores": "1"})
+	assert.NilError(t, err)
+	_, err = createManagedQueueGuaranteed(parentQ2, "child3", false, nil, nil)
+	assert.NilError(t, err)
+
+	app1 := newApplication(appID1, "default", "root.parent.parent1.child1")
+	app1.SetQueue(childQ1)
+	childQ1.applications[appID1] = app1
+	ask1 := newAllocationAsk("alloc1", appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
+	ask1.createTime = time.Now().Add(-2 * time.Minute)
+	assert.NilError(t, app1.AddAllocationAsk(ask1))
+	alloc1 := markAllocated(nodeID1, ask1)
+	app1.AddAllocation(alloc1)
+	assert.Check(t, node.TryAddAllocation(alloc1), "node alloc1 failed")
+	assert.NilError(t, childQ1.IncAllocatedResource(ask1.GetAllocatedResource(), false))
+
+	app2 := newApplication(appID2, "default", "root.parent.parent1.child1")
+	app2.SetQueue(childQ2)
+	childQ1.applications[appID2] = app2
+	ask2 := newAllocationAsk("alloc2", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
+	ask2.createTime = time.Now().Add(-1 * time.Minute)
+	assert.NilError(t, app2.AddAllocationAsk(ask2))
+	alloc2 := markAllocated(nodeID1, ask2)
+	app2.AddAllocation(alloc2)
+	assert.Check(t, node.TryAddAllocation(alloc2), "node alloc2 failed")
+	assert.NilError(t, childQ1.IncAllocatedResource(ask2.GetAllocatedResource(), false))
+
+	app3 := newApplication(appID3, "default", "root.parent.parent1.child2")
+	app3.SetQueue(childQ2)
+	childQ2.applications[appID3] = app3
+	ask3 := newAllocationAsk("alloc3", appID3, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
+	assert.NilError(t, app3.AddAllocationAsk(ask3))
+
+	headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 2})
+	preemptor := NewPreemptor(app3, headRoom, 30*time.Second, ask3, iterator(), false)
+
+	// register predicate handler
+	preemptions := []mock.Preemption{mock.NewPreemption(true, "alloc3", nodeID1, []string{"alloc2"}, 0, 0)}
+	plugin := mock.NewPreemptionPredicatePlugin(nil, nil, preemptions)
+	plugins.RegisterSchedulerPlugin(plugin)
+	defer plugins.UnregisterSchedulerPlugins()
+
+	result, ok := preemptor.TryPreemption()
+	assert.Assert(t, result != nil, "no result")
+	assert.Assert(t, ok, "no victims found")
+	assert.Equal(t, "alloc3", result.Request.GetAllocationKey(), "wrong alloc")
+	assert.Equal(t, nodeID1, result.NodeID, "wrong node")
+	assert.Equal(t, nodeID1, alloc2.nodeID, "wrong node")
+	assert.Check(t, !alloc1.IsPreempted(), "alloc1 preempted")
+	assert.Check(t, alloc2.IsPreempted(), "alloc2 not preempted")
+}
+
+// TestTryPreemption_OnNode_UGParent_With_GNotSetOnBothChilds Test try preemption with 2 level queue hierarchy. Since Node doesn't have enough resources to accomodate, preemption happens because of node resource constraint.
+// Under guaranteed parent with 2 child queues. Victim Child1 queue doesn't have guaranteed set. Preemptor Child2 queue doesn't have guaranteed set.
+// Ask (Preemptor) resource type matches with the victim's resource type. Needs to be preempted because matching resource type has been configured as guaranteed.
+// Setup:
+// Nodes are Node1. Node is full, doesn't enough space to accommodate the ask.
+// root.parent.parent1.child1. Guaranteed not set directly, but set on root.parent.parent1, vcores: 10. 2 Allocations (belongs to two diff apps) are running. Each Allocation usage is vcores:1. Total usage is vcores:2.
+// root.parent.parent1.child2. Guaranteed not set directly, but set on root.parent.parent1, vcores: 10. Ask of vcores: 1 is waiting for resources.
+// root.parent.parent2.child3. No usage, no guaranteed set
+// 1 Allocation on root.parent.parent1.child1 should not be preempted to free up resources for ask arrived in root.parent.parent1.child2 because it could lead to preemption storm or loop.
+func TestTryPreemption_OnNode_UGParent_With_GNotSetOnBothChilds(t *testing.T) {
+	node := newNode(nodeID1, map[string]resources.Quantity{"vcores": 2})
+	iterator := getNodeIteratorFn(node)
+	rootQ, err := createRootQueue(nil)
+	assert.NilError(t, err)
+	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"vcores": "20"}, nil)
+	assert.NilError(t, err)
+	parentQ1, err := createManagedQueueGuaranteed(parentQ, "parent1", true, nil, map[string]string{"vcores": "10"})
+	assert.NilError(t, err)
+	parentQ2, err := createManagedQueueGuaranteed(parentQ, "parent2", true, nil, nil)
+	assert.NilError(t, err)
+
+	childQ1, err := createManagedQueueGuaranteed(parentQ1, "child1", false, nil, nil)
+	assert.NilError(t, err)
+	childQ2, err := createManagedQueueGuaranteed(parentQ1, "child2", false, nil, nil)
+	assert.NilError(t, err)
+	_, err = createManagedQueueGuaranteed(parentQ2, "child3", false, nil, nil)
+	assert.NilError(t, err)
+
+	app1 := newApplication(appID1, "default", "root.parent.parent1.child1")
+	app1.SetQueue(childQ1)
+	childQ1.applications[appID1] = app1
+	ask1 := newAllocationAsk("alloc1", appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
+	ask1.createTime = time.Now().Add(-2 * time.Minute)
+	assert.NilError(t, app1.AddAllocationAsk(ask1))
+	alloc1 := markAllocated(nodeID1, ask1)
+	app1.AddAllocation(alloc1)
+	assert.Check(t, node.TryAddAllocation(alloc1), "node alloc1 failed")
+	assert.NilError(t, childQ1.IncAllocatedResource(ask1.GetAllocatedResource(), false))
+
+	app2 := newApplication(appID2, "default", "root.parent.parent1.child1")
+	app2.SetQueue(childQ2)
+	childQ1.applications[appID2] = app2
+	ask2 := newAllocationAsk("alloc2", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
+	ask2.createTime = time.Now().Add(-1 * time.Minute)
+	assert.NilError(t, app2.AddAllocationAsk(ask2))
+	alloc2 := markAllocated(nodeID1, ask2)
+	app2.AddAllocation(alloc2)
+	assert.Check(t, node.TryAddAllocation(alloc2), "node alloc2 failed")
+	assert.NilError(t, childQ1.IncAllocatedResource(ask2.GetAllocatedResource(), false))
+
+	app3 := newApplication(appID3, "default", "root.parent.parent1.child2")
+	app3.SetQueue(childQ2)
+	childQ2.applications[appID3] = app3
+	ask3 := newAllocationAsk("alloc3", appID3, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
+	assert.NilError(t, app3.AddAllocationAsk(ask3))
+
+	headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 2})
+	preemptor := NewPreemptor(app3, headRoom, 30*time.Second, ask3, iterator(), false)
+
+	// register predicate handler
+	plugin := mock.NewPreemptionPredicatePlugin(nil, nil, nil)
+	plugins.RegisterSchedulerPlugin(plugin)
+	defer plugins.UnregisterSchedulerPlugins()
+
+	result, ok := preemptor.TryPreemption()
+	assert.Assert(t, result == nil, "preemption is yielding results")
+	assert.Assert(t, !ok, "victims found")
+}
+
+// TestTryPreemption_OnNode_UGParent_With_UGPreemptorChild_OGVictimChild_As_Siblings Test try preemption with 2 level queue hierarchy. Since Node doesn't have enough resources to accomodate, preemption happens because of node resource constraint.
+// Under guaranteed parent with 2 child queues. Over Guaranteed Victim Child1 queue has guaranteed set. Under Guaranteed Preemptor Child2 queue is starving for resources.
+// Ask (Preemptor) resource type matches with the victim's resource type. Needs to be preempted because matching resource type has been configured as guaranteed.
+// Setup:
+// Nodes are Node1. Node is full, doesn't enough space to accommodate the ask.
+// root.parent.parent1.child1. Guaranteed of vcores:1 set directly , but also set on root.parent.parent1, vcores: 10. 2 Allocations (belongs to two diff apps) are running. Each Allocation usage is vcores:1. Total usage is vcores:2.
+// root.parent.parent1.child2. Guaranteed of vcores:1 set directly, but also set on root.parent.parent1, vcores: 10. Ask of vcores: 1 is waiting for resources.
+// root.parent.parent2.child3. No usage, no guaranteed set
+// 1 Allocation on root.parent.parent1.child1 should be preempted to free up resources for ask arrived in root.parent.parent1.child2. Also, it won't lead to preemption storm or loop.
+func TestTryPreemption_OnNode_UGParent_With_UGPreemptorChild_OGVictimChild_As_Siblings(t *testing.T) {
+	node := newNode(nodeID1, map[string]resources.Quantity{"vcores": 2})
+	iterator := getNodeIteratorFn(node)
+	rootQ, err := createRootQueue(nil)
+	assert.NilError(t, err)
+	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"vcores": "20"}, nil)
+	assert.NilError(t, err)
+	parentQ1, err := createManagedQueueGuaranteed(parentQ, "parent1", true, nil, map[string]string{"vcores": "10"})
+	assert.NilError(t, err)
+	parentQ2, err := createManagedQueueGuaranteed(parentQ, "parent2", true, nil, nil)
+	assert.NilError(t, err)
+
+	childQ1, err := createManagedQueueGuaranteed(parentQ1, "child1", false, nil, map[string]string{"vcores": "1"})
+	assert.NilError(t, err)
+	childQ2, err := createManagedQueueGuaranteed(parentQ1, "child2", false, nil, map[string]string{"vcores": "1"})
+	assert.NilError(t, err)
+	_, err = createManagedQueueGuaranteed(parentQ2, "child3", false, nil, nil)
+	assert.NilError(t, err)
+
+	app1 := newApplication(appID1, "default", "root.parent.parent1.child1")
+	app1.SetQueue(childQ1)
+	childQ1.applications[appID1] = app1
+	ask1 := newAllocationAsk("alloc1", appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
+	ask1.createTime = time.Now().Add(-2 * time.Minute)
+	assert.NilError(t, app1.AddAllocationAsk(ask1))
+	alloc1 := markAllocated(nodeID1, ask1)
+	app1.AddAllocation(alloc1)
+	assert.Check(t, node.TryAddAllocation(alloc1), "node alloc1 failed")
+	assert.NilError(t, childQ1.IncAllocatedResource(ask1.GetAllocatedResource(), false))
+
+	app2 := newApplication(appID2, "default", "root.parent.parent1.child1")
+	app2.SetQueue(childQ2)
+	childQ1.applications[appID2] = app2
+	ask2 := newAllocationAsk("alloc2", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
+	ask2.createTime = time.Now().Add(-1 * time.Minute)
+	assert.NilError(t, app2.AddAllocationAsk(ask2))
+	alloc2 := markAllocated(nodeID1, ask2)
+	app2.AddAllocation(alloc2)
+	assert.Check(t, node.TryAddAllocation(alloc2), "node alloc2 failed")
+	assert.NilError(t, childQ1.IncAllocatedResource(ask2.GetAllocatedResource(), false))
+
+	app3 := newApplication(appID3, "default", "root.parent.parent1.child2")
+	app3.SetQueue(childQ2)
+	childQ2.applications[appID3] = app3
+	ask3 := newAllocationAsk("alloc3", appID3, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
+	assert.NilError(t, app3.AddAllocationAsk(ask3))
+
+	headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 2})
+	preemptor := NewPreemptor(app3, headRoom, 30*time.Second, ask3, iterator(), false)
+
+	// register predicate handler
+	preemptions := []mock.Preemption{mock.NewPreemption(true, "alloc3", nodeID1, []string{"alloc2"}, 0, 0)}
+	plugin := mock.NewPreemptionPredicatePlugin(nil, nil, preemptions)
+	plugins.RegisterSchedulerPlugin(plugin)
+	defer plugins.UnregisterSchedulerPlugins()
+
+	result, ok := preemptor.TryPreemption()
+	assert.Assert(t, result != nil, "no result")
+	assert.Assert(t, ok, "no victims found")
+	assert.Equal(t, "alloc3", result.Request.GetAllocationKey(), "wrong alloc")
+	assert.Equal(t, nodeID1, result.NodeID, "wrong node")
+	assert.Equal(t, nodeID1, alloc2.nodeID, "wrong node")
+	assert.Check(t, !alloc1.IsPreempted(), "alloc1 preempted")
+	assert.Check(t, alloc2.IsPreempted(), "alloc2 not preempted")
+}
+
 func TestSolutionScoring(t *testing.T) {
 	singleAlloc := scoreMap(nodeID1, []bool{false}, []bool{true})
 	singleOriginator := scoreMap(nodeID1, []bool{true}, []bool{true})

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -1584,7 +1584,7 @@ func TestTryPreemption_OnNode_AskResTypesSame_GuaranteedSetOnVictimAndPreemptorS
 func TestTryPreemption_OnNode_UGParent_With_UGPreemptorChild_GNotSetOnVictimChild_As_Siblings(t *testing.T) {
 	node := newNode(nodeID1, map[string]resources.Quantity{"vcores": 2})
 	iterator := getNodeIteratorFn(node)
-	rootQ, err := createRootQueue(nil)
+	rootQ, err := createRootQueue(map[string]string{"vcores": "25"})
 	assert.NilError(t, err)
 	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"vcores": "20"}, nil)
 	assert.NilError(t, err)
@@ -1659,7 +1659,7 @@ func TestTryPreemption_OnNode_UGParent_With_UGPreemptorChild_GNotSetOnVictimChil
 func TestTryPreemption_OnNode_UGParent_With_GNotSetOnBothChilds(t *testing.T) {
 	node := newNode(nodeID1, map[string]resources.Quantity{"vcores": 2})
 	iterator := getNodeIteratorFn(node)
-	rootQ, err := createRootQueue(nil)
+	rootQ, err := createRootQueue(map[string]string{"vcores": "25"})
 	assert.NilError(t, err)
 	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"vcores": "20"}, nil)
 	assert.NilError(t, err)
@@ -1728,7 +1728,7 @@ func TestTryPreemption_OnNode_UGParent_With_GNotSetOnBothChilds(t *testing.T) {
 func TestTryPreemption_OnNode_UGParent_With_UGPreemptorChild_OGVictimChild_As_Siblings(t *testing.T) {
 	node := newNode(nodeID1, map[string]resources.Quantity{"vcores": 2})
 	iterator := getNodeIteratorFn(node)
-	rootQ, err := createRootQueue(nil)
+	rootQ, err := createRootQueue(map[string]string{"vcores": "25"})
 	assert.NilError(t, err)
 	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"vcores": "20"}, nil)
 	assert.NilError(t, err)


### PR DESCRIPTION
…causing preemption loop

### What is this PR for?
Different preemption cases between siblings under common under guaranteed parent needs to be handled properly without causing preemption storm or loop. Please refer https://docs.google.com/document/d/1vfv8XJJsIqlZN3ecyhP2EFeiUSQnY-9GHEi_UJFB-BU/edit for more details.

A fixable case without causing storm or loop is freeing up resources from victim child queue (not guaranteed set) to under guaranteed preemptor who is starving for resources located under common under guaranteed parent. This case has been discussed in the doc under section 2a)


### What type of PR is it?
* [ ] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2795

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
