### PR TITLE
[YUNIKORN-2794] Resource: Change SubOnlyExisting() to same signature as AddOnlyExisting()

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -363,18 +363,20 @@ func Sub(left, right *Resource) *Resource {
 	return out
 }
 
-// SubOnlyExisting subtract delta from defined resource.
-// Ignore any type not defined in the base resource (ie receiver).
-// Used as part of the headroom updates as undefined resources are unlimited
-func (r *Resource) SubOnlyExisting(delta *Resource) {
+// SubOnlyExisting subtracts delta from base resource.
+// Ignores any type not defined in the base resource (ie receiver).
+// Used as part of the headroom updates as undefined resources are unlimited.
+func SubOnlyExisting(base, delta *Resource) *Resource {
 	// check nil inputs and shortcut
-	if r == nil || delta == nil {
-		return
+	if base == nil || delta == nil {
+		return base.Clone()
 	}
 	// neither are nil, subtract the delta
-	for k := range r.Resources {
-		r.Resources[k] = subVal(r.Resources[k], delta.Resources[k])
+	result := NewResource()
+	for k := range base.Resources {
+		result.Resources[k] = subVal(base.Resources[k], delta.Resources[k])
 	}
+	return result
 }
 
 // AddOnlyExisting adds delta to base resource, ignoring any type not defined in the base resource.

--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -1066,9 +1066,9 @@ func TestSubOnlyExistingNil(t *testing.T) {
 		}
 	}()
 	var r *Resource
-	r.SubOnlyExisting(nil)
-	if r != nil {
-		t.Errorf("sub nil resources did not return nil resource: %v", r)
+	result := SubOnlyExisting(r, nil)
+	if result != nil {
+		t.Errorf("SubOnlyExisting with nil resources did not return nil resource: %v", result)
 	}
 }
 
@@ -1081,32 +1081,38 @@ func TestSubEliminateNegative(t *testing.T) {
 }
 
 func TestSubOnlyExisting(t *testing.T) {
-	// remove nil from empty resource
-	left := NewResource()
-	left.SubOnlyExisting(nil)
-	assert.Equal(t, len(left.Resources), 0, "sub nil resource did not return unchanged resource")
-
-	// remove from empty resource
-	delta := NewResourceFromMap(map[string]Quantity{"a": 5})
-	left.SubOnlyExisting(delta)
-	assert.Equal(t, len(left.Resources), 0, "sub simple resource did not return unchanged resource")
-
-	// complex case: just checking the resource merge, values check is secondary
-	left = &Resource{Resources: map[string]Quantity{"a": 0}}
-	delta = &Resource{Resources: map[string]Quantity{"a": 1, "b": 0}}
-	left.SubOnlyExisting(delta)
-	expected := &Resource{Resources: map[string]Quantity{"a": -1}}
-	assert.Equal(t, len(left.Resources), 1, "sub with 1 resource returned more or less types")
-	assert.Assert(t, Equals(left, expected), "sub failed expected %v, actual %v", expected, left)
-
-	// complex case: just checking the resource merge, values check is secondary
-	left = &Resource{Resources: map[string]Quantity{"a": 1, "b": 0}}
-	delta = &Resource{Resources: map[string]Quantity{"a": 1}}
-	left.SubOnlyExisting(delta)
-	assert.Equal(t, len(left.Resources), 2, "sub with 2 resource returned more or less types")
-
-	expected = &Resource{Resources: map[string]Quantity{"a": 0, "b": 0}}
-	assert.Assert(t, Equals(left, expected), "sub failed expected %v, actual %v", expected, left)
+	var tests = []struct {
+		caseName string
+		base     map[string]Quantity
+		delta    map[string]Quantity
+		expected map[string]Quantity
+	}{
+		{"nil resources", nil, nil, nil},
+		{"nil base", nil, map[string]Quantity{"a": 5}, nil},
+		{"nil delta", map[string]Quantity{"a": 5}, nil, map[string]Quantity{"a": 5}},
+		{"empty base", map[string]Quantity{}, map[string]Quantity{"a": 5}, map[string]Quantity{}},
+		{"single type base matched", map[string]Quantity{"a": 5}, map[string]Quantity{"a": 3, "b": 1}, map[string]Quantity{"a": 2}},
+		{"single type base unmatched", map[string]Quantity{"a": 5}, map[string]Quantity{"b": 1}, map[string]Quantity{"a": 5}},
+		{"multi type base partial match", map[string]Quantity{"a": 5, "b": 3}, map[string]Quantity{"a": 2, "c": 1}, map[string]Quantity{"a": 3, "b": 3}},
+		{"multi type base match", map[string]Quantity{"a": 5, "b": 3}, map[string]Quantity{"a": 2, "b": 1}, map[string]Quantity{"a": 3, "b": 2}},
+		{"negative result", map[string]Quantity{"a": 1}, map[string]Quantity{"a": 3}, map[string]Quantity{"a": -2}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.caseName, func(t *testing.T) {
+			var base, delta, expected *Resource
+			if tt.base != nil {
+				base = NewResourceFromMap(tt.base)
+			}
+			if tt.delta != nil {
+				delta = NewResourceFromMap(tt.delta)
+			}
+			if tt.expected != nil {
+				expected = NewResourceFromMap(tt.expected)
+			}
+			result := SubOnlyExisting(base, delta)
+			assert.Assert(t, Equals(result, expected), "incorrect result returned")
+		})
+	}
 }
 
 func TestAddOnlyExisting(t *testing.T) {

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -926,8 +926,8 @@ func (sa *Application) getOutstandingRequests(headRoom *resources.Resource, user
 				// if headroom is still enough for the resources
 				*total = append(*total, request)
 			}
-			headRoom.SubOnlyExisting(request.GetAllocatedResource())
-			userHeadRoom.SubOnlyExisting(request.GetAllocatedResource())
+			headRoom = resources.SubOnlyExisting(headRoom, request.GetAllocatedResource())
+			userHeadRoom = resources.SubOnlyExisting(userHeadRoom, request.GetAllocatedResource())
 		}
 	}
 }

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -1208,7 +1208,7 @@ func (sq *Queue) getMaxHeadRoom() *resources.Resource {
 func (sq *Queue) internalHeadRoom(parentHeadRoom *resources.Resource) *resources.Resource {
 	sq.RLock()
 	defer sq.RUnlock()
-	headRoom := sq.maxResource.Clone()
+	headRoom := sq.maxResource
 
 	// if we have no max set headroom is always the same as the parent
 	if headRoom == nil {
@@ -1217,7 +1217,7 @@ func (sq *Queue) internalHeadRoom(parentHeadRoom *resources.Resource) *resources
 
 	// calculate what we have left over after removing all allocation
 	// ignore unlimited resource types (ie the ones not defined in max)
-	headRoom.SubOnlyExisting(sq.allocatedResource)
+	headRoom = resources.SubOnlyExisting(headRoom, sq.allocatedResource)
 
 	// check the minimum of the two: parentHeadRoom is nil for root
 	if parentHeadRoom == nil {

--- a/pkg/scheduler/ugm/queue_tracker.go
+++ b/pkg/scheduler/ugm/queue_tracker.go
@@ -219,8 +219,7 @@ func (qt *QueueTracker) headroom(hierarchy []string, trackType trackingType) *re
 
 	// arrived at the leaf or on the way out: check against current max if set
 	if !resources.IsZero(qt.maxResources) {
-		headroom = qt.maxResources.Clone()
-		headroom.SubOnlyExisting(qt.resourceUsage)
+		headroom = resources.SubOnlyExisting(qt.maxResources, qt.resourceUsage)
 	}
 
 	if headroom == nil {


### PR DESCRIPTION
### What is this PR for?
Refactor the `SubOnlyExisting` function to match the signature of the `AddOnlyExisting` function.
This change will ensure both functions operate consistently by taking two resource objects and returning a new one, eliminating the need for cloning before calling the method within a locked resource object.

### What type of PR is it?
* [x] - Refactoring

### What is the Jira issue?
[YUNIKORN-2794](https://issues.apache.org/jira/browse/YUNIKORN-2794)

### How should this be tested?
This has already passed the CI tests on [my forked repo](https://github.com/blueBlue0102/yunikorn-core/actions/runs/10433583568)
