### PR TITLE
[YUNIKORN-2917] Add additional buckets for latency histograms

### DIFF
--- a/pkg/metrics/scheduler.go
+++ b/pkg/metrics/scheduler.go
@@ -113,8 +113,8 @@ func InitSchedulerMetrics() *SchedulerMetrics {
 			Namespace: Namespace,
 			Subsystem: SchedulerSubsystem,
 			Name:      "scheduling_latency_milliseconds",
-			Help:      "Latency of the main scheduling routine, in milliseconds.",
-			Buckets:   prometheus.ExponentialBuckets(0.0001, 10, 6), // start from 0.1ms
+			Help:      "Latency of the main scheduling routine, in seconds.",
+			Buckets:   prometheus.ExponentialBuckets(0.0001, 10, 8), // start from 0.1ms
 		},
 	)
 	s.sortingLatency = prometheus.NewHistogramVec(
@@ -122,8 +122,8 @@ func InitSchedulerMetrics() *SchedulerMetrics {
 			Namespace: Namespace,
 			Subsystem: SchedulerSubsystem,
 			Name:      "node_sorting_latency_milliseconds",
-			Help:      "Latency of all nodes sorting, in milliseconds.",
-			Buckets:   prometheus.ExponentialBuckets(0.0001, 10, 6), // start from 0.1ms
+			Help:      "Latency of all nodes sorting, in seconds.",
+			Buckets:   prometheus.ExponentialBuckets(0.0001, 10, 8), // start from 0.1ms
 		}, []string{"level"})
 
 	s.tryNodeLatency = prometheus.NewHistogram(
@@ -131,8 +131,8 @@ func InitSchedulerMetrics() *SchedulerMetrics {
 			Namespace: Namespace,
 			Subsystem: SchedulerSubsystem,
 			Name:      "trynode_latency_milliseconds",
-			Help:      "Latency of node condition checks for container allocations, such as placement constraints, in milliseconds.",
-			Buckets:   prometheus.ExponentialBuckets(0.0001, 10, 6),
+			Help:      "Latency of node condition checks for container allocations, such as placement constraints, in seconds.",
+			Buckets:   prometheus.ExponentialBuckets(0.0001, 10, 8),
 		},
 	)
 
@@ -141,8 +141,8 @@ func InitSchedulerMetrics() *SchedulerMetrics {
 			Namespace: Namespace,
 			Subsystem: SchedulerSubsystem,
 			Name:      "trypreemption_latency_milliseconds",
-			Help:      "Latency of preemption condition checks for container allocations, in milliseconds.",
-			Buckets:   prometheus.ExponentialBuckets(0.0001, 10, 6),
+			Help:      "Latency of preemption condition checks for container allocations, in seconds.",
+			Buckets:   prometheus.ExponentialBuckets(0.0001, 10, 8),
 		},
 	)
 


### PR DESCRIPTION
### What is this PR for?

Update latency histograms to allow buckets for larger (> 10s) values. Also update descriptions to reflect that despite the naming, the values are, in fact, specified in seconds.

Existing names are retained to avoid breaking backwards compatibility.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2917

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
