### PR TITLE
[YUNIKORN-2450]Rename updateLowestId to updateLowestID, TestLoggerIds to TestLoggerIDs

### DIFF
--- a/pkg/events/event_ringbuffer.go
+++ b/pkg/events/event_ringbuffer.go
@@ -203,7 +203,7 @@ func newEventRingBuffer(capacity uint64) *eventRingBuffer {
 }
 
 // called from Resize(), this function updates the lowest event id available in the buffer
-func (e *eventRingBuffer) updateLowestId(beginSize, endSize uint64) {
+func (e *eventRingBuffer) updateLowestID(beginSize, endSize uint64) {
 	// if buffer size is increasing, lowestId stays the same
 	if beginSize < endSize {
 		return
@@ -238,7 +238,7 @@ func (e *eventRingBuffer) Resize(newSize uint64) {
 	endIndex := (startIndex + numEventsToCopy - 1) % e.capacity
 
 	prevLowestId := e.getLowestID()
-	e.updateLowestId(initialSize, newSize)
+	e.updateLowestID(initialSize, newSize)
 	newLowestId := e.getLowestID()
 
 	if prevLowestId != newLowestId {

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -35,7 +35,7 @@ var logFile string
 
 var iterations = 100000
 
-func TestLoggerIds(t *testing.T) {
+func TestLoggerIDs(t *testing.T) {
 	_ = Log(Test)
 
 	// validate logger count


### PR DESCRIPTION
### What is this PR for?
Rename `updateLowestId` to `updateLowestID`, `TestLoggerIds` to `TestLoggerIDs`
This is follow-up of https://issues.apache.org/jira/browse/YUNIKORN-2413

The methods are shown below.

https://github.com/apache/yunikorn-core/blob/master/pkg/events/event_ringbuffer.go#L206
https://github.com/apache/yunikorn-core/blob/master/pkg/log/logger_test.go#L38

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2450

### How should this be tested?
It should pass all unit tests
### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
