### PR TITLE
[YUNIKORN-2978] Fix handling of reserved allocations where node differs

### DIFF
--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -344,6 +344,12 @@ func (sn *Node) RemoveAllocation(allocationKey string) *Allocation {
 		}
 		sn.availableResource.AddTo(alloc.GetAllocatedResource())
 		sn.nodeEvents.SendAllocationRemovedEvent(sn.NodeID, alloc.allocationKey, alloc.GetAllocatedResource())
+		log.Log(log.SchedNode).Info("node allocation removed",
+			zap.String("appID", alloc.GetApplicationID()),
+			zap.String("allocationKey", alloc.GetAllocationKey()),
+			zap.Stringer("allocatedResource", alloc.GetAllocatedResource()),
+			zap.Bool("placeholder", alloc.IsPlaceholder()),
+			zap.String("targetNode", sn.NodeID))
 		return alloc
 	}
 
@@ -382,6 +388,10 @@ func (sn *Node) UpdateForeignAllocation(alloc *Allocation) *Allocation {
 	delta := resources.Sub(newResource, existingResource)
 	delta.Prune()
 
+	log.Log(log.SchedNode).Info("node foreign allocation updated",
+		zap.String("allocationKey", alloc.GetAllocationKey()),
+		zap.Stringer("deltaResource", delta),
+		zap.String("targetNode", sn.NodeID))
 	sn.occupiedResource.AddTo(delta)
 	sn.occupiedResource.Prune()
 	sn.refreshAvailableResource()
@@ -416,6 +426,12 @@ func (sn *Node) addAllocationInternal(alloc *Allocation, force bool) bool {
 		sn.availableResource.SubFrom(res)
 		sn.availableResource.Prune()
 		sn.nodeEvents.SendAllocationAddedEvent(sn.NodeID, alloc.allocationKey, res)
+		log.Log(log.SchedNode).Info("node allocation processed",
+			zap.String("appID", alloc.GetApplicationID()),
+			zap.String("allocationKey", alloc.GetAllocationKey()),
+			zap.Stringer("allocatedResource", alloc.GetAllocatedResource()),
+			zap.Bool("placeholder", alloc.IsPlaceholder()),
+			zap.String("targetNode", sn.NodeID))
 		result = true
 		return result
 	}
@@ -440,6 +456,12 @@ func (sn *Node) ReplaceAllocation(allocationKey string, replace *Allocation, del
 	sn.allocatedResource.AddTo(delta)
 	sn.availableResource.SubFrom(delta)
 	sn.availableResource.Prune()
+	log.Log(log.SchedNode).Info("node allocation replaced",
+		zap.String("appID", replace.GetApplicationID()),
+		zap.String("allocationKey", replace.GetAllocationKey()),
+		zap.Stringer("allocatedResource", replace.GetAllocatedResource()),
+		zap.String("placeholderKey", allocationKey),
+		zap.String("targetNode", sn.NodeID))
 	if !before.FitIn(sn.allocatedResource) {
 		log.Log(log.SchedNode).Warn("unexpected increase in node usage after placeholder replacement",
 			zap.String("placeholder allocationKey", allocationKey),

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -871,17 +871,6 @@ func (pc *PartitionContext) allocate(result *objects.AllocationResult) *objects.
 	// the node ID is set when a reservation is allocated on a non-reserved node
 	alloc := result.Request
 	targetNodeID := result.NodeID
-	var reservedNodeID string
-	if result.ReservedNodeID == "" {
-		reservedNodeID = result.NodeID
-	} else {
-		reservedNodeID = result.ReservedNodeID
-		log.Log(log.SchedPartition).Debug("Reservation allocated on different node",
-			zap.String("current node", result.NodeID),
-			zap.String("reserved node", reservedNodeID),
-			zap.String("appID", appID))
-	}
-
 	targetNode := pc.GetNode(targetNodeID)
 	if targetNode == nil {
 		log.Log(log.SchedPartition).Info("Target node was removed while allocating",
@@ -907,8 +896,20 @@ func (pc *PartitionContext) allocate(result *objects.AllocationResult) *objects.
 		pc.reserve(app, targetNode, result.Request)
 		return nil
 	}
+
 	// unreserve
 	if result.ResultType == objects.Unreserved || result.ResultType == objects.AllocatedReserved {
+		var reservedNodeID string
+		if result.ReservedNodeID == "" {
+			reservedNodeID = result.NodeID
+		} else {
+			reservedNodeID = result.ReservedNodeID
+			log.Log(log.SchedPartition).Debug("Reservation allocated on different node",
+				zap.String("current node", result.NodeID),
+				zap.String("reserved node", reservedNodeID),
+				zap.String("appID", appID))
+		}
+
 		reservedNode := pc.GetNode(reservedNodeID)
 		if reservedNode != nil {
 			pc.unReserve(app, reservedNode, result.Request)

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -871,14 +871,14 @@ func (pc *PartitionContext) allocate(result *objects.AllocationResult) *objects.
 	// the node ID is set when a reservation is allocated on a non-reserved node
 	alloc := result.Request
 	targetNodeID := result.NodeID
-	var srcNodeID string
+	var reservedNodeID string
 	if result.ReservedNodeID == "" {
-		srcNodeID = result.NodeID
+		reservedNodeID = result.NodeID
 	} else {
-		srcNodeID = result.ReservedNodeID
+		reservedNodeID = result.ReservedNodeID
 		log.Log(log.SchedPartition).Debug("Reservation allocated on different node",
 			zap.String("current node", result.NodeID),
-			zap.String("reserved node", srcNodeID),
+			zap.String("reserved node", reservedNodeID),
 			zap.String("appID", appID))
 	}
 
@@ -909,12 +909,12 @@ func (pc *PartitionContext) allocate(result *objects.AllocationResult) *objects.
 	}
 	// unreserve
 	if result.ResultType == objects.Unreserved || result.ResultType == objects.AllocatedReserved {
-		srcNode := pc.GetNode(srcNodeID)
-		if srcNode != nil {
-			pc.unReserve(app, srcNode, result.Request)
+		reservedNode := pc.GetNode(reservedNodeID)
+		if reservedNode != nil {
+			pc.unReserve(app, reservedNode, result.Request)
 		} else {
-			log.Log(log.SchedPartition).Info("Source node was removed while allocating",
-				zap.String("nodeID", srcNodeID),
+			log.Log(log.SchedPartition).Info("Reserved node was removed while allocating",
+				zap.String("nodeID", reservedNodeID),
 				zap.String("appID", appID))
 		}
 		if result.ResultType == objects.Unreserved {

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -2369,6 +2369,9 @@ func TestAllocReserveNewNode(t *testing.T) {
 	assert.Equal(t, 0, len(node1.GetReservationKeys()), "old node should have no more reservations")
 	assert.Equal(t, 0, len(app.GetReservations()), "ask should have been reserved")
 	assertLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 16000}))
+	alloc2 := node2.GetAllocation("alloc-2")
+	assert.Assert(t, alloc2 != nil, "alloc was nil")
+	assert.Equal(t, nodeID2, alloc2.GetNodeID(), "wrong node id")
 }
 
 func TestTryAllocateReserve(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
YUNIKORN-2700 introduced a bug where allocations of previously-reserved tasks were not handled correctly in the case where we schedule on a different node than the reservation. Ensure that we unreserve and allocate using the proper node in both cases.

Also introduce additional logging of allocations on nodes to make finding issues like this easier in the future.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2978

### How should this be tested?
Verified successful processing of 1000-pod job on autoscaled cluster where previously this would fail.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
