### PR TITLE
[YUNIKORN-2974] Expose preemption and priority settings via REST

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -696,7 +696,7 @@ func (sq *Queue) GetPartitionQueueDAOInfo(include bool) dao.PartitionQueueDAOInf
 	queueInfo.AbsUsedCapacity = resources.CalculateAbsUsedCapacity(sq.maxResource, sq.allocatedResource).DAOMap()
 	queueInfo.SortingPolicy = sq.sortType.String()
 	queueInfo.PrioritySorting = sq.prioritySortEnabled
-	queueInfo.PreemptionEnabled = sq.preemptionPolicy == policies.DisabledPreemptionPolicy
+	queueInfo.PreemptionEnabled = sq.preemptionPolicy != policies.DisabledPreemptionPolicy
 	queueInfo.IsPreemptionFence = sq.preemptionPolicy == policies.FencePreemptionPolicy
 	queueInfo.PreemptionDelay = sq.preemptionDelay.String()
 	queueInfo.IsPriorityFence = sq.priorityPolicy == policies.FencePriorityPolicy

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -693,8 +693,14 @@ func (sq *Queue) GetPartitionQueueDAOInfo(include bool) dao.PartitionQueueDAOInf
 	queueInfo.IsManaged = sq.isManaged
 	queueInfo.CurrentPriority = sq.getCurrentPriority()
 	queueInfo.TemplateInfo = sq.template.GetTemplateInfo()
-	queueInfo.AbsUsedCapacity = resources.CalculateAbsUsedCapacity(
-		sq.maxResource, sq.allocatedResource).DAOMap()
+	queueInfo.AbsUsedCapacity = resources.CalculateAbsUsedCapacity(sq.maxResource, sq.allocatedResource).DAOMap()
+	queueInfo.SortingPolicy = sq.sortType.String()
+	queueInfo.PrioritySorting = sq.prioritySortEnabled
+	queueInfo.PreemptionEnabled = sq.preemptionPolicy == policies.DisabledPreemptionPolicy
+	queueInfo.IsPreemptionFence = sq.preemptionPolicy == policies.FencePreemptionPolicy
+	queueInfo.PreemptionDelay = sq.preemptionDelay.String()
+	queueInfo.IsPriorityFence = sq.priorityPolicy == policies.FencePriorityPolicy
+	queueInfo.PriorityOffset = sq.priorityOffset
 	queueInfo.Properties = make(map[string]string)
 	for k, v := range sq.properties {
 		queueInfo.Properties[k] = v

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1705,9 +1705,23 @@ func TestGetPartitionQueueDAOInfo(t *testing.T) {
 	assert.Equal(t, leafDAO.QueueName, "root.leaf-queue")
 	assert.Equal(t, len(leafDAO.Children), 0, "leaf has no children")
 	assert.Equal(t, len(leafDAO.ChildNames), 0, "leaf has no children (names)")
+	assert.Equal(t, leafDAO.PreemptionEnabled, true, "preemption should be enabled")
 	assert.Equal(t, leafDAO.IsPreemptionFence, true, "fence should have been set")
 	assert.Equal(t, leafDAO.PreemptionDelay, "1h0m0s", "incorrect delay returned")
 	assert.Equal(t, leafDAO.SortingPolicy, "fair", "incorrect policy returned")
+
+	// special prop checks
+	leaf.properties = map[string]string{
+		configs.ApplicationSortPolicy: policies.FifoSortPolicy.String(),
+		configs.PreemptionDelay:       "10s",
+		configs.PreemptionPolicy:      policies.DisabledPreemptionPolicy.String(),
+	}
+	leaf.UpdateQueueProperties()
+	leafDAO = leaf.GetPartitionQueueDAOInfo(false)
+	assert.Equal(t, leafDAO.PreemptionEnabled, false, "preemption should not be enabled")
+	assert.Equal(t, leafDAO.IsPreemptionFence, false, "queue should not be a fence")
+	assert.Equal(t, leafDAO.PreemptionDelay, "10s", "incorrect delay returned")
+	assert.Equal(t, leafDAO.SortingPolicy, "fifo", "incorrect policy returned")
 }
 
 func getAllocatingAcceptedApps() map[string]bool {

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -807,7 +807,7 @@ func (pc *PartitionContext) tryAllocate() *objects.AllocationResult {
 		return nil
 	}
 	// try allocating from the root down
-	result := pc.root.TryAllocate(pc.GetNodeIterator, pc.GetFullNodeIterator, pc.GetNode, pc.isPreemptionEnabled())
+	result := pc.root.TryAllocate(pc.GetNodeIterator, pc.GetFullNodeIterator, pc.GetNode, pc.IsPreemptionEnabled())
 	if result != nil {
 		return pc.allocate(result)
 	}
@@ -1598,7 +1598,7 @@ func (pc *PartitionContext) GetNodeSortingResourceWeights() map[string]float64 {
 	return policy.ResourceWeights()
 }
 
-func (pc *PartitionContext) isPreemptionEnabled() bool {
+func (pc *PartitionContext) IsPreemptionEnabled() bool {
 	pc.RLock()
 	defer pc.RUnlock()
 	return pc.preemptionEnabled

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -3778,29 +3778,27 @@ func TestUpdatePreemption(t *testing.T) {
 
 	partition, err := newBasePartition()
 	assert.NilError(t, err, "Partition creation failed")
-	assert.Assert(t, partition.isPreemptionEnabled(), "preeemption should be enabled by default")
+	assert.Assert(t, partition.IsPreemptionEnabled(), "preeemption should be enabled by default")
 
 	partition.updatePreemption(configs.PartitionConfig{})
-	assert.Assert(t, partition.isPreemptionEnabled(), "preeemption should be enabled by empty config")
+	assert.Assert(t, partition.IsPreemptionEnabled(), "preeemption should be enabled by empty config")
 
 	partition.updatePreemption(configs.PartitionConfig{Preemption: configs.PartitionPreemptionConfig{}})
-	assert.Assert(t, partition.isPreemptionEnabled(), "preeemption should be enabled by empty preemption section")
+	assert.Assert(t, partition.IsPreemptionEnabled(), "preeemption should be enabled by empty preemption section")
 
 	partition.updatePreemption(configs.PartitionConfig{Preemption: configs.PartitionPreemptionConfig{Enabled: nil}})
-	assert.Assert(t, partition.isPreemptionEnabled(), "preeemption should be enabled by explicit nil")
+	assert.Assert(t, partition.IsPreemptionEnabled(), "preeemption should be enabled by explicit nil")
 
 	partition.updatePreemption(configs.PartitionConfig{Preemption: configs.PartitionPreemptionConfig{Enabled: &True}})
-	assert.Assert(t, partition.isPreemptionEnabled(), "preeemption should be enabled by explicit true")
+	assert.Assert(t, partition.IsPreemptionEnabled(), "preeemption should be enabled by explicit true")
 
 	partition.updatePreemption(configs.PartitionConfig{Preemption: configs.PartitionPreemptionConfig{Enabled: &False}})
-	assert.Assert(t, !partition.isPreemptionEnabled(), "preeemption should be disabled by explicit false")
+	assert.Assert(t, !partition.IsPreemptionEnabled(), "preeemption should be disabled by explicit false")
 }
 
 func TestUpdateNodeSortingPolicy(t *testing.T) {
 	partition, err := newBasePartition()
-	if err != nil {
-		t.Errorf("Partition creation failed: %s", err.Error())
-	}
+	assert.NilError(t, err, "Partition creation failed unexpectedly")
 
 	if partition.nodes.GetNodeSortingPolicy().PolicyType().String() != policies.FairnessPolicy.String() {
 		t.Error("Node policy is not set with the default policy which is fair policy.")

--- a/pkg/webservice/dao/partition_info.go
+++ b/pkg/webservice/dao/partition_info.go
@@ -23,6 +23,7 @@ type PartitionInfo struct {
 	Name                    string            `json:"name"`              // no omitempty, name should not be empty
 	Capacity                PartitionCapacity `json:"capacity"`          // no omitempty, omitempty doesn't work on a structure value
 	NodeSortingPolicy       NodeSortingPolicy `json:"nodeSortingPolicy"` // no omitempty, omitempty doesn't work on a structure value
+	PreemptionEnabled       bool              `json:"preemptionEnabled"` // no omitempty, false shows preemption status better
 	TotalNodes              int               `json:"totalNodes,omitempty"`
 	Applications            map[string]int    `json:"applications,omitempty"`
 	TotalContainers         int               `json:"totalContainers,omitempty"`

--- a/pkg/webservice/dao/queue_info.go
+++ b/pkg/webservice/dao/queue_info.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package dao
 
 type TemplateInfo struct {
@@ -27,7 +28,7 @@ type TemplateInfo struct {
 type PartitionQueueDAOInfo struct {
 	QueueName              string                  `json:"queuename"` // no omitempty, queue name should not be empty
 	Status                 string                  `json:"status,omitempty"`
-	Partition              string                  `json:"partition"` // no omitempty, queue name should not be empty
+	Partition              string                  `json:"partition"` // no omitempty, partition name should not be empty
 	PendingResource        map[string]int64        `json:"pendingResource,omitempty"`
 	MaxResource            map[string]int64        `json:"maxResource,omitempty"`
 	GuaranteedResource     map[string]int64        `json:"guaranteedResource,omitempty"`
@@ -46,4 +47,11 @@ type PartitionQueueDAOInfo struct {
 	RunningApps            uint64                  `json:"runningApps,omitempty"`
 	CurrentPriority        int32                   `json:"currentPriority"` // no omitempty, as the current priority value may be 0, which is a valid priority level
 	AllocatingAcceptedApps []string                `json:"allocatingAcceptedApps,omitempty"`
+	SortingPolicy          string                  `json:"sortingPolicy,omitempty"`
+	PrioritySorting        bool                    `json:"prioritySorting"`   // no omitempty, false shows priority sorting status better
+	PreemptionEnabled      bool                    `json:"preemptionEnabled"` // no omitempty, false shows preemption status better
+	IsPreemptionFence      bool                    `json:"isPreemptionFence"` // no omitempty, a false value gives a quick way to understand whether it's fenced.
+	PreemptionDelay        string                  `json:"preemptionDelay,omitempty"`
+	IsPriorityFence        bool                    `json:"isPriorityFence"` // no omitempty, a false value gives a quick way to understand whether it's fenced.
+	PriorityOffset         int32                   `json:"priorityOffset,omitempty"`
 }

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -1006,6 +1006,7 @@ func getPartitionInfoDAO(lists map[string]*scheduler.PartitionContext) []*dao.Pa
 		partitionInfo.Name = common.GetPartitionNameWithoutClusterID(partitionContext.Name)
 		partitionInfo.State = partitionContext.GetCurrentState()
 		partitionInfo.LastStateTransitionTime = partitionContext.GetStateTime().UnixNano()
+		partitionInfo.PreemptionEnabled = partitionContext.IsPreemptionEnabled()
 
 		capacityInfo := dao.PartitionCapacity{}
 		capacity := partitionContext.GetTotalPartitionResource()


### PR DESCRIPTION
### What is this PR for?
Add preemption and priority details to the queue REST information. Currently the configuration is exposed via the properties. The properties contain the raw configuration values which need to be interpreted.
Invalid configuration values are ignored and not set on the queue. This could cause an incorrect view of what is or should be active on the queue if based on the properties. Using the active values from the object to show the real state.

Expose Partition level preemption flag as part of this change to complement the queue details.

### What type of PR is it?
* [X] - Improvement

### What is the Jira issue?
[YUNIKORN-2976](https://issues.apache.org/jira/browse/YUNIKORN-2976)

### How should this be tested?
new unit tests added

### Questions:
* [X] - It needs documentation.
