### PR TITLE
[YUNIKORN-2912] CI: Remove "Restore cache failed" warning

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -66,6 +66,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: k8shim/.go_version
+          cache-dependency-path: "**/go.sum"
       - name: Set hugepage
         run: |
           echo "vm.nr_hugepages = 1024" | sudo tee -a /etc/sysctl.conf


### PR DESCRIPTION
### What is this PR for?
Add caching dependencies to remove the warning in our GitHub Actions workflows.

Ref: [actions/setup-go](https://github.com/actions/setup-go/blob/6c1fd22b67f7a7c42ad9a45c0f4197434035e429/docs/adrs/0000-caching-dependencies.md#example-of-real-use-cases)

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
[YUNIKORN-2912](https://issues.apache.org/jira/browse/YUNIKORN-2912)

### Final Result
<img width="1470" alt="截圖 2024-10-11 下午5 32 16" src="https://github.com/user-attachments/assets/1391e28e-4241-46c7-b1cf-56326387d76c">

