### PR TITLE
[YUNIKORN-2452] node.go#GetAvailableResource ought to use read-lock instead of readwrite-lock 

### DIFF
--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -262,8 +262,8 @@ func (sn *Node) GetAllocatedResource() *resources.Resource {
 
 // Get the available resource on this node.
 func (sn *Node) GetAvailableResource() *resources.Resource {
-	sn.Lock()
-	defer sn.Unlock()
+	sn.RLock()
+	defer sn.RUnlock()
 	return sn.availableResource.Clone()
 }
 


### PR DESCRIPTION
### What is this PR for?
The other similar methods (`GetAllocatedResource`, `GetOccupiedResource`, and `GetCapacity`) are using read-lock, so `GetAvailableResource` ought to apply read-lock too.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2452

### How should this be tested?
It passed all CI tests locally.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
