### PR TITLE
[YUNIKORN-2778] Core: Use unified UpdateAllocation API for both asks and allocations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ module github.com/apache/yunikorn-core
 go 1.21
 
 require (
-	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240731203810-92032b13d586
+	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240815142741-38a38685cd4e
 	github.com/google/btree v1.1.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240731203810-92032b13d586 h1:ZVpo9Qj2/gvwX6Rl44UxkZBm2pZWEJDYWTramc9hwF0=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240731203810-92032b13d586/go.mod h1:WuHJpVk34t8N5+1ErYGj/5Qq33/cRzL4YtuoAsbMtWc=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240815142741-38a38685cd4e h1:ZOLst6ROwUrgoUQbEdYaz28iKuiU5YNYGtelKsTFhqw=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240815142741-38a38685cd4e/go.mod h1:WuHJpVk34t8N5+1ErYGj/5Qq33/cRzL4YtuoAsbMtWc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/pkg/examples/simple_example.go
+++ b/pkg/examples/simple_example.go
@@ -209,10 +209,10 @@ partitions:
 
 	// Send request
 	err = proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: []*si.AllocationAsk{
+		Allocations: []*si.Allocation{
 			{
 				AllocationKey: "alloc-1",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 10},
 						"vcore":  {Value: 1},

--- a/pkg/rmproxy/rmevent/events.go
+++ b/pkg/rmproxy/rmevent/events.go
@@ -81,11 +81,6 @@ type RMApplicationUpdateEvent struct {
 	UpdatedApplications  []*si.UpdatedApplication
 }
 
-type RMRejectedAllocationAskEvent struct {
-	RmID                   string
-	RejectedAllocationAsks []*si.RejectedAllocationAsk
-}
-
 type RMRejectedAllocationEvent struct {
 	RmID                string
 	RejectedAllocations []*si.RejectedAllocation
@@ -95,11 +90,6 @@ type RMReleaseAllocationEvent struct {
 	RmID                string
 	ReleasedAllocations []*si.AllocationRelease
 	Channel             chan *Result `json:"-"`
-}
-
-type RMReleaseAllocationAskEvent struct {
-	RmID                   string
-	ReleasedAllocationAsks []*si.AllocationAskRelease
 }
 
 type RMNodeUpdateEvent struct {

--- a/pkg/rmproxy/rmproxy.go
+++ b/pkg/rmproxy/rmproxy.go
@@ -162,27 +162,6 @@ func (rmp *RMProxy) triggerUpdateAllocation(rmID string, response *si.Allocation
 	}
 }
 
-func (rmp *RMProxy) processRMReleaseAllocationAskEvent(event *rmevent.RMReleaseAllocationAskEvent) {
-	if len(event.ReleasedAllocationAsks) == 0 {
-		return
-	}
-	response := &si.AllocationResponse{
-		ReleasedAsks: event.ReleasedAllocationAsks,
-	}
-	rmp.triggerUpdateAllocation(event.RmID, response)
-}
-
-func (rmp *RMProxy) processRMRejectedAllocationAskEvent(event *rmevent.RMRejectedAllocationAskEvent) {
-	if len(event.RejectedAllocationAsks) == 0 {
-		return
-	}
-	response := &si.AllocationResponse{
-		Rejected: event.RejectedAllocationAsks,
-	}
-	rmp.triggerUpdateAllocation(event.RmID, response)
-	metrics.GetSchedulerMetrics().AddRejectedContainers(len(event.RejectedAllocationAsks))
-}
-
 func (rmp *RMProxy) processRMRejectedAllocationEvent(event *rmevent.RMRejectedAllocationEvent) {
 	if len(event.RejectedAllocations) == 0 {
 		return
@@ -224,14 +203,10 @@ func (rmp *RMProxy) handleRMEvents() {
 				rmp.processApplicationUpdateEvent(v)
 			case *rmevent.RMReleaseAllocationEvent:
 				rmp.processRMReleaseAllocationEvent(v)
-			case *rmevent.RMRejectedAllocationAskEvent:
-				rmp.processRMRejectedAllocationAskEvent(v)
 			case *rmevent.RMRejectedAllocationEvent:
 				rmp.processRMRejectedAllocationEvent(v)
 			case *rmevent.RMNodeUpdateEvent:
 				rmp.processRMNodeUpdateEvent(v)
-			case *rmevent.RMReleaseAllocationAskEvent:
-				rmp.processRMReleaseAllocationAskEvent(v)
 			default:
 				panic(fmt.Sprintf("%s is not an acceptable type for RM event.", reflect.TypeOf(v).String()))
 			}
@@ -304,17 +279,9 @@ func (rmp *RMProxy) UpdateAllocation(request *si.AllocationRequest) error {
 		alloc.PartitionName = common.GetNormalizedPartitionName(alloc.PartitionName, request.RmID)
 	}
 
-	// Update asks
-	for _, ask := range request.Asks {
-		ask.PartitionName = common.GetNormalizedPartitionName(ask.PartitionName, request.RmID)
-	}
-
 	// Update releases
 	if request.Releases != nil {
 		for _, rel := range request.Releases.AllocationsToRelease {
-			rel.PartitionName = common.GetNormalizedPartitionName(rel.PartitionName, request.RmID)
-		}
-		for _, rel := range request.Releases.AllocationAsksToRelease {
 			rel.PartitionName = common.GetNormalizedPartitionName(rel.PartitionName, request.RmID)
 		}
 	}

--- a/pkg/scheduler/health_checker_test.go
+++ b/pkg/scheduler/health_checker_test.go
@@ -205,7 +205,7 @@ func TestGetSchedulerHealthStatusContext(t *testing.T) {
 
 	// add orphan allocation to a node
 	node := schedulerContext.partitions[partName].nodes.GetNode("node")
-	alloc := markAllocated("node", newAllocationAsk("key", "appID", resources.NewResource()))
+	alloc := newAllocation("key", "appID", "node", resources.NewResource())
 	node.AddAllocation(alloc)
 	healthInfo = GetSchedulerHealthStatus(schedulerMetrics, schedulerContext)
 	assert.Assert(t, !healthInfo.Healthy, "Scheduler should not be healthy")

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/mock"
 	"github.com/apache/yunikorn-core/pkg/plugins"
+	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
 const alloc = "alloc"
@@ -1565,8 +1566,11 @@ func scoreMap(nodeID string, orig, self []bool) map[string][]*Allocation {
 }
 
 func allocForScore(originator bool, allowPreemptSelf bool) *Allocation {
-	ask := NewAllocationAsk("alloc1", appID1, resources.NewResource())
-	ask.originator = originator
-	ask.allowPreemptSelf = allowPreemptSelf
-	return markAllocated(nodeID1, ask)
+	return NewAllocationFromSI(&si.Allocation{
+		AllocationKey:    "alloc1",
+		ApplicationID:    appID1,
+		Originator:       originator,
+		NodeID:           nodeID1,
+		PreemptionPolicy: &si.PreemptionPolicy{AllowPreemptSelf: allowPreemptSelf},
+	})
 }

--- a/pkg/scheduler/objects/required_node_preemptor_test.go
+++ b/pkg/scheduler/objects/required_node_preemptor_test.go
@@ -30,17 +30,17 @@ import (
 
 func createAllocationAsk(allocationKey string, app string, allowPreemption bool, isOriginator bool, priority int32, res *resources.Resource) *Allocation {
 	tags := map[string]string{}
-	siAsk := &si.AllocationAsk{
+	siAsk := &si.Allocation{
 		AllocationKey:    allocationKey,
 		ApplicationID:    app,
 		PartitionName:    "default",
 		Priority:         priority,
-		ResourceAsk:      res.ToProto(),
+		ResourcePerAlloc: res.ToProto(),
 		Originator:       isOriginator,
 		PreemptionPolicy: &si.PreemptionPolicy{AllowPreemptSelf: allowPreemption, AllowPreemptOther: true},
-		Tags:             tags,
+		AllocationTags:   tags,
 	}
-	ask := NewAllocationAskFromSI(siAsk)
+	ask := NewAllocationFromSI(siAsk)
 	return ask
 }
 

--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -240,16 +240,16 @@ func newAllocationAskTG(allocKey, appID, taskGroup string, res *resources.Resour
 }
 
 func newAllocationAskAll(allocKey, appID, taskGroup string, res *resources.Resource, placeholder bool, priority int32) *Allocation {
-	ask := &si.AllocationAsk{
-		AllocationKey: allocKey,
-		ApplicationID: appID,
-		PartitionName: "default",
-		ResourceAsk:   res.ToProto(),
-		TaskGroupName: taskGroup,
-		Placeholder:   placeholder,
-		Priority:      priority,
+	ask := &si.Allocation{
+		AllocationKey:    allocKey,
+		ApplicationID:    appID,
+		PartitionName:    "default",
+		ResourcePerAlloc: res.ToProto(),
+		TaskGroupName:    taskGroup,
+		Placeholder:      placeholder,
+		Priority:         priority,
 	}
-	return NewAllocationAskFromSI(ask)
+	return NewAllocationFromSI(ask)
 }
 
 func getTestUserGroup() security.UserGroup {

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1113,65 +1113,170 @@ func (pc *PartitionContext) GetNodes() []*objects.Node {
 	return pc.nodes.GetNodes()
 }
 
-// Add an already bound allocation to the partition/node/application/queue.
-// Queue max allocation is not checked as the allocation came from the RM.
-//
+// UpdateAllocation adds or updates an Allocation. If the Allocation has no NodeID specified, it is considered a
+// pending allocation and processed appropriate. This call is idempotent, and can be called multiple times with the
+// same allocation (such as on change updates from the shim)
+// Upon successfully processing, two flags are returned: requestCreated (if a new request was added) and allocCreated (if an allocation was satisifed).
+// This can be used by callers that need this information to take further action.
 // NOTE: this is a lock free call. It must NOT be called holding the PartitionContext lock.
-func (pc *PartitionContext) AddAllocation(alloc *objects.Allocation) error {
+func (pc *PartitionContext) UpdateAllocation(alloc *objects.Allocation) (requestCreated bool, allocCreated bool, err error) { //nolint:funlen
 	// cannot do anything with a nil alloc, should only happen if the shim broke things badly
 	if alloc == nil {
-		return nil
+		return false, false, nil
 	}
 	if pc.isStopped() {
-		return fmt.Errorf("partition %s is stopped cannot add new allocation %s", pc.Name, alloc.GetAllocationKey())
+		return false, false, fmt.Errorf("partition %s is stopped; cannot process allocation %s", pc.Name, alloc.GetAllocationKey())
 	}
 
-	log.Log(log.SchedPartition).Info("adding recovered allocation",
+	allocationKey := alloc.GetAllocationKey()
+	applicationID := alloc.GetApplicationID()
+	nodeID := alloc.GetNodeID()
+
+	log.Log(log.SchedPartition).Info("processing allocation",
 		zap.String("partitionName", pc.Name),
-		zap.String("appID", alloc.GetApplicationID()),
-		zap.String("allocationKey", alloc.GetAllocationKey()))
+		zap.String("appID", applicationID),
+		zap.String("allocationKey", allocationKey))
 
-	// Check if allocation violates any resource restriction, or allocate on a
-	// non-existent application or nodes.
-	node := pc.GetNode(alloc.GetNodeID())
-	if node == nil {
-		metrics.GetSchedulerMetrics().IncSchedulingError()
-		return fmt.Errorf("failed to find node %s", alloc.GetNodeID())
-	}
-
+	// find application
 	app := pc.getApplication(alloc.GetApplicationID())
 	if app == nil {
 		metrics.GetSchedulerMetrics().IncSchedulingError()
-		return fmt.Errorf("failed to find application %s", alloc.GetApplicationID())
+		return false, false, fmt.Errorf("failed to find application %s", applicationID)
 	}
 	queue := app.GetQueue()
 
-	// Do not check if the new allocation goes beyond the queue's max resource (recursive).
-	// still handle a returned error but they should never happen.
-	if err := queue.IncAllocatedResource(alloc.GetAllocatedResource(), true); err != nil {
-		metrics.GetSchedulerMetrics().IncSchedulingError()
-		return fmt.Errorf("cannot allocate resource from application %s: %v ",
-			alloc.GetApplicationID(), err)
+	// find node if one is specified
+	var node *objects.Node = nil
+	allocated := alloc.IsAllocated()
+	if allocated {
+		node = pc.GetNode(alloc.GetNodeID())
+		if node == nil {
+			metrics.GetSchedulerMetrics().IncSchedulingError()
+			return false, false, fmt.Errorf("failed to find node %s", nodeID)
+		}
 	}
 
-	metrics.GetQueueMetrics(queue.GetQueuePath()).IncAllocatedContainer()
-	node.AddAllocation(alloc)
-	alloc.SetInstanceType(node.GetInstanceType())
-	app.RecoverAllocationAsk(alloc)
-	app.AddAllocation(alloc)
+	// check to see if allocation exists already on app
+	existing := app.GetAllocationAsk(allocationKey)
 
-	// track the number of allocations
-	pc.updateAllocationCount(1)
-	if alloc.IsPlaceholder() {
-		pc.incPhAllocationCount()
+	// CASE 1/2: no existing allocation
+	if existing == nil {
+		// CASE 1: new request
+		if node == nil {
+			log.Log(log.SchedPartition).Info("handling new request",
+				zap.String("partitionName", pc.Name),
+				zap.String("appID", applicationID),
+				zap.String("allocationKey", allocationKey))
+
+			if err := app.AddAllocationAsk(alloc); err != nil {
+				log.Log(log.SchedPartition).Info("failed to add request",
+					zap.String("partitionName", pc.Name),
+					zap.String("appID", applicationID),
+					zap.String("allocationKey", allocationKey),
+					zap.Error(err))
+				return false, false, err
+			}
+
+			log.Log(log.SchedPartition).Info("added new request",
+				zap.String("partitionName", pc.Name),
+				zap.String("appID", applicationID),
+				zap.String("allocationKey", allocationKey))
+			return true, false, nil
+		}
+
+		// CASE 2: new allocation already assigned
+		log.Log(log.SchedPartition).Info("handling existing allocation",
+			zap.String("partitionName", pc.Name),
+			zap.String("appID", applicationID),
+			zap.String("allocationKey", allocationKey))
+
+		// Do not check if the new allocation goes beyond the queue's max resource (recursive).
+		// still handle a returned error but they should never happen.
+		if err := queue.IncAllocatedResource(alloc.GetAllocatedResource(), true); err != nil {
+			metrics.GetSchedulerMetrics().IncSchedulingError()
+			return false, false, fmt.Errorf("cannot allocate resource from application %s: %v ",
+				alloc.GetApplicationID(), err)
+		}
+
+		metrics.GetQueueMetrics(queue.GetQueuePath()).IncAllocatedContainer()
+		node.AddAllocation(alloc)
+		alloc.SetInstanceType(node.GetInstanceType())
+		app.RecoverAllocationAsk(alloc)
+		app.AddAllocation(alloc)
+		pc.updateAllocationCount(1)
+		if alloc.IsPlaceholder() {
+			pc.incPhAllocationCount()
+		}
+
+		log.Log(log.SchedPartition).Info("added existing allocation",
+			zap.String("partitionName", pc.Name),
+			zap.String("appID", applicationID),
+			zap.String("allocationKey", allocationKey),
+			zap.Bool("placeholder", alloc.IsPlaceholder()))
+		return false, true, nil
 	}
 
-	log.Log(log.SchedPartition).Info("recovered allocation",
+	// CASE 3: updating an existing allocation
+	if existing.IsAllocated() {
+		// this is a placeholder for eventual resource updates; nothing to do yet
+		log.Log(log.SchedPartition).Info("handling allocation update",
+			zap.String("partitionName", pc.Name),
+			zap.String("appID", applicationID),
+			zap.String("allocationKey", allocationKey))
+		return false, false, nil
+	}
+
+	// CASE 4: transitioning from requested to allocated
+	if allocated {
+		log.Log(log.SchedPartition).Info("handling allocation placement",
+			zap.String("partitionName", pc.Name),
+			zap.String("appID", applicationID),
+			zap.String("allocationKey", allocationKey))
+
+		existing.SetNodeID(nodeID)
+		existing.SetBindTime(alloc.GetBindTime())
+		if _, err := app.AllocateAsk(allocationKey); err != nil {
+			log.Log(log.SchedPartition).Info("failed to allocate ask for allocation placement",
+				zap.String("partitionName", pc.Name),
+				zap.String("appID", applicationID),
+				zap.String("allocationKey", allocationKey),
+				zap.Error(err))
+			return false, false, err
+		}
+
+		// Do not check if the new allocation goes beyond the queue's max resource (recursive).
+		// still handle a returned error but they should never happen.
+		if err := queue.IncAllocatedResource(alloc.GetAllocatedResource(), true); err != nil {
+			metrics.GetSchedulerMetrics().IncSchedulingError()
+			return false, false, fmt.Errorf("cannot allocate resource from application %s: %v ",
+				alloc.GetApplicationID(), err)
+		}
+
+		metrics.GetQueueMetrics(queue.GetQueuePath()).IncAllocatedContainer()
+		node.AddAllocation(existing)
+		existing.SetInstanceType(node.GetInstanceType())
+		app.AddAllocation(existing)
+		pc.updateAllocationCount(1)
+		if existing.IsPlaceholder() {
+			pc.incPhAllocationCount()
+		}
+
+		log.Log(log.SchedPartition).Info("external allocation placed",
+			zap.String("partitionName", pc.Name),
+			zap.String("appID", applicationID),
+			zap.String("allocationKey", allocationKey),
+			zap.Bool("placeholder", alloc.IsPlaceholder()))
+		return false, true, nil
+	}
+
+	// CASE 5: updating existing request
+	log.Log(log.SchedPartition).Info("handling request update",
 		zap.String("partitionName", pc.Name),
-		zap.String("appID", alloc.GetApplicationID()),
-		zap.String("allocationKey", alloc.GetAllocationKey()),
-		zap.Bool("placeholder", alloc.IsPlaceholder()))
-	return nil
+		zap.String("appID", applicationID),
+		zap.String("allocationKey", allocationKey))
+
+	// this is a placeholder for eventual resource updates; nothing to do yet
+	return false, false, nil
 }
 
 func (pc *PartitionContext) convertUGI(ugi *si.UserGroupInformation, forced bool) (security.UserGroup, error) {
@@ -1255,7 +1360,7 @@ func (pc *PartitionContext) generateReleased(release *si.AllocationRelease, app 
 
 // removeAllocation removes the referenced allocation(s) from the applications and nodes
 // NOTE: this is a lock free call. It must NOT be called holding the PartitionContext lock.
-func (pc *PartitionContext) removeAllocation(release *si.AllocationRelease) ([]*objects.Allocation, *objects.Allocation) {
+func (pc *PartitionContext) removeAllocation(release *si.AllocationRelease) ([]*objects.Allocation, *objects.Allocation) { //nolint:funlen
 	if release == nil {
 		return nil, nil
 	}
@@ -1375,48 +1480,13 @@ func (pc *PartitionContext) removeAllocation(release *si.AllocationRelease) ([]*
 	if release.TerminationType == si.TerminationType_TIMEOUT || release.TerminationType == si.TerminationType_PREEMPTED_BY_SCHEDULER {
 		released = nil
 	}
+
+	if release.TerminationType != si.TerminationType_TIMEOUT {
+		// handle ask releases as well
+		_ = app.RemoveAllocationAsk(allocationKey)
+	}
+
 	return released, confirmed
-}
-
-// Remove the allocation ask from the specified application
-// NOTE: this is a lock free call. It must NOT be called holding the PartitionContext lock.
-func (pc *PartitionContext) removeAllocationAsk(release *si.AllocationAskRelease) {
-	if release == nil {
-		return
-	}
-	appID := release.ApplicationID
-	allocKey := release.AllocationKey
-	// A timeout termination is send by the core to the shim, ignore on return.
-	if release.TerminationType == si.TerminationType_TIMEOUT {
-		log.Log(log.SchedPartition).Debug("Ignoring ask release with termination type Timeout",
-			zap.String("appID", appID),
-			zap.String("ask", allocKey))
-		return
-	}
-	app := pc.getApplication(appID)
-	if app == nil {
-		log.Log(log.SchedPartition).Info("Invalid ask release requested by shim",
-			zap.String("appID", appID),
-			zap.String("ask", allocKey),
-			zap.Stringer("terminationType", release.TerminationType))
-		return
-	}
-	// remove the allocation asks from the app
-	_ = app.RemoveAllocationAsk(allocKey)
-}
-
-// Add the allocation ask to the specified application
-// NOTE: this is a lock free call. It must NOT be called holding the PartitionContext lock.
-func (pc *PartitionContext) addAllocationAsk(siAsk *si.AllocationAsk) error {
-	if siAsk == nil {
-		return nil
-	}
-	app := pc.getApplication(siAsk.ApplicationID)
-	if app == nil {
-		return fmt.Errorf("failed to find application %s, for allocation ask %s", siAsk.ApplicationID, siAsk.AllocationKey)
-	}
-	// add the allocation asks to the app
-	return app.AddAllocationAsk(objects.NewAllocationAskFromSI(siAsk))
 }
 
 func (pc *PartitionContext) GetCurrentState() string {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -23,6 +23,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/apache/yunikorn-core/pkg/common/resources"
+	"github.com/apache/yunikorn-core/pkg/scheduler/objects"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
@@ -45,27 +46,30 @@ func TestInspectOutstandingRequests(t *testing.T) {
 		"vcores": 1,
 		"memory": 1,
 	})
-	siAsk1 := &si.AllocationAsk{
-		AllocationKey: "ask-uuid-1",
-		ApplicationID: appID1,
-		ResourceAsk:   askResource.ToProto(),
+	siAsk1 := &si.Allocation{
+		AllocationKey:    "ask-uuid-1",
+		ApplicationID:    appID1,
+		ResourcePerAlloc: askResource.ToProto(),
 	}
-	siAsk2 := &si.AllocationAsk{
-		AllocationKey: "ask-uuid-2",
-		ApplicationID: appID1,
-		ResourceAsk:   askResource.ToProto(),
+	siAsk2 := &si.Allocation{
+		AllocationKey:    "ask-uuid-2",
+		ApplicationID:    appID1,
+		ResourcePerAlloc: askResource.ToProto(),
 	}
-	siAsk3 := &si.AllocationAsk{
-		AllocationKey: "ask-uuid-3",
-		ApplicationID: appID2,
-		ResourceAsk:   askResource.ToProto(),
+	siAsk3 := &si.Allocation{
+		AllocationKey:    "ask-uuid-3",
+		ApplicationID:    appID2,
+		ResourcePerAlloc: askResource.ToProto(),
 	}
-	err = partition.addAllocationAsk(siAsk1)
+	askCreated, _, err := partition.UpdateAllocation(objects.NewAllocationFromSI(siAsk1))
 	assert.NilError(t, err)
-	err = partition.addAllocationAsk(siAsk2)
+	assert.Check(t, askCreated)
+	askCreated, _, err = partition.UpdateAllocation(objects.NewAllocationFromSI(siAsk2))
 	assert.NilError(t, err)
-	err = partition.addAllocationAsk(siAsk3)
+	assert.Check(t, askCreated)
+	askCreated, _, err = partition.UpdateAllocation(objects.NewAllocationFromSI(siAsk3))
 	assert.NilError(t, err)
+	assert.Check(t, askCreated)
 
 	// mark asks as attempted
 	expectedTotal := resources.NewResourceFromMap(map[string]resources.Quantity{

--- a/pkg/scheduler/tests/application_tracking_test.go
+++ b/pkg/scheduler/tests/application_tracking_test.go
@@ -111,10 +111,10 @@ func TestApplicationHistoryTracking(t *testing.T) {
 
 	// Add allocation ask & check events
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: []*si.AllocationAsk{
+		Allocations: []*si.Allocation{
 			{
 				AllocationKey: "alloc-1",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 10000000},
 						"vcore":  {Value: 1000},
@@ -166,7 +166,7 @@ func TestApplicationHistoryTracking(t *testing.T) {
 
 	eventsDao, err = client.GetBatchEvents()
 	assert.NilError(t, err)
-	assert.Equal(t, 17, len(eventsDao.EventRecords), "number of events generated")
+	assert.Equal(t, 18, len(eventsDao.EventRecords), "number of events generated")
 	verifyAllocationCancelledEvents(t, eventsDao.EventRecords[13:])
 	events, _ = getEventsFromStream(t, false, stream, 4)
 	assert.NilError(t, err)

--- a/pkg/scheduler/tests/mockscheduler_test.go
+++ b/pkg/scheduler/tests/mockscheduler_test.go
@@ -147,17 +147,17 @@ func (m *mockScheduler) removeApp(appID, partition string) error {
 }
 
 func (m *mockScheduler) addAppRequest(appID, allocKeyPrefix string, resource *si.Resource, repeat int) error {
-	asks := make([]*si.AllocationAsk, repeat)
+	asks := make([]*si.Allocation, repeat)
 	for i := 0; i < repeat; i++ {
-		asks[i] = &si.AllocationAsk{
-			AllocationKey: fmt.Sprintf("%s-%d", allocKeyPrefix, i),
-			ApplicationID: appID,
-			ResourceAsk:   resource,
+		asks[i] = &si.Allocation{
+			AllocationKey:    fmt.Sprintf("%s-%d", allocKeyPrefix, i),
+			ApplicationID:    appID,
+			ResourcePerAlloc: resource,
 		}
 	}
 	return m.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: asks,
-		RmID: m.rmID,
+		Allocations: asks,
+		RmID:        m.rmID,
 	})
 }
 
@@ -168,21 +168,6 @@ func (m *mockScheduler) releaseAllocRequest(appID, allocationKey string) error {
 				{
 					ApplicationID: appID,
 					AllocationKey: allocationKey,
-					PartitionName: m.partitionName,
-				},
-			},
-		},
-		RmID: m.rmID,
-	})
-}
-
-func (m *mockScheduler) releaseAskRequest(appID, allocKey string) error {
-	return m.proxy.UpdateAllocation(&si.AllocationRequest{
-		Releases: &si.AllocationReleasesRequest{
-			AllocationAsksToRelease: []*si.AllocationAskRelease{
-				{
-					ApplicationID: appID,
-					AllocationKey: allocKey,
 					PartitionName: m.partitionName,
 				},
 			},

--- a/pkg/scheduler/tests/operation_test.go
+++ b/pkg/scheduler/tests/operation_test.go
@@ -89,10 +89,10 @@ partitions:
 
 	// App asks for 2 allocations
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: []*si.AllocationAsk{
+		Allocations: []*si.Allocation{
 			{
 				AllocationKey: "alloc-1",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 10000000},
 						"vcore":  {Value: 1000},
@@ -102,7 +102,7 @@ partitions:
 			},
 			{
 				AllocationKey: "alloc-2",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 10000000},
 						"vcore":  {Value: 1000},
@@ -227,10 +227,10 @@ partitions:
 
 	// App asks for 2 allocations
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: []*si.AllocationAsk{
+		Allocations: []*si.Allocation{
 			{
 				AllocationKey: "alloc-1",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 10000000},
 						"vcore":  {Value: 1000},
@@ -240,7 +240,7 @@ partitions:
 			},
 			{
 				AllocationKey: "alloc-2",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 10000000},
 						"vcore":  {Value: 1000},

--- a/pkg/scheduler/tests/performance_test.go
+++ b/pkg/scheduler/tests/performance_test.go
@@ -127,11 +127,11 @@ partitions:
 
 	// Request pods
 	app1NumPods := numPods / 2
-	app1Asks := make([]*si.AllocationAsk, app1NumPods)
+	app1Asks := make([]*si.Allocation, app1NumPods)
 	for i := 0; i < app1NumPods; i++ {
-		app1Asks[i] = &si.AllocationAsk{
+		app1Asks[i] = &si.Allocation{
 			AllocationKey: fmt.Sprintf("alloc-1-%d", i),
-			ResourceAsk: &si.Resource{
+			ResourcePerAlloc: &si.Resource{
 				Resources: map[string]*si.Quantity{
 					"memory": {Value: int64(requestMem)},
 					"vcore":  {Value: int64(requestVcore)},
@@ -141,19 +141,19 @@ partitions:
 		}
 	}
 	err = proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: app1Asks,
-		RmID: "rm:123",
+		Allocations: app1Asks,
+		RmID:        "rm:123",
 	})
 	if err != nil {
 		b.Error(err.Error())
 	}
 
 	app2NumPods := numPods - app1NumPods
-	app2Asks := make([]*si.AllocationAsk, app2NumPods)
+	app2Asks := make([]*si.Allocation, app2NumPods)
 	for i := 0; i < app2NumPods; i++ {
-		app2Asks[i] = &si.AllocationAsk{
+		app2Asks[i] = &si.Allocation{
 			AllocationKey: fmt.Sprintf("alloc-2-%d", i),
-			ResourceAsk: &si.Resource{
+			ResourcePerAlloc: &si.Resource{
 				Resources: map[string]*si.Quantity{
 					"memory": {Value: int64(requestMem)},
 					"vcore":  {Value: int64(requestVcore)},
@@ -163,8 +163,8 @@ partitions:
 		}
 	}
 	err = proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: app2Asks,
-		RmID: "rm:123",
+		Allocations: app2Asks,
+		RmID:        "rm:123",
 	})
 	if err != nil {
 		b.Error(err.Error())

--- a/pkg/scheduler/tests/plugin_test.go
+++ b/pkg/scheduler/tests/plugin_test.go
@@ -89,10 +89,10 @@ partitions:
 
 	// now submit a request, that uses 8/10 memory from the node
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: []*si.AllocationAsk{
+		Allocations: []*si.Allocation{
 			{
 				AllocationKey: "alloc-1",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 8},
 					},
@@ -113,10 +113,10 @@ partitions:
 	//  - queue has plenty of resources
 	// we expect the plugin to be called to trigger an update
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: []*si.AllocationAsk{
+		Allocations: []*si.Allocation{
 			{
 				AllocationKey: "alloc-2",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 5},
 					},

--- a/pkg/scheduler/tests/reservation_test.go
+++ b/pkg/scheduler/tests/reservation_test.go
@@ -413,7 +413,7 @@ func TestUnReservationAndDeletion(t *testing.T) {
 	// delete pending asks
 	for _, ask := range app.GetReservations() {
 		askID := ask[strings.Index(ask, "|")+1:]
-		err = ms.releaseAskRequest(appID1, askID)
+		err = ms.releaseAllocRequest(appID1, askID)
 		assert.NilError(t, err, "ask release update failed")
 	}
 	// delete existing allocations

--- a/pkg/scheduler/tests/smoke_test.go
+++ b/pkg/scheduler/tests/smoke_test.go
@@ -235,10 +235,10 @@ func TestBasicScheduler(t *testing.T) {
 	assert.Equal(t, app01.CurrentState(), objects.New.String())
 
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: []*si.AllocationAsk{
+		Allocations: []*si.Allocation{
 			{
 				AllocationKey: "alloc-1a",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 10000000},
 						"vcore":  {Value: 1000},
@@ -248,7 +248,7 @@ func TestBasicScheduler(t *testing.T) {
 			},
 			{
 				AllocationKey: "alloc-1b",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 10000000},
 						"vcore":  {Value: 1000},
@@ -290,10 +290,10 @@ func TestBasicScheduler(t *testing.T) {
 
 	// ask for 4 more tasks
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: []*si.AllocationAsk{
+		Allocations: []*si.Allocation{
 			{
 				AllocationKey: "alloc-2a",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 50000000},
 						"vcore":  {Value: 5000},
@@ -303,7 +303,7 @@ func TestBasicScheduler(t *testing.T) {
 			},
 			{
 				AllocationKey: "alloc-2b",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 50000000},
 						"vcore":  {Value: 5000},
@@ -313,7 +313,7 @@ func TestBasicScheduler(t *testing.T) {
 			},
 			{
 				AllocationKey: "alloc-3a",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 100000000},
 						"vcore":  {Value: 5000},
@@ -323,7 +323,7 @@ func TestBasicScheduler(t *testing.T) {
 			},
 			{
 				AllocationKey: "alloc-3b",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 100000000},
 						"vcore":  {Value: 5000},
@@ -395,7 +395,7 @@ func TestBasicScheduler(t *testing.T) {
 	// Release asks
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
 		Releases: &si.AllocationReleasesRequest{
-			AllocationAsksToRelease: []*si.AllocationAskRelease{
+			AllocationsToRelease: []*si.AllocationRelease{
 				{
 					ApplicationID: appID1,
 					PartitionName: "default",
@@ -463,11 +463,11 @@ func TestBasicSchedulerAutoAllocation(t *testing.T) {
 	ms.mockRM.waitForAcceptedNode(t, "node-1:1234", 1000)
 	ms.mockRM.waitForAcceptedNode(t, "node-2:1234", 1000)
 
-	asks := make([]*si.AllocationAsk, 20)
+	asks := make([]*si.Allocation, 20)
 	for i := 0; i < 20; i++ {
-		asks[i] = &si.AllocationAsk{
+		asks[i] = &si.Allocation{
 			AllocationKey: fmt.Sprintf("alloc-%d", i),
-			ResourceAsk: &si.Resource{
+			ResourcePerAlloc: &si.Resource{
 				Resources: map[string]*si.Quantity{
 					"memory": {Value: 10000000},
 					"vcore":  {Value: 1000},
@@ -477,8 +477,8 @@ func TestBasicSchedulerAutoAllocation(t *testing.T) {
 		}
 	}
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: asks,
-		RmID: "rm:123",
+		Allocations: asks,
+		RmID:        "rm:123",
 	})
 
 	assert.NilError(t, err, "AllocationRequest 2 failed")
@@ -574,12 +574,12 @@ partitions:
 	ms.mockRM.waitForAcceptedNode(t, "node-1:1234", 1000)
 	ms.mockRM.waitForAcceptedNode(t, "node-2:1234", 1000)
 
-	asks := make([]*si.AllocationAsk, 40)
+	asks := make([]*si.Allocation, 40)
 	appIDs := []string{app1ID, app2ID}
 	for i := 0; i < 40; i++ {
-		asks[i] = &si.AllocationAsk{
+		asks[i] = &si.Allocation{
 			AllocationKey: fmt.Sprintf("alloc-%d", i),
-			ResourceAsk: &si.Resource{
+			ResourcePerAlloc: &si.Resource{
 				Resources: map[string]*si.Quantity{
 					"memory": {Value: 10000000},
 					"vcore":  {Value: 1000},
@@ -589,8 +589,8 @@ partitions:
 		}
 	}
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: asks,
-		RmID: "rm:123",
+		Allocations: asks,
+		RmID:        "rm:123",
 	})
 
 	assert.NilError(t, err, "AllocationRequest 2 failed")
@@ -686,12 +686,12 @@ partitions:
 	ms.mockRM.waitForAcceptedNode(t, "node-1:1234", 1000)
 	ms.mockRM.waitForAcceptedNode(t, "node-2:1234", 1000)
 
-	asks := make([]*si.AllocationAsk, 40)
+	asks := make([]*si.Allocation, 40)
 	appIDs := []string{app1ID, app2ID}
 	for i := 0; i < 40; i++ {
-		asks[i] = &si.AllocationAsk{
+		asks[i] = &si.Allocation{
 			AllocationKey: fmt.Sprintf("alloc-%d", i),
-			ResourceAsk: &si.Resource{
+			ResourcePerAlloc: &si.Resource{
 				Resources: map[string]*si.Quantity{
 					"memory": {Value: 10000000},
 					"vcore":  {Value: 1000},
@@ -701,8 +701,8 @@ partitions:
 		}
 	}
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: asks,
-		RmID: "rm:123",
+		Allocations: asks,
+		RmID:        "rm:123",
 	})
 
 	assert.NilError(t, err, "AllocationRequest 2 failed")
@@ -876,11 +876,11 @@ partitions:
 
 			ms.mockRM.waitForAcceptedNode(t, "node-1:1234", 1000)
 
-			asks := make([]*si.AllocationAsk, param.numOfAsk)
+			asks := make([]*si.Allocation, param.numOfAsk)
 			for i := int32(0); i < param.numOfAsk; i++ {
-				asks[i] = &si.AllocationAsk{
+				asks[i] = &si.Allocation{
 					AllocationKey: fmt.Sprintf("alloc-%d", i),
-					ResourceAsk: &si.Resource{
+					ResourcePerAlloc: &si.Resource{
 						Resources: map[string]*si.Quantity{
 							"memory": {Value: param.askMemory},
 							"vcore":  {Value: param.askCPU},
@@ -890,8 +890,8 @@ partitions:
 				}
 			}
 			err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-				Asks: asks,
-				RmID: "rm:123",
+				Allocations: asks,
+				RmID:        "rm:123",
 			})
 
 			assert.NilError(t, err, "AllocationRequest 2 failed in run %s", param.name)
@@ -1127,12 +1127,12 @@ partitions:
 	ms.mockRM.waitForAcceptedNode(t, "node-1:1234", 1000)
 	ms.mockRM.waitForAcceptedNode(t, "node-2:1234", 1000)
 
-	asks := make([]*si.AllocationAsk, 40)
+	asks := make([]*si.Allocation, 40)
 	appIDs := []string{app1ID, app2ID}
 	for i := 0; i < 40; i++ {
-		asks[i] = &si.AllocationAsk{
+		asks[i] = &si.Allocation{
 			AllocationKey: fmt.Sprintf("alloc-%d", i),
-			ResourceAsk: &si.Resource{
+			ResourcePerAlloc: &si.Resource{
 				Resources: map[string]*si.Quantity{
 					"memory": {Value: 10000000},
 					"vcore":  {Value: 1000},
@@ -1142,8 +1142,8 @@ partitions:
 		}
 	}
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: asks,
-		RmID: "rm:123",
+		Allocations: asks,
+		RmID:        "rm:123",
 	})
 
 	assert.NilError(t, err, "UpdateRequest 2 failed")
@@ -1237,11 +1237,11 @@ partitions:
 	}
 
 	// Request 20 allocations
-	asks := make([]*si.AllocationAsk, 20)
+	asks := make([]*si.Allocation, 20)
 	for i := 0; i < 20; i++ {
-		asks[i] = &si.AllocationAsk{
+		asks[i] = &si.Allocation{
 			AllocationKey: fmt.Sprintf("alloc-%d", i),
-			ResourceAsk: &si.Resource{
+			ResourcePerAlloc: &si.Resource{
 				Resources: map[string]*si.Quantity{
 					"memory": {Value: 10000000},
 					"vcore":  {Value: 1000},
@@ -1251,8 +1251,8 @@ partitions:
 		}
 	}
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: asks,
-		RmID: "rm:123",
+		Allocations: asks,
+		RmID:        "rm:123",
 	})
 
 	assert.NilError(t, err, "AllocationRequest failed")
@@ -1348,10 +1348,10 @@ func TestDupReleasesInGangScheduling(t *testing.T) {
 
 	// shim side creates a placeholder, and send the UpdateRequest
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: []*si.AllocationAsk{
+		Allocations: []*si.Allocation{
 			{
 				AllocationKey: "alloc-1",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 10000000},
 						"vcore":  {Value: 1000},
@@ -1382,10 +1382,10 @@ func TestDupReleasesInGangScheduling(t *testing.T) {
 
 	// shim submits the actual pod for scheduling
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: []*si.AllocationAsk{
+		Allocations: []*si.Allocation{
 			{
 				AllocationKey: "alloc-2",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 10000000},
 						"vcore":  {Value: 1000},
@@ -1544,10 +1544,10 @@ partitions:
 	assert.Equal(t, app01.CurrentState(), objects.New.String())
 
 	err = ms.proxy.UpdateAllocation(&si.AllocationRequest{
-		Asks: []*si.AllocationAsk{
+		Allocations: []*si.Allocation{
 			{
 				AllocationKey: "alloc-1",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 10000000},
 						"vcore":  {Value: 1000},
@@ -1557,7 +1557,7 @@ partitions:
 			},
 			{
 				AllocationKey: "alloc-2",
-				ResourceAsk: &si.Resource{
+				ResourcePerAlloc: &si.Resource{
 					Resources: map[string]*si.Quantity{
 						"memory": {Value: 10000000},
 						"vcore":  {Value: 1000},

--- a/pkg/scheduler/utilities_test.go
+++ b/pkg/scheduler/utilities_test.go
@@ -21,7 +21,6 @@ package scheduler
 import (
 	"strconv"
 	"testing"
-	"time"
 
 	"gotest.tools/v3/assert"
 
@@ -568,26 +567,47 @@ func newAllocationAskPriority(allocKey, appID string, res *resources.Resource, p
 }
 
 func newAllocationAskAll(allocKey, appID, taskGroup string, res *resources.Resource, prio int32, placeHolder bool) *objects.Allocation {
-	return objects.NewAllocationAskFromSI(&si.AllocationAsk{
-		AllocationKey: allocKey,
-		ApplicationID: appID,
-		PartitionName: "test",
-		ResourceAsk:   res.ToProto(),
-		Priority:      prio,
-		TaskGroupName: taskGroup,
-		Placeholder:   placeHolder,
+	return objects.NewAllocationFromSI(&si.Allocation{
+		AllocationKey:    allocKey,
+		ApplicationID:    appID,
+		PartitionName:    "test",
+		ResourcePerAlloc: res.ToProto(),
+		Priority:         prio,
+		TaskGroupName:    taskGroup,
+		Placeholder:      placeHolder,
+	})
+}
+
+func newAllocationTG(allocKey, appID, nodeID, taskGroup string, res *resources.Resource, placeHolder bool) *objects.Allocation {
+	return newAllocationAll(allocKey, appID, nodeID, taskGroup, res, 1, placeHolder)
+}
+
+func newAllocation(allocKey, appID, nodeID string, res *resources.Resource) *objects.Allocation {
+	return newAllocationAll(allocKey, appID, nodeID, "", res, 1, false)
+}
+
+func newAllocationAll(allocKey, appID, nodeID, taskGroup string, res *resources.Resource, prio int32, placeHolder bool) *objects.Allocation {
+	return objects.NewAllocationFromSI(&si.Allocation{
+		AllocationKey:    allocKey,
+		ApplicationID:    appID,
+		PartitionName:    "test",
+		NodeID:           nodeID,
+		ResourcePerAlloc: res.ToProto(),
+		Priority:         prio,
+		TaskGroupName:    taskGroup,
+		Placeholder:      placeHolder,
 	})
 }
 
 func newAllocationAskPreempt(allocKey, appID string, prio int32, res *resources.Resource) *objects.Allocation {
-	return objects.NewAllocationAskFromSI(&si.AllocationAsk{
-		AllocationKey: allocKey,
-		ApplicationID: appID,
-		PartitionName: "default",
-		ResourceAsk:   res.ToProto(),
-		Priority:      prio,
-		TaskGroupName: taskGroup,
-		Placeholder:   false,
+	return objects.NewAllocationFromSI(&si.Allocation{
+		AllocationKey:    allocKey,
+		ApplicationID:    appID,
+		PartitionName:    "default",
+		ResourcePerAlloc: res.ToProto(),
+		Priority:         prio,
+		TaskGroupName:    taskGroup,
+		Placeholder:      false,
 		PreemptionPolicy: &si.PreemptionPolicy{
 			AllowPreemptSelf:  true,
 			AllowPreemptOther: true,
@@ -725,10 +745,4 @@ func getMaxApplications(usage *dao.ResourceUsageDAOInfo, maxApplications map[str
 		}
 	}
 	return maxApplications
-}
-
-func markAllocated(nodeID string, alloc *objects.Allocation) *objects.Allocation {
-	alloc.SetBindTime(time.Now())
-	alloc.SetNodeID(nodeID)
-	return alloc
 }


### PR DESCRIPTION

### What is this PR for?
Handle both asks and allocations using a single method. This allows for idempotency and simplified shim interactions.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2778

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
