### PR TITLE
[YUNIKORN-2832] [core] Add non-Yunikorn allocation tracking logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ module github.com/apache/yunikorn-core
 go 1.21
 
 require (
-	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240827015655-68e8c6cca28a
+	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240924203603-aaf51c93d3a0
 	github.com/google/btree v1.1.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240827015655-68e8c6cca28a h1:3WRXGTvhunGBZj8AVZDxx7Bs/AXiH9mvf2jYcuDyklA=
-github.com/apache/yunikorn-scheduler-interface v0.0.0-20240827015655-68e8c6cca28a/go.mod h1:co3uU98sj1CUTPNTM13lTyi+CY0DOgDndDW2KiUjktU=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240924203603-aaf51c93d3a0 h1:/9j0YXuifvoOl4YVEbO0r+DPkkYLzaQ+/ac+xCc7SY8=
+github.com/apache/yunikorn-scheduler-interface v0.0.0-20240924203603-aaf51c93d3a0/go.mod h1:co3uU98sj1CUTPNTM13lTyi+CY0DOgDndDW2KiUjktU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -759,7 +759,7 @@ func (cc *ClusterContext) processAllocations(request *si.AllocationRequest) {
 			continue
 		}
 		// at some point, we may need to handle new requests as well
-		if newAlloc {
+		if newAlloc && !alloc.IsForeign() {
 			cc.notifyRMNewAllocation(request.RmID, alloc)
 		}
 	}

--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -156,14 +156,6 @@ func NewAllocationFromSI(alloc *si.Allocation) *Allocation {
 	}
 }
 
-// NewAllocationFromSIAllocated creates an Allocation where the "allocated" flag is always true,
-// regardless whehether the NodeID if empty or not. Used for testing.
-func NewAllocationFromSIAllocated(siAlloc *si.Allocation) *Allocation {
-	alloc := NewAllocationFromSI(siAlloc)
-	alloc.allocated = true
-	return alloc
-}
-
 // NewSIFromAllocation converts the Allocation into a SI object. This is a limited set of values that gets copied into
 // the SI. This is only used to communicate *back* to the RM. All other fields are considered incoming fields from
 // the RM into the core. The limited set of fields link the Allocation to an Application and Node.

--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -49,6 +49,8 @@ type Allocation struct {
 	originator        bool
 	tags              map[string]string
 	resKeyWithoutNode string // the reservation key without node
+	foreign           bool
+	preemptable       bool
 
 	// Mutable fields which need protection
 	allocated            bool
@@ -106,6 +108,20 @@ func NewAllocationFromSI(alloc *si.Allocation) *Allocation {
 		createTime = time.Unix(siCreationTime, 0)
 	}
 
+	foreign := false
+	preemptable := true
+	if foreignType, ok := alloc.AllocationTags[siCommon.Foreign]; ok {
+		foreign = true
+		switch foreignType {
+		case siCommon.AllocTypeStatic:
+			preemptable = false
+		case siCommon.AllocTypeDefault:
+		default:
+			log.Log(log.SchedAllocation).Warn("Foreign tag has illegal value, using default",
+				zap.String("value", foreignType))
+		}
+	}
+
 	var allocated bool
 	var nodeID string
 	var bindTime time.Time
@@ -135,7 +151,17 @@ func NewAllocationFromSI(alloc *si.Allocation) *Allocation {
 		allocated:         allocated,
 		nodeID:            nodeID,
 		bindTime:          bindTime,
+		foreign:           foreign,
+		preemptable:       preemptable,
 	}
+}
+
+// NewAllocationFromSIAllocated creates an Allocation where the "allocated" flag is always true,
+// regardless whehether the NodeID if empty or not. Used for testing.
+func NewAllocationFromSIAllocated(siAlloc *si.Allocation) *Allocation {
+	alloc := NewAllocationFromSI(siAlloc)
+	alloc.allocated = true
+	return alloc
 }
 
 // NewSIFromAllocation converts the Allocation into a SI object. This is a limited set of values that gets copied into
@@ -572,4 +598,12 @@ func (a *Allocation) setUserQuotaCheckPassed() {
 		a.userQuotaCheckFailed = false
 		a.askEvents.SendRequestFitsInUserQuota(a.allocationKey, a.applicationID, a.allocatedResource)
 	}
+}
+
+func (a *Allocation) IsForeign() bool {
+	return a.foreign
+}
+
+func (a *Allocation) IsPreemptable() bool {
+	return a.preemptable
 }

--- a/pkg/scheduler/objects/allocation_test.go
+++ b/pkg/scheduler/objects/allocation_test.go
@@ -466,3 +466,36 @@ func TestNewAllocFromSI(t *testing.T) {
 	assert.Assert(t, !alloc.IsAllowPreemptSelf(), "alloc should not have allow-preempt-self set")
 	assert.Assert(t, !alloc.IsAllowPreemptOther(), "alloc should not have allow-preempt-other set")
 }
+
+func TestNewForeignAllocFromSI(t *testing.T) {
+	res := resources.NewResourceFromMap(map[string]resources.Quantity{
+		"first": 1,
+	})
+	siAlloc := &si.Allocation{
+		AllocationKey:    "foreign-1",
+		NodeID:           "node-1",
+		ResourcePerAlloc: res.ToProto(),
+		TaskGroupName:    "",
+		AllocationTags: map[string]string{
+			siCommon.Foreign: siCommon.AllocTypeDefault,
+		},
+	}
+
+	// default
+	alloc := NewAllocationFromSI(siAlloc)
+	assert.Assert(t, alloc.IsPreemptable())
+	assert.Assert(t, alloc.IsForeign())
+	assert.Equal(t, "foreign-1", alloc.GetAllocationKey())
+	assert.Equal(t, "node-1", alloc.GetNodeID())
+	assert.Assert(t, resources.Equals(res, alloc.GetAllocatedResource()))
+
+	// static
+	siAlloc.AllocationTags[siCommon.Foreign] = siCommon.AllocTypeStatic
+	alloc = NewAllocationFromSI(siAlloc)
+	assert.Assert(t, !alloc.IsPreemptable())
+
+	// illegal value for foreign type
+	siAlloc.AllocationTags[siCommon.Foreign] = "xyz"
+	alloc = NewAllocationFromSI(siAlloc)
+	assert.Assert(t, alloc.IsPreemptable())
+}

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -260,7 +260,7 @@ func (sn *Node) GetForeignAllocations() []*Allocation {
 func (sn *Node) getAllocations(foreign bool) []*Allocation {
 	arr := make([]*Allocation, 0)
 	for _, v := range sn.allocations {
-		if (v.IsForeign() && foreign) || (!v.IsForeign() && !foreign) {
+		if v.IsForeign() == foreign {
 			arr = append(arr, v)
 		}
 	}

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -243,6 +243,31 @@ func (sn *Node) GetAllAllocations() []*Allocation {
 	return arr
 }
 
+// GetYunikornAllocations returns a copy of Yunikorn allocations on this node
+func (sn *Node) GetYunikornAllocations() []*Allocation {
+	sn.RLock()
+	defer sn.RUnlock()
+	return sn.getAllocations(false)
+}
+
+// GetForeignAllocations returns a copy of non-Yunikorn allocations on this node
+func (sn *Node) GetForeignAllocations() []*Allocation {
+	sn.RLock()
+	defer sn.RUnlock()
+	return sn.getAllocations(true)
+}
+
+func (sn *Node) getAllocations(foreign bool) []*Allocation {
+	arr := make([]*Allocation, 0)
+	for _, v := range sn.allocations {
+		if (v.IsForeign() && foreign) || (!v.IsForeign() && !foreign) {
+			arr = append(arr, v)
+		}
+	}
+
+	return arr
+}
+
 // Set the node to unschedulable.
 // This will cause the node to be skipped during the scheduling cycle.
 // Visible for testing only
@@ -312,15 +337,24 @@ func (sn *Node) FitInNode(resRequest *resources.Resource) bool {
 // is found the Allocation removed is returned. Used resources will decrease available
 // will increase as per the allocation removed.
 func (sn *Node) RemoveAllocation(allocationKey string) *Allocation {
-	defer sn.notifyListeners()
+	var alloc *Allocation
+	defer func() {
+		if alloc != nil && !alloc.IsForeign() {
+			sn.notifyListeners()
+		}
+	}()
 	sn.Lock()
 	defer sn.Unlock()
 
-	alloc := sn.allocations[allocationKey]
+	alloc = sn.allocations[allocationKey]
 	if alloc != nil {
 		delete(sn.allocations, allocationKey)
-		sn.allocatedResource.SubFrom(alloc.GetAllocatedResource())
-		sn.allocatedResource.Prune()
+		if alloc.IsForeign() {
+			sn.occupiedResource = resources.Sub(sn.occupiedResource, alloc.GetAllocatedResource())
+		} else {
+			sn.allocatedResource.SubFrom(alloc.GetAllocatedResource())
+			sn.allocatedResource.Prune()
+		}
 		sn.availableResource.AddTo(alloc.GetAllocatedResource())
 		sn.nodeEvents.SendAllocationRemovedEvent(sn.NodeID, alloc.allocationKey, alloc.GetAllocatedResource())
 		return alloc
@@ -348,9 +382,10 @@ func (sn *Node) addAllocationInternal(alloc *Allocation, force bool) bool {
 		return false
 	}
 	result := false
+	foreign := alloc.IsForeign()
 	defer func() {
 		// check result to ensure we don't notify listeners unnecessarily
-		if result {
+		if result && !foreign {
 			sn.notifyListeners()
 		}
 	}()
@@ -361,7 +396,11 @@ func (sn *Node) addAllocationInternal(alloc *Allocation, force bool) bool {
 	res := alloc.GetAllocatedResource()
 	if force || sn.availableResource.FitIn(res) {
 		sn.allocations[alloc.GetAllocationKey()] = alloc
-		sn.allocatedResource.AddTo(res)
+		if foreign {
+			sn.occupiedResource = resources.Add(sn.occupiedResource, alloc.GetAllocatedResource())
+		} else {
+			sn.allocatedResource.AddTo(res)
+		}
 		sn.availableResource.SubFrom(res)
 		sn.availableResource.Prune()
 		sn.nodeEvents.SendAllocationAddedEvent(sn.NodeID, alloc.allocationKey, res)

--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -34,20 +34,23 @@ import (
 	"github.com/apache/yunikorn-core/pkg/rmproxy"
 	schedEvt "github.com/apache/yunikorn-core/pkg/scheduler/objects/events"
 	"github.com/apache/yunikorn-core/pkg/scheduler/ugm"
+	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
 const (
-	appID0    = "app-0"
-	appID1    = "app-1"
-	appID2    = "app-2"
-	appID3    = "app-3"
-	aKey      = "alloc-1"
-	aKey2     = "alloc-2"
-	nodeID1   = "node-1"
-	nodeID2   = "node-2"
-	instType1 = "itype-1"
-	testgroup = "testgroup"
+	appID0        = "app-0"
+	appID1        = "app-1"
+	appID2        = "app-2"
+	appID3        = "app-3"
+	aKey          = "alloc-1"
+	aKey2         = "alloc-2"
+	nodeID1       = "node-1"
+	nodeID2       = "node-2"
+	instType1     = "itype-1"
+	testgroup     = "testgroup"
+	foreignAlloc1 = "foreign-1"
+	foreignAlloc2 = "foreign-2"
 )
 
 // Create the root queue, base for all testing
@@ -222,6 +225,18 @@ func newAllocation(appID, nodeID string, res *resources.Resource) *Allocation {
 // Create a new Allocation with a specified allocation key
 func newAllocationWithKey(allocKey, appID, nodeID string, res *resources.Resource) *Allocation {
 	return newAllocationAll(allocKey, appID, nodeID, "", res, false, 0)
+}
+
+// Create a new foreign Allocation with a specified allocation key
+func newForeignAllocation(allocKey, nodeID string, res *resources.Resource) *Allocation {
+	return NewAllocationFromSI(&si.Allocation{
+		AllocationKey: allocKey,
+		AllocationTags: map[string]string{
+			siCommon.Foreign: siCommon.AllocTypeDefault,
+		},
+		ResourcePerAlloc: res.ToProto(),
+		NodeID:           nodeID,
+	})
 }
 
 // Create a new Allocation with a random ask key

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1550,7 +1550,7 @@ func (pc *PartitionContext) removeAllocation(release *si.AllocationRelease) ([]*
 func (pc *PartitionContext) removeForeignAllocation(allocID string) {
 	nodeID := pc.foreignAllocs[allocID]
 	if nodeID == "" {
-		log.Log(log.SchedPartition).Warn("Tried to remove a non-existing foreign allocation",
+		log.Log(log.SchedPartition).Debug("Tried to remove a non-existing foreign allocation",
 			zap.String("allocationID", allocID),
 			zap.String("nodeID", nodeID))
 		return
@@ -1558,7 +1558,7 @@ func (pc *PartitionContext) removeForeignAllocation(allocID string) {
 	delete(pc.foreignAllocs, allocID)
 	node := pc.GetNode(nodeID)
 	if node == nil {
-		log.Log(log.SchedPartition).Warn("Node not found for foreign allocation",
+		log.Log(log.SchedPartition).Debug("Node not found for foreign allocation",
 			zap.String("allocationID", allocID),
 			zap.String("nodeID", nodeID))
 		return

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -366,15 +366,15 @@ func TestCalculateNodesResourceUsage(t *testing.T) {
 	err = partition.AddNode(node)
 	assert.NilError(t, err)
 
-	occupiedResources := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 50})
-	alloc := newAllocation("key", "appID", nodeID1, occupiedResources)
+	res := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 50})
+	alloc := newAllocation("key", "appID", nodeID1, res)
 	node.AddAllocation(alloc)
 	usageMap := partition.calculateNodesResourceUsage()
 	assert.Equal(t, node.GetAvailableResource().Resources["first"], resources.Quantity(50))
 	assert.Equal(t, usageMap["first"][4], 1)
 
-	occupiedResources = resources.NewResourceFromMap(map[string]resources.Quantity{"first": 50})
-	alloc = newAllocation("key", "appID", nodeID1, occupiedResources)
+	res = resources.NewResourceFromMap(map[string]resources.Quantity{"first": 50})
+	alloc = newAllocation("key", "appID", nodeID1, res)
 	node.AddAllocation(alloc)
 	usageMap = partition.calculateNodesResourceUsage()
 	assert.Equal(t, node.GetAvailableResource().Resources["first"], resources.Quantity(0))
@@ -4688,4 +4688,57 @@ func TestPlaceholderAllocationAndReplacementAfterRecovery(t *testing.T) {
 	assert.Assert(t, confirmed != nil, "expected to have a confirmed allocation")
 	assert.Equal(t, "real-alloc", confirmed.GetAllocationKey())
 	assert.Equal(t, "tg-1", confirmed.GetTaskGroup())
+}
+
+func TestForeignAllocation(t *testing.T) {
+	setupUGM()
+	partition, err := newBasePartition()
+	assert.NilError(t, err, "partition create failed")
+	nodeRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
+	node1 := newNodeMaxResource(nodeID1, nodeRes)
+	err = partition.AddNode(node1)
+	assert.NilError(t, err)
+
+	// error: adding request (non-allocation)
+	req := newForeignRequest("foreign-nonalloc")
+	reqCreated, allocCreated, err := partition.UpdateAllocation(req)
+	assert.Assert(t, !reqCreated)
+	assert.Assert(t, !allocCreated)
+	assert.Error(t, err, "trying to add a foreign request (non-allocation) foreign-nonalloc")
+
+	// error: empty node ID
+	req = newForeignAllocation(foreignAlloc1, "")
+	reqCreated, allocCreated, err = partition.UpdateAllocation(req)
+	assert.Assert(t, !reqCreated)
+	assert.Assert(t, !allocCreated)
+	assert.Error(t, err, "node ID is empty for allocation foreign-alloc-1")
+
+	// error: no node found
+	req = newForeignAllocation(foreignAlloc1, nodeID2)
+	reqCreated, allocCreated, err = partition.UpdateAllocation(req)
+	assert.Assert(t, !reqCreated)
+	assert.Assert(t, !allocCreated)
+	assert.Error(t, err, "failed to find node node-2 for allocation foreign-alloc-1")
+	assert.Equal(t, 0, len(partition.foreignAllocs))
+
+	// add new allocation
+	req = newForeignAllocation(foreignAlloc1, nodeID1)
+	reqCreated, allocCreated, err = partition.UpdateAllocation(req)
+	assert.Assert(t, !reqCreated)
+	assert.Assert(t, allocCreated)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(partition.foreignAllocs))
+	assert.Equal(t, nodeID1, partition.foreignAllocs[foreignAlloc1])
+	assert.Equal(t, 1, len(node1.GetAllAllocations()))
+	assert.Assert(t, node1.GetAllocation(foreignAlloc1) != nil)
+
+	// remove allocation
+	released, confirmed := partition.removeAllocation(&si.AllocationRelease{
+		AllocationKey: foreignAlloc1,
+	})
+	assert.Assert(t, released == nil)
+	assert.Assert(t, confirmed == nil)
+	assert.Equal(t, 0, len(partition.foreignAllocs))
+	assert.Equal(t, 0, len(node1.GetAllAllocations()))
+	assert.Assert(t, node1.GetAllocation(foreignAlloc1) == nil)
 }

--- a/pkg/scheduler/utilities_test.go
+++ b/pkg/scheduler/utilities_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/apache/yunikorn-core/pkg/scheduler/objects"
 	"github.com/apache/yunikorn-core/pkg/scheduler/ugm"
 	"github.com/apache/yunikorn-core/pkg/webservice/dao"
+	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
@@ -52,6 +53,7 @@ const (
 	allocKey3       = "alloc-3"
 	maxresources    = "maxresources"
 	maxapplications = "maxapplications"
+	foreignAlloc1   = "foreign-alloc-1"
 )
 
 func newBasePartitionNoRootDefault() (*PartitionContext, error) {
@@ -599,6 +601,26 @@ func newAllocationAll(allocKey, appID, nodeID, taskGroup string, res *resources.
 	})
 }
 
+func newForeignRequest(allocKey string) *objects.Allocation {
+	return objects.NewAllocationFromSI(&si.Allocation{
+		AllocationKey: allocKey,
+		AllocationTags: map[string]string{
+			siCommon.Foreign: siCommon.AllocTypeDefault,
+		},
+	})
+}
+
+func newForeignAllocation(allocKey, nodeID string) *objects.Allocation {
+	alloc := objects.NewAllocationFromSIAllocated(&si.Allocation{
+		AllocationKey: allocKey,
+		AllocationTags: map[string]string{
+			siCommon.Foreign: siCommon.AllocTypeDefault,
+		},
+		NodeID: nodeID,
+	})
+	return alloc
+}
+
 func newAllocationAskPreempt(allocKey, appID string, prio int32, res *resources.Resource) *objects.Allocation {
 	return objects.NewAllocationFromSI(&si.Allocation{
 		AllocationKey:    allocKey,
@@ -614,6 +636,7 @@ func newAllocationAskPreempt(allocKey, appID string, prio int32, res *resources.
 		},
 	})
 }
+
 func newNodeWithResources(nodeID string, max, occupied *resources.Resource) *objects.Node {
 	proto := &si.NodeInfo{
 		NodeID:              nodeID,

--- a/pkg/scheduler/utilities_test.go
+++ b/pkg/scheduler/utilities_test.go
@@ -611,12 +611,22 @@ func newForeignRequest(allocKey string) *objects.Allocation {
 }
 
 func newForeignAllocation(allocKey, nodeID string) *objects.Allocation {
-	alloc := objects.NewAllocationFromSIAllocated(&si.Allocation{
+	var alloc *objects.Allocation
+	defer func() {
+		if nodeID == "" {
+			alloc.SetNodeID("")
+		}
+	}()
+	id := nodeID
+	if nodeID == "" {
+		id = "tmp" // set a temporary value to force allocated = true
+	}
+	alloc = objects.NewAllocationFromSI(&si.Allocation{
 		AllocationKey: allocKey,
 		AllocationTags: map[string]string{
 			siCommon.Foreign: siCommon.AllocTypeDefault,
 		},
-		NodeID: nodeID,
+		NodeID: id,
 	})
 	return alloc
 }

--- a/pkg/webservice/dao/allocation_info.go
+++ b/pkg/webservice/dao/allocation_info.go
@@ -34,3 +34,12 @@ type AllocationDAOInfo struct {
 	Preempted        bool              `json:"preempted,omitempty"`
 	Originator       bool              `json:"originator,omitempty"`
 }
+
+type ForeignAllocationDAOInfo struct {
+	AllocationKey    string           `json:"allocationKey"` // no omitempty, allocation key should not be empty
+	AllocationTime   int64            `json:"allocationTime,omitempty"`
+	ResourcePerAlloc map[string]int64 `json:"resource,omitempty"`
+	Priority         string           `json:"priority,omitempty"`
+	NodeID           string           `json:"nodeId,omitempty"`
+	Preemptable      bool             `json:"preemptable,omitempty"`
+}

--- a/pkg/webservice/dao/node_info.go
+++ b/pkg/webservice/dao/node_info.go
@@ -24,17 +24,18 @@ type NodesDAOInfo struct {
 }
 
 type NodeDAOInfo struct {
-	NodeID       string               `json:"nodeID"` // no omitempty, node id should not be empty
-	HostName     string               `json:"hostName,omitempty"`
-	RackName     string               `json:"rackName,omitempty"`
-	Attributes   map[string]string    `json:"attributes,omitempty"`
-	Capacity     map[string]int64     `json:"capacity,omitempty"`
-	Allocated    map[string]int64     `json:"allocated,omitempty"`
-	Occupied     map[string]int64     `json:"occupied,omitempty"`
-	Available    map[string]int64     `json:"available,omitempty"`
-	Utilized     map[string]int64     `json:"utilized,omitempty"`
-	Allocations  []*AllocationDAOInfo `json:"allocations,omitempty"`
-	Schedulable  bool                 `json:"schedulable"` // no omitempty, a false value gives a quick way to understand whether a node is schedulable.
-	IsReserved   bool                 `json:"isReserved"`  // no omitempty, a false value gives a quick way to understand whether a node is reserved.
-	Reservations []string             `json:"reservations,omitempty"`
+	NodeID             string                      `json:"nodeID"` // no omitempty, node id should not be empty
+	HostName           string                      `json:"hostName,omitempty"`
+	RackName           string                      `json:"rackName,omitempty"`
+	Attributes         map[string]string           `json:"attributes,omitempty"`
+	Capacity           map[string]int64            `json:"capacity,omitempty"`
+	Allocated          map[string]int64            `json:"allocated,omitempty"`
+	Occupied           map[string]int64            `json:"occupied,omitempty"`
+	Available          map[string]int64            `json:"available,omitempty"`
+	Utilized           map[string]int64            `json:"utilized,omitempty"`
+	Allocations        []*AllocationDAOInfo        `json:"allocations,omitempty"`
+	ForeignAllocations []*ForeignAllocationDAOInfo `json:"foreignAllocations,omitempty"`
+	Schedulable        bool                        `json:"schedulable"` // no omitempty, a false value gives a quick way to understand whether a node is schedulable.
+	IsReserved         bool                        `json:"isReserved"`  // no omitempty, a false value gives a quick way to understand whether a node is reserved.
+	Reservations       []string                    `json:"reservations,omitempty"`
 }

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -254,10 +254,31 @@ func getAllocationDAO(alloc *objects.Allocation) *dao.AllocationDAOInfo {
 	return allocDAO
 }
 
+func getForeignAllocationDAO(alloc *objects.Allocation) *dao.ForeignAllocationDAOInfo {
+	allocTime := alloc.GetCreateTime().UnixNano()
+	allocDAO := &dao.ForeignAllocationDAOInfo{
+		AllocationKey:    alloc.GetAllocationKey(),
+		AllocationTime:   allocTime,
+		ResourcePerAlloc: alloc.GetAllocatedResource().DAOMap(),
+		Priority:         strconv.Itoa(int(alloc.GetPriority())),
+		NodeID:           alloc.GetNodeID(),
+		Preemptable:      alloc.IsPreemptable(),
+	}
+	return allocDAO
+}
+
 func getAllocationsDAO(allocations []*objects.Allocation) []*dao.AllocationDAOInfo {
 	allocsDAO := make([]*dao.AllocationDAOInfo, 0, len(allocations))
 	for _, alloc := range allocations {
 		allocsDAO = append(allocsDAO, getAllocationDAO(alloc))
+	}
+	return allocsDAO
+}
+
+func getForeignAllocationsDAO(allocations []*objects.Allocation) []*dao.ForeignAllocationDAOInfo {
+	allocsDAO := make([]*dao.ForeignAllocationDAOInfo, 0, len(allocations))
+	for _, alloc := range allocations {
+		allocsDAO = append(allocsDAO, getForeignAllocationDAO(alloc))
 	}
 	return allocsDAO
 }
@@ -375,19 +396,20 @@ func getAllocationAsksDAO(asks []*objects.Allocation) []*dao.AllocationAskDAOInf
 
 func getNodeDAO(node *objects.Node) *dao.NodeDAOInfo {
 	return &dao.NodeDAOInfo{
-		NodeID:       node.NodeID,
-		HostName:     node.Hostname,
-		RackName:     node.Rackname,
-		Attributes:   node.GetAttributes(),
-		Capacity:     node.GetCapacity().DAOMap(),
-		Occupied:     node.GetOccupiedResource().DAOMap(),
-		Allocated:    node.GetAllocatedResource().DAOMap(),
-		Available:    node.GetAvailableResource().DAOMap(),
-		Utilized:     node.GetUtilizedResource().DAOMap(),
-		Allocations:  getAllocationsDAO(node.GetAllAllocations()),
-		Schedulable:  node.IsSchedulable(),
-		IsReserved:   node.IsReserved(),
-		Reservations: node.GetReservationKeys(),
+		NodeID:             node.NodeID,
+		HostName:           node.Hostname,
+		RackName:           node.Rackname,
+		Attributes:         node.GetAttributes(),
+		Capacity:           node.GetCapacity().DAOMap(),
+		Occupied:           node.GetOccupiedResource().DAOMap(),
+		Allocated:          node.GetAllocatedResource().DAOMap(),
+		Available:          node.GetAvailableResource().DAOMap(),
+		Utilized:           node.GetUtilizedResource().DAOMap(),
+		Allocations:        getAllocationsDAO(node.GetYunikornAllocations()),
+		ForeignAllocations: getForeignAllocationsDAO(node.GetForeignAllocations()),
+		Schedulable:        node.IsSchedulable(),
+		IsReserved:         node.IsReserved(),
+		Reservations:       node.GetReservationKeys(),
 	}
 }
 


### PR DESCRIPTION
### What is this PR for?
Add foreign pod tracking logic to the scheduler core.

**Note**: existing code which updates `occupiedResources` is not removed in this PR. Removal will be done as a follow-up task.
Updating the allocation resource usage be implemented in YUNIKORN-1765.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2832

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
