### PR TITLE
[YUNIKORN-2822] Improve resources & tracked_resources funtion's test coverage

### DIFF
--- a/pkg/common/resources/resources_test.go
+++ b/pkg/common/resources/resources_test.go
@@ -356,6 +356,13 @@ func TestMatchAnyOnlyExisting(t *testing.T) {
 			}
 		})
 	}
+
+	// case: left and right resource is same instance
+	quantity := map[string]Quantity{"first": 1}
+	left := NewResourceFromMap(quantity)
+	right := left
+	result := left.MatchAny(right)
+	assert.Assert(t, result)
 }
 
 func TestStrictlyGreaterThanOnlyExisting(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
Improve following funtion's test coverage

- resources MatchAny (both left and right resources equal instance)
- tracked_resources String
- tracked_resources Clone (tracked resource nil case)
- tracked_resources AggregateTrackedResource (resources nil case)

### What type of PR is it?
* [x] - Test

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2822
