### PR TITLE
[YUNIKORN-2806] Fix deadlock in Preemptor.findEligiblePreemptionVictims()

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -1769,6 +1769,9 @@ func (sq *Queue) findEligiblePreemptionVictims(results map[string]*QueuePreempti
 	if sq == nil {
 		return
 	}
+	if sq.GetQueuePath() == queuePath {
+		return
+	}
 	if sq.IsLeafQueue() {
 		// leaf queue, skip queue if preemption is disabled
 		if sq.GetPreemptionPolicy() == policies.DisabledPreemptionPolicy {


### PR DESCRIPTION
### What is this PR for?
Preemptor.findEligiblePreemptionVictims() needs to disregard apps in the current queue to avoid a recursive deadlock.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2806

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
