### PR TITLE
[YUNIKORN-2859] fix: missing assertion in TestGetApplicationHandler

### DIFF
--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1741,6 +1741,9 @@ func TestGetApplicationHandler(t *testing.T) {
 	getApplication(resp, req)
 	err = json.Unmarshal(resp.outputBytes, &appsDao)
 	assert.NilError(t, err, unmarshalError)
+	assert.Equal(t, appsDao.ApplicationID, "app-1")
+	assert.Equal(t, appsDao.Partition, "default")
+	assert.Equal(t, appsDao.QueueName, "root.default")
 
 	if !appsDao.HasReserved {
 		assert.Equal(t, len(appsDao.Reservations), 0)
@@ -1781,6 +1784,15 @@ func TestGetApplicationHandler(t *testing.T) {
 	getApplication(resp4, req4)
 	err = json.Unmarshal(resp4.outputBytes, &appsDao4)
 	assert.NilError(t, err, unmarshalError)
+	assert.Assert(t, appsDao4 != nil)
+	assert.Equal(t, appsDao4.ApplicationID, "app-1")
+	assert.Equal(t, appsDao4.Partition, "default")
+	assert.Equal(t, appsDao4.QueueName, "root.default")
+	if !appsDao4.HasReserved {
+		assert.Equal(t, len(appsDao4.Reservations), 0)
+	} else {
+		assert.Check(t, len(appsDao4.Reservations) > 0, "app should have at least 1 reservation")
+	}
 
 	// test invalid queue name
 	var req5 *http.Request


### PR DESCRIPTION
### What is this PR for?
our current code cannot verify *dao.ApplicationDAOInfo, both empty and legit app can pass the test. we should fix that.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2859

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
