### PR TITLE
[YUNIKORN-2972] Remove internal object from user and group REST info

### DIFF
--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -284,19 +284,23 @@ func getUserGroup(userName string, groupNameList []string) security.UserGroup {
 }
 
 func assertUserGroupResource(t *testing.T, userGroup security.UserGroup, expected *resources.Resource) {
-	ugm := ugm.GetUserManager()
-	userResource := ugm.GetUserResources(userGroup)
-	groupResource := ugm.GetGroupResources(userGroup.Groups[0])
-	assert.Equal(t, resources.Equals(userResource, expected), true)
-	assert.Equal(t, resources.Equals(groupResource, nil), true)
+	assertUserResourcesAndGroupResources(t, userGroup, expected, nil, 0)
 }
 
 func assertUserResourcesAndGroupResources(t *testing.T, userGroup security.UserGroup, expectedUserResources *resources.Resource, expectedGroupResources *resources.Resource, i int) {
-	ugm := ugm.GetUserManager()
-	userResource := ugm.GetUserResources(userGroup)
-	groupResource := ugm.GetGroupResources(userGroup.Groups[i])
-	assert.Equal(t, resources.Equals(userResource, expectedUserResources), true)
-	assert.Equal(t, resources.Equals(groupResource, expectedGroupResources), true)
+	m := ugm.GetUserManager()
+	userResource := m.GetUserResources(userGroup.User)
+	if expectedUserResources == nil {
+		assert.Assert(t, userResource.IsEmpty(), "expected empty resource in user tracker")
+	} else {
+		assert.Assert(t, resources.Equals(userResource, expectedUserResources), "user value '%s' not equal to expected '%s'", userResource.String(), expectedUserResources.String())
+	}
+	groupResource := m.GetGroupResources(userGroup.Groups[i])
+	if expectedGroupResources == nil {
+		assert.Assert(t, groupResource.IsEmpty(), "expected empty resource in group tracker")
+	} else {
+		assert.Assert(t, resources.Equals(groupResource, expectedGroupResources), "group value '%s' not equal to expected '%s'", groupResource.String(), expectedGroupResources.String())
+	}
 }
 
 func assertAllocationLog(t *testing.T, ask *Allocation) {

--- a/pkg/scheduler/ugm/group_tracker_test.go
+++ b/pkg/scheduler/ugm/group_tracker_test.go
@@ -69,8 +69,8 @@ func TestGTIncreaseTrackedResource(t *testing.T) {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage3)
 	}
 	groupTracker.increaseTrackedResource(path4, TestApp4, usage4, user.User)
-	actualResources := getGroupResource(groupTracker)
 
+	actualResources := groupTracker.queueTracker.getUsedResources()
 	assert.Equal(t, "map[mem:80000000 vcore:80000]", actualResources["root"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:80000000 vcore:80000]", actualResources["root.parent"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:40000000 vcore:40000]", actualResources["root.parent.child1"].String(), "wrong resource")
@@ -104,9 +104,9 @@ func TestGTDecreaseTrackedResource(t *testing.T) {
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, usage2)
 	}
 	groupTracker.increaseTrackedResource(path2, TestApp2, usage2, user.User)
-	actualResources := getGroupResource(groupTracker)
 
 	assert.Equal(t, 2, len(groupTracker.getTrackedApplications()))
+	actualResources := groupTracker.getUsedResources()
 	assert.Equal(t, "map[mem:90000000 vcore:90000]", actualResources["root"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:90000000 vcore:90000]", actualResources["root.parent"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:70000000 vcore:70000]", actualResources["root.parent.child1"].String(), "wrong resource")
@@ -126,8 +126,7 @@ func TestGTDecreaseTrackedResource(t *testing.T) {
 	removeQT = groupTracker.decreaseTrackedResource(path2, TestApp2, usage3, false)
 	assert.Equal(t, removeQT, false, "wrong remove queue tracker value")
 
-	actualResources1 := getGroupResource(groupTracker)
-
+	actualResources1 := groupTracker.getUsedResources()
 	assert.Equal(t, "map[mem:70000000 vcore:70000]", actualResources1["root"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:70000000 vcore:70000]", actualResources1["root.parent"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:60000000 vcore:60000]", actualResources1["root.parent.child1"].String(), "wrong resource")
@@ -281,10 +280,4 @@ func TestGTCanRunApp(t *testing.T) {
 	}), user.User)
 	assert.Assert(t, groupTracker.canRunApp(hierarchy1, TestApp1))
 	assert.Assert(t, !groupTracker.canRunApp(hierarchy1, TestApp2))
-}
-
-func getGroupResource(gt *GroupTracker) map[string]*resources.Resource {
-	resources := make(map[string]*resources.Resource)
-	usage := gt.GetGroupResourceUsageDAOInfo()
-	return internalGetResource(usage.Queues, resources)
 }

--- a/pkg/scheduler/ugm/user_tracker_test.go
+++ b/pkg/scheduler/ugm/user_tracker_test.go
@@ -99,7 +99,7 @@ func TestIncreaseTrackedResource(t *testing.T) {
 	userTracker.increaseTrackedResource(path4, TestApp4, usage4)
 	userTracker.setGroupForApp(TestApp4, groupTracker)
 
-	actualResources := getUserResource(userTracker)
+	actualResources := userTracker.getUsedResources()
 	assert.Equal(t, "map[mem:80000000 vcore:80000]", actualResources["root"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:80000000 vcore:80000]", actualResources["root.parent"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:40000000 vcore:40000]", actualResources["root.parent.child1"].String(), "wrong resource")
@@ -134,8 +134,8 @@ func TestDecreaseTrackedResource(t *testing.T) {
 	}
 	userTracker.increaseTrackedResource(path2, TestApp2, usage2)
 	userTracker.setGroupForApp(TestApp2, groupTracker)
-	actualResources := getUserResource(userTracker)
 
+	actualResources := userTracker.getUsedResources()
 	assert.Equal(t, 2, len(userTracker.getTrackedApplications()))
 	assert.Equal(t, "map[mem:90000000 vcore:90000]", actualResources["root"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:90000000 vcore:90000]", actualResources["root.parent"].String(), "wrong resource")
@@ -153,9 +153,9 @@ func TestDecreaseTrackedResource(t *testing.T) {
 	assert.Equal(t, si.EventRecord_REMOVE, eventSystem.Events[0].EventChangeType)
 
 	removeQT = userTracker.decreaseTrackedResource(path2, TestApp2, usage3, false)
-	actualResources1 := getUserResource(userTracker)
-
 	assert.Equal(t, removeQT, false, "wrong remove queue tracker value")
+
+	actualResources1 := userTracker.getUsedResources()
 	assert.Equal(t, "map[mem:70000000 vcore:70000]", actualResources1["root"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:70000000 vcore:70000]", actualResources1["root.parent"].String(), "wrong resource")
 	assert.Equal(t, "map[mem:60000000 vcore:60000]", actualResources1["root.parent.child1"].String(), "wrong resource")
@@ -288,10 +288,4 @@ func TestUTCanRunApp(t *testing.T) {
 	}))
 	assert.Assert(t, userTracker.canRunApp(hierarchy1, TestApp1))
 	assert.Assert(t, !userTracker.canRunApp(hierarchy1, TestApp2))
-}
-
-func getUserResource(ut *UserTracker) map[string]*resources.Resource {
-	resources := make(map[string]*resources.Resource)
-	usage := ut.GetUserResourceUsageDAOInfo()
-	return internalGetResource(usage.Queues, resources)
 }

--- a/pkg/scheduler/ugm/utilities_test.go
+++ b/pkg/scheduler/ugm/utilities_test.go
@@ -22,20 +22,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
-
-	"github.com/apache/yunikorn-core/pkg/common/resources"
-	"github.com/apache/yunikorn-core/pkg/webservice/dao"
 )
-
-func internalGetResource(usage *dao.ResourceUsageDAOInfo, resources map[string]*resources.Resource) map[string]*resources.Resource {
-	resources[usage.QueuePath] = usage.ResourceUsage
-	if len(usage.Children) > 0 {
-		for _, resourceUsage := range usage.Children {
-			internalGetResource(resourceUsage, resources)
-		}
-	}
-	return resources
-}
 
 func TestGetParentQueuePath(t *testing.T) {
 	assert.Equal(t, getParentPath(""), "")

--- a/pkg/webservice/dao/ugm_info.go
+++ b/pkg/webservice/dao/ugm_info.go
@@ -18,8 +18,6 @@
 
 package dao
 
-import "github.com/apache/yunikorn-core/pkg/common/resources"
-
 type UserResourceUsageDAOInfo struct {
 	UserName string                `json:"userName"` // no omitempty, user name should not be empty
 	Groups   map[string]string     `json:"groups,omitempty"`
@@ -34,9 +32,9 @@ type GroupResourceUsageDAOInfo struct {
 
 type ResourceUsageDAOInfo struct {
 	QueuePath           string                  `json:"queuePath"` // no omitempty, queue path should not be empty
-	ResourceUsage       *resources.Resource     `json:"resourceUsage,omitempty"`
+	ResourceUsage       map[string]int64        `json:"resourceUsage,omitempty"`
 	RunningApplications []string                `json:"runningApplications,omitempty"`
-	MaxResources        *resources.Resource     `json:"maxResources,omitempty"`
+	MaxResources        map[string]int64        `json:"maxResources,omitempty"`
 	MaxApplications     uint64                  `json:"maxApplications,omitempty"`
 	Children            []*ResourceUsageDAOInfo `json:"children,omitempty"`
 }

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -1165,10 +1165,10 @@ func getMetrics(w http.ResponseWriter, r *http.Request) {
 func getUsersResourceUsage(w http.ResponseWriter, _ *http.Request) {
 	writeHeaders(w)
 	userManager := ugm.GetUserManager()
-	usersResources := userManager.GetUsersResources()
-	result := make([]*dao.UserResourceUsageDAOInfo, len(usersResources))
-	for i, tracker := range usersResources {
-		result[i] = tracker.GetUserResourceUsageDAOInfo()
+	trackers := userManager.GetUserTrackers()
+	result := make([]*dao.UserResourceUsageDAOInfo, len(trackers))
+	for i, tracker := range trackers {
+		result[i] = tracker.GetResourceUsageDAOInfo()
 	}
 	if err := json.NewEncoder(w).Encode(result); err != nil {
 		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
@@ -1197,8 +1197,8 @@ func getUserResourceUsage(w http.ResponseWriter, r *http.Request) {
 		buildJSONErrorResponse(w, UserDoesNotExists, http.StatusNotFound)
 		return
 	}
-	var result = userTracker.GetUserResourceUsageDAOInfo()
-	if err := json.NewEncoder(w).Encode(result); err != nil {
+	result := userTracker.GetResourceUsageDAOInfo()
+	if err = json.NewEncoder(w).Encode(result); err != nil {
 		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -1206,10 +1206,10 @@ func getUserResourceUsage(w http.ResponseWriter, r *http.Request) {
 func getGroupsResourceUsage(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(w)
 	userManager := ugm.GetUserManager()
-	groupsResources := userManager.GetGroupsResources()
-	result := make([]*dao.GroupResourceUsageDAOInfo, len(groupsResources))
-	for i, tracker := range groupsResources {
-		result[i] = tracker.GetGroupResourceUsageDAOInfo()
+	trackers := userManager.GetGroupTrackers()
+	result := make([]*dao.GroupResourceUsageDAOInfo, len(trackers))
+	for i, tracker := range trackers {
+		result[i] = tracker.GetResourceUsageDAOInfo()
 	}
 	if err := json.NewEncoder(w).Encode(result); err != nil {
 		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
@@ -1238,8 +1238,8 @@ func getGroupResourceUsage(w http.ResponseWriter, r *http.Request) {
 		buildJSONErrorResponse(w, GroupDoesNotExists, http.StatusNotFound)
 		return
 	}
-	var result = groupTracker.GetGroupResourceUsageDAOInfo()
-	if err := json.NewEncoder(w).Encode(result); err != nil {
+	result := groupTracker.GetResourceUsageDAOInfo()
+	if err = json.NewEncoder(w).Encode(result); err != nil {
 		buildJSONErrorResponse(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -2149,12 +2149,12 @@ func TestSpecificUserResourceUsage(t *testing.T) {
 			Groups:   map[string]string{"app-1": "testgroup"},
 			Queues: &dao.ResourceUsageDAOInfo{
 				QueuePath:           "root",
-				ResourceUsage:       resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1}),
+				ResourceUsage:       map[string]int64{"vcore": 1},
 				RunningApplications: []string{"app-1"},
 				Children: []*dao.ResourceUsageDAOInfo{
 					{
 						QueuePath:           "root.default",
-						ResourceUsage:       resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1}),
+						ResourceUsage:       map[string]int64{"vcore": 1},
 						RunningApplications: []string{"app-1"},
 					},
 				},
@@ -2220,13 +2220,13 @@ func TestSpecificGroupResourceUsage(t *testing.T) {
 			Applications: []string{"app-1"},
 			Queues: &dao.ResourceUsageDAOInfo{
 				QueuePath:           "root",
-				ResourceUsage:       resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1}),
+				ResourceUsage:       map[string]int64{"vcore": 1},
 				RunningApplications: []string{"app-1"},
 				Children: []*dao.ResourceUsageDAOInfo{
 					{
 						QueuePath:           "root.default",
-						ResourceUsage:       resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1}),
-						MaxResources:        resources.NewResourceFromMap(map[string]resources.Quantity{"cpu": 200}),
+						ResourceUsage:       map[string]int64{"vcore": 1},
+						MaxResources:        map[string]int64{"cpu": 200},
 						RunningApplications: []string{"app-1"},
 					},
 				},
@@ -2283,8 +2283,8 @@ func TestUsersAndGroupsResourceUsage(t *testing.T) {
 	getUsersResourceUsage(resp, req)
 	err = json.Unmarshal(resp.outputBytes, &usersResourceUsageDao)
 	assert.NilError(t, err, unmarshalError)
-	assert.Equal(t, usersResourceUsageDao[0].Queues.ResourceUsage.String(),
-		resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1}).String())
+	assert.DeepEqual(t, usersResourceUsageDao[0].Queues.ResourceUsage,
+		resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1}).DAOMap())
 
 	// Assert existing users
 	assert.Equal(t, len(usersResourceUsageDao), 1)
@@ -2298,8 +2298,8 @@ func TestUsersAndGroupsResourceUsage(t *testing.T) {
 	getGroupsResourceUsage(resp, req)
 	err = json.Unmarshal(resp.outputBytes, &groupsResourceUsageDao)
 	assert.NilError(t, err, unmarshalError)
-	assert.Equal(t, groupsResourceUsageDao[0].Queues.ResourceUsage.String(),
-		resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1}).String())
+	assert.DeepEqual(t, groupsResourceUsageDao[0].Queues.ResourceUsage,
+		resources.NewResourceFromMap(map[string]resources.Quantity{siCommon.CPU: 1}).DAOMap())
 
 	// Assert existing groups
 	assert.Equal(t, len(groupsResourceUsageDao), 1)


### PR DESCRIPTION
### What is this PR for?
Remove the Resource object from the REST response for the user and group trackers. Removed the usage of the DAO objects in the internal unit tests. The unit tests use new functions which directly expose the same structures without using the DAO.

Cleanup:
- remove export from internal functions (UserTracker, GroupTracker)
- renamed functions to match their results (Manager)
- update handler to call renamed functions in Manager
- reimplemented test functions to not use DAO objects (Manager, UserTracker, GroupTracker, QueueTracker)
- assert function changes to use new functions removing DAO usage (scheduler/utilites_test, scheduler/objects/utilites_test)

### What type of PR is it?
* [X] - Bug Fix
* [X] - Improvement
* [X] - Refactoring

### What is the Jira issue?
* [YUNIKORN-2972](https://issues.apache.org/jira/browse/YUNIKORN-2972)

### How should this be tested?
Existing unit test cover the code

NOTE: this will break e2e test, the `user_group_limit_test` uses the DAO directly

### Questions:
* [X] - There is breaking changes for older versions.
* [X] - It needs documentation.
