### PR TITLE
[UNIKORN-2862] Improve nodesorting funtion's test coverage

### DIFF
--- a/pkg/scheduler/objects/nodesorting.go
+++ b/pkg/scheduler/objects/nodesorting.go
@@ -131,10 +131,6 @@ func NewNodeSortingPolicy(policyType string, resourceWeights map[string]float64)
 		sp = fairnessNodeSortingPolicy{
 			resourceWeights: weights,
 		}
-	default:
-		sp = fairnessNodeSortingPolicy{
-			resourceWeights: weights,
-		}
 	}
 
 	log.Log(log.SchedNode).Debug("new node sorting policy added",


### PR DESCRIPTION
### What is this PR for?
Improve the following funtion's test coverage
- absResourceUsage (zero weight & shares resource value NaN case)
- cloneWeights
- ResourceWeights
- ResourceWeights
- NewNodeSortingPolicy (SortingPolicy default case unreachable case)

### What type of PR is it?
* [x] - Test

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2862
