### PR TITLE
[YUNIKORN-2926] placeholder counters incorrect

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -1805,22 +1805,28 @@ func (sa *Application) updatePreemptedResource(info *Allocation) {
 		info.GetAllocatedResource(), info.GetBindTime())
 }
 
+// ReplaceAllocation removes the placeholder from the allocation list and replaces it with the real allocation.
+// If no replacing allocation is linked to the placeholder it will still be removed from the application.
+// Queue and Node objects are updated by the caller.
 func (sa *Application) ReplaceAllocation(allocationKey string) *Allocation {
 	sa.Lock()
 	defer sa.Unlock()
 	// remove the placeholder that was just confirmed by the shim
 	ph := sa.removeAllocationInternal(allocationKey, si.TerminationType_PLACEHOLDER_REPLACED)
-	// this has already been replaced or it is a duplicate message from the shim
-	if ph == nil || !ph.HasRelease() {
-		log.Log(log.SchedApplication).Debug("Unexpected placeholder released",
+	// this has already been replaced, or it is a duplicate message from the shim just ignore
+	if ph == nil {
+		return nil
+	}
+	// ph is the placeholder, the releases entry points to the real allocation we need to swap in
+	alloc := ph.GetRelease()
+	if alloc == nil {
+		log.Log(log.SchedApplication).Warn("Placeholder replaced without replacement allocation",
 			zap.String("applicationID", sa.ApplicationID),
 			zap.Stringer("placeholder", ph))
-		return nil
+		return ph
 	}
 	// update the replacing allocation
 	// we double linked the real and placeholder allocation
-	// ph is the placeholder, the releases entry points to the real one
-	alloc := ph.GetRelease()
 	alloc.SetPlaceholderUsed(true)
 	alloc.SetPlaceholderCreateTime(ph.GetCreateTime())
 	alloc.SetBindTime(time.Now())
@@ -1828,13 +1834,10 @@ func (sa *Application) ReplaceAllocation(allocationKey string) *Allocation {
 	// order is important: clean up the allocation after adding it to the app
 	// we need the original Replaced allocation resultType.
 	alloc.ClearRelease()
-	if sa.placeholderData != nil {
-		sa.placeholderData[ph.GetTaskGroup()].Replaced++
-	}
 	return ph
 }
 
-// Remove the Allocation from the application.
+// RemoveAllocation removes the Allocation from the application.
 // Return the allocation that was removed or nil if not found.
 func (sa *Application) RemoveAllocation(allocationKey string, releaseType si.TerminationType) *Allocation {
 	sa.Lock()
@@ -1842,8 +1845,9 @@ func (sa *Application) RemoveAllocation(allocationKey string, releaseType si.Ter
 	return sa.removeAllocationInternal(allocationKey, releaseType)
 }
 
-// Remove the Allocation from the application
-// No locking must be called while holding the lock
+// removeAllocationInternal removes the Allocation from the application.
+// Returns the allocation that was removed or nil if not found.
+// No locking must be called while holding the application lock.
 func (sa *Application) removeAllocationInternal(allocationKey string, releaseType si.TerminationType) *Allocation {
 	alloc := sa.allocations[allocationKey]
 
@@ -1858,9 +1862,14 @@ func (sa *Application) removeAllocationInternal(allocationKey string, releaseTyp
 	// update correct allocation tracker
 	if alloc.IsPlaceholder() {
 		// make sure we account for the placeholders being removed in the tracking data
-		if releaseType == si.TerminationType_STOPPED_BY_RM || releaseType == si.TerminationType_PREEMPTED_BY_SCHEDULER || releaseType == si.TerminationType_UNKNOWN_TERMINATION_TYPE {
-			if _, ok := sa.placeholderData[alloc.taskGroupName]; ok {
-				sa.placeholderData[alloc.taskGroupName].TimedOut++
+		// update based on termination type: everything is counted as a timeout except for a real replace
+		if sa.placeholderData != nil {
+			if phData, ok := sa.placeholderData[alloc.taskGroupName]; ok {
+				if releaseType == si.TerminationType_PLACEHOLDER_REPLACED {
+					phData.Replaced++
+				} else {
+					phData.TimedOut++
+				}
 			}
 		}
 		// as and when every ph gets removed (for replacement), resource usage would be reduced.
@@ -1933,7 +1942,7 @@ func (sa *Application) hasZeroAllocations() bool {
 	return resources.IsZero(sa.pending) && resources.IsZero(sa.allocatedResource)
 }
 
-// Remove all allocations from the application.
+// RemoveAllAllocations removes all allocations from the application.
 // All allocations that have been removed are returned.
 func (sa *Application) RemoveAllAllocations() []*Allocation {
 	sa.Lock()
@@ -1941,6 +1950,12 @@ func (sa *Application) RemoveAllAllocations() []*Allocation {
 
 	allocationsToRelease := make([]*Allocation, 0)
 	for _, alloc := range sa.allocations {
+		// update placeholder tracking data
+		if alloc.IsPlaceholder() && sa.placeholderData != nil {
+			if phData, ok := sa.placeholderData[alloc.taskGroupName]; ok {
+				phData.TimedOut++
+			}
+		}
 		allocationsToRelease = append(allocationsToRelease, alloc)
 		// Aggregate the resources used by this alloc to the application's user resource tracker
 		sa.trackCompletedResource(alloc)
@@ -1959,7 +1974,7 @@ func (sa *Application) RemoveAllAllocations() []*Allocation {
 	// When the resource trackers are zero we should not expect anything to come in later.
 	if resources.IsZero(sa.pending) {
 		if err := sa.HandleApplicationEvent(CompleteApplication); err != nil {
-			log.Log(log.SchedApplication).Warn("Application state not changed to Waiting while removing all allocations",
+			log.Log(log.SchedApplication).Warn("Application state not changed to Completing while removing all allocations",
 				zap.String("currentState", sa.CurrentState()),
 				zap.Error(err))
 		}

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -461,7 +461,7 @@ func TestPlaceholderDataWithPlaceholderPreemption(t *testing.T) {
 	assert.Equal(t, 7, partition.GetTotalAllocationCount(), "placeholder allocation should be counted as normal allocations on the partition")
 	assert.Equal(t, 6, partition.getPhAllocationCount(), "placeholder allocations should be counted as placeholders on the partition")
 
-	assertPlaceholderData(t, gangApp, 6, 0)
+	assertPlaceholderData(t, gangApp, 6, 0, 0)
 	partition.removeApplication(appID1)
 	assert.Equal(t, 6, partition.GetTotalAllocationCount(), "remove app did not remove allocation from count")
 	assert.Equal(t, 6, partition.getPhAllocationCount(), "placeholder allocations changed unexpectedly")
@@ -515,7 +515,7 @@ func TestPlaceholderDataWithPlaceholderPreemption(t *testing.T) {
 	assert.Assert(t, confirmed == nil, "not expecting any confirmed allocations")
 	assert.Equal(t, 5, partition.GetTotalAllocationCount(), "preempted placeholder should be removed from allocations")
 	assert.Equal(t, 5, partition.getPhAllocationCount(), "preempted placeholder should be removed")
-	assertPlaceholderData(t, gangApp, 6, 1)
+	assertPlaceholderData(t, gangApp, 6, 1, 0)
 }
 
 // test node removal effect on placeholder data
@@ -597,11 +597,11 @@ func TestPlaceholderDataWithNodeRemoval(t *testing.T) {
 	// try to allocate a last placeholder via normal allocate
 	partition.tryAllocate()
 
-	assertPlaceholderData(t, gangApp, 7, 0)
+	assertPlaceholderData(t, gangApp, 7, 0, 0)
 
 	// Remove node
 	partition.removeNode(nodeID2)
-	assertPlaceholderData(t, gangApp, 7, 4)
+	assertPlaceholderData(t, gangApp, 7, 4, 0)
 }
 
 // Test removal of placeholder has been accounted as timed out in app placeholder data
@@ -685,7 +685,7 @@ func TestPlaceholderDataWithRemoval(t *testing.T) {
 
 	// try to allocate a last placeholder via normal allocate
 	partition.tryAllocate()
-	assertPlaceholderData(t, gangApp, 7, 0)
+	assertPlaceholderData(t, gangApp, 7, 0, 0)
 
 	// release allocation: do what the context would do after the shim processing
 	release := &si.AllocationRelease{
@@ -696,16 +696,17 @@ func TestPlaceholderDataWithRemoval(t *testing.T) {
 	}
 	releases, _ := partition.removeAllocation(release)
 	assert.Equal(t, 1, len(releases), "unexpected number of allocations released")
-	assertPlaceholderData(t, gangApp, 7, 1)
+	assertPlaceholderData(t, gangApp, 7, 1, 0)
 }
 
 // check PlaceHolderData
-func assertPlaceholderData(t *testing.T, gangApp *objects.Application, count int64, timedout int64) {
+func assertPlaceholderData(t *testing.T, gangApp *objects.Application, count, timedout, replaced int64) {
 	assert.Equal(t, len(gangApp.GetAllPlaceholderData()), 1)
-	assert.Equal(t, gangApp.GetAllPlaceholderData()[0].TaskGroupName, taskGroup)
-	assert.Equal(t, gangApp.GetAllPlaceholderData()[0].Count, count)
-	assert.Equal(t, gangApp.GetAllPlaceholderData()[0].Replaced, int64(0))
-	assert.Equal(t, gangApp.GetAllPlaceholderData()[0].TimedOut, timedout)
+	phData := gangApp.GetAllPlaceholderData()[0]
+	assert.Equal(t, phData.TaskGroupName, taskGroup)
+	assert.Equal(t, phData.Count, count, "placeholder count does not match")
+	assert.Equal(t, phData.Replaced, replaced, "replaced count does not match")
+	assert.Equal(t, phData.TimedOut, timedout, "timedout count does not match")
 }
 
 // test with a replacement of a placeholder: placeholder on the removed node, real on the 2nd node
@@ -2983,6 +2984,8 @@ func TestPlaceholderSmallerThanReal(t *testing.T) {
 	ask := newAllocationAskTG(phID, appID1, taskGroup, phRes, true)
 	err = app.AddAllocationAsk(ask)
 	assert.NilError(t, err, "failed to add placeholder ask ph-1 to app")
+	assertPlaceholderData(t, app, 1, 0, 0)
+
 	// try to allocate a placeholder via normal allocate
 	result := partition.tryAllocate()
 	if result == nil || result.Request == nil {
@@ -3016,6 +3019,7 @@ func TestPlaceholderSmallerThanReal(t *testing.T) {
 
 	released, _ := partition.removeAllocation(release)
 	assert.Equal(t, 0, partition.getPhAllocationCount(), "ph should not be registered")
+	assertPlaceholderData(t, app, 1, 1, 0)
 
 	assert.Equal(t, 0, len(released), "expected no releases")
 	assert.Assert(t, resources.IsZero(node.GetAllocatedResource()), "nothing should be allocated on node")
@@ -3042,7 +3046,7 @@ func TestPlaceholderSmallerMulti(t *testing.T) {
 	app := newApplicationTG(appID1, "default", "root.default", tgRes)
 	err = partition.AddApplication(app)
 	assert.NilError(t, err, "app-1 should have been added to the partition")
-	phs := make(map[string]*objects.Allocation, 5)
+	phs := make(map[string]*objects.Allocation, phCount)
 	for i := 0; i < phCount; i++ {
 		// add an ask for a placeholder and allocate
 		id := "ph-" + strconv.Itoa(i)
@@ -3057,6 +3061,8 @@ func TestPlaceholderSmallerMulti(t *testing.T) {
 		assert.Equal(t, id, result.Request.GetAllocationKey(), "expected allocation of %s to be returned", id)
 		phs[id] = result.Request
 	}
+	assertPlaceholderData(t, app, int64(phCount), 0, 0)
+
 	assert.Assert(t, resources.Equals(tgRes, app.GetQueue().GetAllocatedResource()), "all placeholders should be allocated on queue")
 	assert.Assert(t, resources.Equals(tgRes, node.GetAllocatedResource()), "all placeholders should be allocated on node")
 	assert.Equal(t, phCount, partition.GetTotalAllocationCount(), "placeholder allocation should be counted as normal allocations on the partition")
@@ -3088,6 +3094,9 @@ func TestPlaceholderSmallerMulti(t *testing.T) {
 		released, _ := partition.removeAllocation(release)
 		assert.Equal(t, 0, len(released), "expected no releases")
 	}
+	// check the tracking details for the placeholders
+	assertPlaceholderData(t, app, int64(phCount), int64(phCount), 0)
+
 	assert.Assert(t, resources.IsZero(node.GetAllocatedResource()), "nothing should be allocated on node")
 	assert.Assert(t, resources.IsZero(app.GetQueue().GetAllocatedResource()), "nothing should be allocated on queue")
 	assert.Equal(t, 0, partition.GetTotalAllocationCount(), "no allocation should be registered on the partition")
@@ -3123,6 +3132,8 @@ func TestPlaceholderBiggerThanReal(t *testing.T) {
 	if result == nil || result.Request == nil {
 		t.Fatal("expected placeholder ph-1 to be allocated")
 	}
+	assertPlaceholderData(t, app, 1, 0, 0)
+
 	assert.Equal(t, phID, result.Request.GetAllocationKey(), "expected allocation of ph-1 to be returned")
 	assert.Assert(t, resources.Equals(phRes, app.GetQueue().GetAllocatedResource()), "placeholder size should be allocated on queue")
 	assert.Assert(t, resources.Equals(phRes, node.GetAllocatedResource()), "placeholder size should be allocated on node")
@@ -3158,6 +3169,8 @@ func TestPlaceholderBiggerThanReal(t *testing.T) {
 	if confirmed == nil {
 		t.Fatal("one allocation should be confirmed")
 	}
+	assertPlaceholderData(t, app, 1, 0, 1)
+
 	assert.Equal(t, 1, partition.GetTotalAllocationCount(), "real allocation should be registered on the partition")
 	assert.Equal(t, 0, partition.getPhAllocationCount(), "no placeholder allocation should be registered")
 	assert.Assert(t, resources.Equals(smallRes, app.GetQueue().GetAllocatedResource()), "real size should be allocated on queue")
@@ -3184,6 +3197,7 @@ func TestPlaceholderMatch(t *testing.T) {
 	ask := newAllocationAskTG(phID, appID1, taskGroup, phRes, true)
 	err = app.AddAllocationAsk(ask)
 	assert.NilError(t, err, "failed to add placeholder ask ph-1 to app")
+	assertPlaceholderData(t, app, 1, 0, 0)
 	// try to allocate a placeholder via normal allocate
 	result := partition.tryAllocate()
 	if result == nil || result.Request == nil {
@@ -3191,7 +3205,6 @@ func TestPlaceholderMatch(t *testing.T) {
 	}
 	phAllocationKey := result.Request.GetAllocationKey()
 	assert.Equal(t, phID, phAllocationKey, "expected allocation of ph-1 to be returned")
-	assert.Equal(t, 1, len(app.GetAllPlaceholderData()), "placeholder data should be created on allocate")
 	assert.Equal(t, 1, partition.GetTotalAllocationCount(), "placeholder allocation should be registered as allocation")
 	assert.Equal(t, 1, partition.getPhAllocationCount(), "placeholder allocation should be registered")
 	assertLimits(t, getTestUserGroup(), phRes)
@@ -3207,9 +3220,7 @@ func TestPlaceholderMatch(t *testing.T) {
 	assert.Equal(t, 2, partition.GetTotalAllocationCount(), "allocations should be registered: ph + normal")
 	assert.Equal(t, 1, partition.getPhAllocationCount(), "placeholder allocation should be registered")
 	assert.Equal(t, allocKey, result.Request.GetAllocationKey(), "expected allocation of alloc-1 to be returned")
-	assert.Equal(t, 1, len(app.GetAllPlaceholderData()), "placeholder data should not be updated")
-	assert.Equal(t, int64(1), app.GetAllPlaceholderData()[0].Count, "placeholder data should show 1 available placeholder")
-	assert.Equal(t, int64(0), app.GetAllPlaceholderData()[0].Replaced, "placeholder data should show no replacements")
+	assertPlaceholderData(t, app, 1, 0, 0)
 	assertLimits(t, getTestUserGroup(), resources.Multiply(phRes, 2))
 
 	// add a new ask the same task group as the placeholder
@@ -3220,9 +3231,7 @@ func TestPlaceholderMatch(t *testing.T) {
 	if result != nil {
 		t.Fatal("expected ask not to be allocated (matched task group)")
 	}
-	assert.Equal(t, 1, len(app.GetAllPlaceholderData()), "placeholder data should not be updated")
-	assert.Equal(t, int64(1), app.GetAllPlaceholderData()[0].Count, "placeholder data should show 1 available placeholder")
-	assert.Equal(t, int64(0), app.GetAllPlaceholderData()[0].Replaced, "placeholder data should show no replacements")
+	assertPlaceholderData(t, app, 1, 0, 0)
 	assertLimits(t, getTestUserGroup(), resources.Multiply(phRes, 2))
 
 	// replace the placeholder should work
@@ -3233,8 +3242,7 @@ func TestPlaceholderMatch(t *testing.T) {
 	assert.Equal(t, 2, partition.GetTotalAllocationCount(), "allocations should be registered: ph + normal")
 	assert.Equal(t, 1, partition.getPhAllocationCount(), "placeholder allocation should be registered")
 	assert.Equal(t, allocKey2, result.Request.GetAllocationKey(), "expected allocation of alloc-2 to be returned")
-	assert.Equal(t, int64(1), app.GetAllPlaceholderData()[0].Count, "placeholder data should show 1 available placeholder")
-	assert.Equal(t, int64(0), app.GetAllPlaceholderData()[0].Replaced, "placeholder data should show no replacements yet")
+	assertPlaceholderData(t, app, 1, 0, 0)
 
 	// release placeholder: do what the context would do after the shim processing
 	release := &si.AllocationRelease{
@@ -3248,9 +3256,9 @@ func TestPlaceholderMatch(t *testing.T) {
 	if confirmed == nil {
 		t.Fatal("confirmed allocation should not be nil")
 	}
+	assertPlaceholderData(t, app, 1, 0, 1)
 	assert.Equal(t, 2, partition.GetTotalAllocationCount(), "two allocations should be registered")
 	assert.Equal(t, 0, partition.getPhAllocationCount(), "no placeholder allocation should be registered")
-	assert.Equal(t, int64(1), app.GetAllPlaceholderData()[0].Replaced, "placeholder data should show the replacement")
 	assertLimits(t, getTestUserGroup(), resources.Multiply(phRes, 2))
 
 	// add a new ask the same task group as the placeholder
@@ -3265,6 +3273,7 @@ func TestPlaceholderMatch(t *testing.T) {
 	assertLimits(t, getTestUserGroup(), resources.Multiply(phRes, 3))
 	assert.Equal(t, 3, partition.GetTotalAllocationCount(), "three allocations should be registered")
 	assert.Equal(t, 0, partition.getPhAllocationCount(), "no placeholder allocation should be registered")
+	assertPlaceholderData(t, app, 1, 0, 1)
 }
 
 func TestPreemptedPlaceholderSkip(t *testing.T) {
@@ -3285,6 +3294,7 @@ func TestPreemptedPlaceholderSkip(t *testing.T) {
 	ask := newAllocationAskTG(phID, appID1, taskGroup, phRes, true)
 	err = app.AddAllocationAsk(ask)
 	assert.NilError(t, err, "failed to add placeholder ask ph-1 to app")
+	assertPlaceholderData(t, app, 1, 0, 0)
 	// try to allocate a placeholder via normal allocate
 	result := partition.tryAllocate()
 	if result == nil || result.Request == nil {
@@ -3293,7 +3303,6 @@ func TestPreemptedPlaceholderSkip(t *testing.T) {
 	ph := result.Request
 	phAllocationKey := result.Request.GetAllocationKey()
 	assert.Equal(t, phID, phAllocationKey, "expected allocation of ph-1 to be returned")
-	assert.Equal(t, 1, len(app.GetAllPlaceholderData()), "placeholder data should be created on allocate")
 	assert.Equal(t, 1, partition.GetTotalAllocationCount(), "placeholder allocation should be registered as allocation")
 	assert.Equal(t, 1, partition.getPhAllocationCount(), "placeholder allocation should be registered")
 
@@ -3327,7 +3336,8 @@ func TestPreemptedPlaceholderSkip(t *testing.T) {
 	if confirmed != nil {
 		t.Fatal("confirmed allocation should be nil")
 	}
-	assert.Equal(t, int64(1), app.GetAllPlaceholderData()[0].TimedOut, "placeholder data should show the preemption")
+	// preemption shows as timedout
+	assertPlaceholderData(t, app, 1, 1, 0)
 	assert.Equal(t, 0, partition.GetTotalAllocationCount(), "no allocation should be registered")
 	assert.Equal(t, 0, partition.getPhAllocationCount(), "no placeholder allocation should be registered")
 
@@ -3337,10 +3347,8 @@ func TestPreemptedPlaceholderSkip(t *testing.T) {
 		t.Fatal("expected ask to be allocated (no placeholder left)")
 	}
 	assert.Equal(t, allocKey, result.Request.GetAllocationKey(), "expected allocation of alloc-1 to be returned")
-	assert.Equal(t, 1, len(app.GetAllPlaceholderData()), "placeholder data should not be updated")
-	assert.Equal(t, int64(1), app.GetAllPlaceholderData()[0].Count, "placeholder data should show 1 available placeholder")
-	assert.Equal(t, int64(0), app.GetAllPlaceholderData()[0].Replaced, "placeholder data should show no replacements")
-	assert.Equal(t, int64(1), app.GetAllPlaceholderData()[0].TimedOut, "placeholder data should show the preemption")
+	// no change is the placeholder tracking
+	assertPlaceholderData(t, app, 1, 1, 0)
 	assert.Equal(t, 1, partition.GetTotalAllocationCount(), "allocation should be registered as allocation")
 	assert.Equal(t, 0, partition.getPhAllocationCount(), "placeholder allocation should be registered")
 }
@@ -3373,6 +3381,8 @@ func TestTryPlaceholderAllocate(t *testing.T) {
 	ask := newAllocationAskTG(phID, appID1, taskGroup, res, true)
 	err = app.AddAllocationAsk(ask)
 	assert.NilError(t, err, "failed to add placeholder ask ph-1 to app")
+	assertPlaceholderData(t, app, 1, 0, 0)
+
 	// try to allocate placeholder should just return
 	result := partition.tryPlaceholderAllocate()
 	if result != nil {
@@ -3397,6 +3407,8 @@ func TestTryPlaceholderAllocate(t *testing.T) {
 	ask = newAllocationAskTG("ph-2", appID1, taskGroup, res, true)
 	err = app.AddAllocationAsk(ask)
 	assert.NilError(t, err, "failed to add placeholder ask ph-2 to app")
+	assertPlaceholderData(t, app, 2, 0, 0)
+
 	// try to allocate placeholder should just return
 	result = partition.tryPlaceholderAllocate()
 	if result != nil {
@@ -3465,6 +3477,8 @@ func TestTryPlaceholderAllocate(t *testing.T) {
 	if !resources.Equals(app.GetAllocatedResource(), res) {
 		t.Fatalf("allocations not updated as expected: got %s, expected %s", app.GetAllocatedResource(), res)
 	}
+	assertPlaceholderData(t, app, 2, 0, 1)
+
 	assertLimits(t, getTestUserGroup(), resources.Multiply(res, 2))
 }
 
@@ -3500,6 +3514,7 @@ func TestFailReplacePlaceholder(t *testing.T) {
 	ask := newAllocationAskTG(phID, appID1, taskGroup, res, true)
 	err = app.AddAllocationAsk(ask)
 	assert.NilError(t, err, "failed to add placeholder ask ph-1 to app")
+	assertPlaceholderData(t, app, 1, 0, 0)
 
 	// try to allocate a placeholder via normal allocate
 	result := partition.tryAllocate()
@@ -3561,6 +3576,7 @@ func TestFailReplacePlaceholder(t *testing.T) {
 	assert.Assert(t, resources.IsZero(node.GetAllocatedResource()), "node-1 allocated resources should be zero")
 	assert.Assert(t, resources.Equals(node2.GetAllocatedResource(), res), "node-2 allocations not set as expected: got %s, expected %s", node2.GetAllocatedResource(), res)
 	assert.Assert(t, !app.IsCompleting(), "application with allocation should not be in COMPLETING state")
+	assertPlaceholderData(t, app, 1, 0, 1)
 	assertLimits(t, getTestUserGroup(), res)
 }
 


### PR DESCRIPTION
### What is this PR for?
Placeholder tracking data is maintained inside the application for scheduling. If the placeholder is released we update the counters in the tracking data. We have cases in which we do not do that correctly:
* placeholders are smaller than the real allocation
* placeholder does not have an allocation to replace
* all allocations are removed from an application

Tests updated to check all the counters inside the placeholder data for consistency.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
* [YUNIKORN-2926](https://issues.apache.org/jira/browse/YUNIKORN-2926)

### How should this be tested?
New unit tests added
e2e test with incorrectly sized placeholders is needed
