### PR TITLE
[YUNIKORN-2925] Remove internal object from application REST info

### DIFF
--- a/pkg/common/resources/tracked_resources_test.go
+++ b/pkg/common/resources/tracked_resources_test.go
@@ -47,7 +47,7 @@ func TestNewTrackedResourceFromMap(t *testing.T) {
 	var tests = []struct {
 		caseName string
 		input    map[string]map[string]Quantity
-		trMap map[string]map[string]Quantity
+		trMap    map[string]map[string]Quantity
 	}{
 		{
 			"nil",
@@ -220,8 +220,8 @@ func TestTrackedResourceAggregateTrackedResource(t *testing.T) {
 func TestEqualsTracked(t *testing.T) {
 	var tests = []struct {
 		caseName string
-		base    map[string]map[string]Quantity
-		compare map[string]map[string]int64
+		base     map[string]map[string]Quantity
+		compare  map[string]map[string]int64
 		expected bool
 	}{
 		{"nil inputs", nil, nil, true},

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -124,29 +124,6 @@ type Application struct {
 	locking.RWMutex
 }
 
-func (sa *Application) GetApplicationSummary(rmID string) *ApplicationSummary {
-	sa.RLock()
-	defer sa.RUnlock()
-	state := sa.stateMachine.Current()
-	resourceUsage := sa.usedResource.Clone()
-	preemptedUsage := sa.preemptedResource.Clone()
-	placeHolderUsage := sa.placeholderResource.Clone()
-	appSummary := &ApplicationSummary{
-		ApplicationID:       sa.ApplicationID,
-		SubmissionTime:      sa.SubmissionTime,
-		StartTime:           sa.startTime,
-		FinishTime:          sa.finishedTime,
-		User:                sa.user.User,
-		Queue:               sa.queuePath,
-		State:               state,
-		RmID:                rmID,
-		ResourceUsage:       resourceUsage,
-		PreemptedResource:   preemptedUsage,
-		PlaceholderResource: placeHolderUsage,
-	}
-	return appSummary
-}
-
 func NewApplication(siApp *si.AddApplicationRequest, ugi security.UserGroup, eventHandler handler.EventHandler, rmID string) *Application {
 	app := &Application{
 		ApplicationID:         siApp.ApplicationID,
@@ -2131,21 +2108,58 @@ func (sa *Application) cleanupTrackedResource() {
 	sa.preemptedResource = nil
 }
 
-func (sa *Application) CleanupTrackedResource() {
+// GetApplicationSummary locked version to get the application summary
+// Exposed for test only
+func (sa *Application) GetApplicationSummary(rmID string) *ApplicationSummary {
+	sa.RLock()
+	defer sa.RUnlock()
+	return sa.getApplicationSummary(rmID)
+}
+
+func (sa *Application) getApplicationSummary(rmID string) *ApplicationSummary {
+	return &ApplicationSummary{
+		ApplicationID:       sa.ApplicationID,
+		SubmissionTime:      sa.SubmissionTime,
+		StartTime:           sa.startTime,
+		FinishTime:          sa.finishedTime,
+		User:                sa.user.User,
+		Queue:               sa.queuePath,
+		State:               sa.stateMachine.Current(),
+		RmID:                rmID,
+		ResourceUsage:       sa.usedResource.Clone(),
+		PreemptedResource:   sa.preemptedResource.Clone(),
+		PlaceholderResource: sa.placeholderResource.Clone(),
+	}
+}
+
+// LogAppSummary log the summary details for the application if it has run at any point in time.
+// The application summary only contains correct data when the application is in the Completed state.
+// Logging the data in any other state will show incomplete or inconsistent data.
+// After the data is logged the objects are cleaned up to lower overhead of Completed application tracking.
+func (sa *Application) LogAppSummary(rmID string) {
 	sa.Lock()
 	defer sa.Unlock()
+	if !sa.startTime.IsZero() {
+		appSummary := sa.getApplicationSummary(rmID)
+		appSummary.DoLogging()
+	}
 	sa.cleanupTrackedResource()
 }
 
-func (sa *Application) LogAppSummary(rmID string) {
-	if sa.startTime.IsZero() {
-		return
+// GetTrackedDAOMap returns the tracked resources type specified in which as a DAO similar to the normal resources.
+func (sa *Application) GetTrackedDAOMap(which string) map[string]map[string]int64 {
+	sa.RLock()
+	defer sa.RUnlock()
+	switch which {
+	case "usedResource":
+		return sa.usedResource.DAOMap()
+	case "preemptedResource":
+		return sa.preemptedResource.DAOMap()
+	case "placeholderResource":
+		return sa.placeholderResource.DAOMap()
+	default:
+		return map[string]map[string]int64{}
 	}
-	appSummary := sa.GetApplicationSummary(rmID)
-	appSummary.DoLogging()
-	appSummary.ResourceUsage = nil
-	appSummary.PreemptedResource = nil
-	appSummary.PlaceholderResource = nil
 }
 
 func (sa *Application) HasPlaceholderAllocation() bool {

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1619,7 +1619,6 @@ func (pc *PartitionContext) moveTerminatedApp(appID string) {
 		zap.String("appID", appID),
 		zap.String("app status", app.CurrentState()))
 	app.LogAppSummary(pc.RmID)
-	app.CleanupTrackedResource()
 	pc.Lock()
 	defer pc.Unlock()
 	delete(pc.applications, appID)

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1928,8 +1928,7 @@ func TestRequiredNodeAllocation(t *testing.T) {
 	assertLimits(t, getTestUserGroup(), resources.Multiply(res, 2))
 }
 
-func assertPreemptedResource(t *testing.T, appSummary *objects.ApplicationSummary, memorySeconds int64,
-	vcoresSecconds int64) {
+func assertPreemptedResource(t *testing.T, appSummary *objects.ApplicationSummary, memorySeconds int64, vcoresSecconds int64) {
 	detailedResource := appSummary.PreemptedResource.TrackedResourceMap["UNKNOWN"]
 
 	memValue, memPresent := detailedResource.Resources["memory"]
@@ -2008,11 +2007,9 @@ func TestPreemption(t *testing.T) {
 	assert.Equal(t, result.Request.GetAllocationKey(), allocKey3, "expected ask alloc-3 to be allocated")
 	assertUserGroupResourceMaxLimits(t, getTestUserGroup(), resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 10000}), getExpectedQueuesLimitsForPreemption())
 
-	appSummary := app1.GetApplicationSummary("default")
-	assertPreemptedResource(t, appSummary, -1, 5000)
+	assertPreemptedResource(t, app1.GetApplicationSummary("default"), -1, 5000)
 
-	appSummary = app2.GetApplicationSummary("default")
-	assert.Assert(t, appSummary.PreemptedResource.TrackedResourceMap["UNKNOWN"] == nil)
+	assert.Assert(t, app2.GetApplicationSummary("default").PreemptedResource.TrackedResourceMap["UNKNOWN"] == nil)
 }
 
 // Preemption followed by a normal allocation

--- a/pkg/webservice/dao/application_info.go
+++ b/pkg/webservice/dao/application_info.go
@@ -18,38 +18,32 @@
 
 package dao
 
-import (
-	"github.com/apache/yunikorn-core/pkg/common/resources"
-)
-
 type ApplicationsDAOInfo struct {
 	Applications []ApplicationDAOInfo `json:"applications,omitempty"`
 }
 
 type ApplicationDAOInfo struct {
-	ApplicationID       string                     `json:"applicationID"` // no omitempty, application id should not be empty
-	UsedResource        map[string]int64           `json:"usedResource,omitempty"`
-	MaxUsedResource     map[string]int64           `json:"maxUsedResource,omitempty"`
-	PendingResource     map[string]int64           `json:"pendingResource,omitempty"`
-	Partition           string                     `json:"partition"` // no omitempty, partition should not be empty
-	QueueName           string                     `json:"queueName"` // no omitempty, queue name should not be empty
-	SubmissionTime      int64                      `json:"submissionTime,omitempty"`
-	FinishedTime        *int64                     `json:"finishedTime,omitempty"`
-	Requests            []*AllocationAskDAOInfo    `json:"requests,omitempty"`
-	Allocations         []*AllocationDAOInfo       `json:"allocations,omitempty"`
-	State               string                     `json:"applicationState,omitempty"`
-	User                string                     `json:"user,omitempty"`
-	Groups              []string                   `json:"groups,omitempty"`
-	RejectedMessage     string                     `json:"rejectedMessage,omitempty"`
-	StateLog            []*StateDAOInfo            `json:"stateLog,omitempty"`
-	PlaceholderData     []*PlaceholderDAOInfo      `json:"placeholderData,omitempty"`
-	HasReserved         bool                       `json:"hasReserved,omitempty"`
-	Reservations        []string                   `json:"reservations,omitempty"`
-	MaxRequestPriority  int32                      `json:"maxRequestPriority,omitempty"`
-	StartTime           int64                      `json:"startTime,omitempty"`
-	ResourceUsage       *resources.TrackedResource `json:"resourceUsage,omitempty"`
-	PreemptedResource   *resources.TrackedResource `json:"preemptedResource,omitempty"`
-	PlaceholderResource *resources.TrackedResource `json:"placeholderResource,omitempty"`
+	ApplicationID      string                  `json:"applicationID"` // no omitempty, application id should not be empty
+	UsedResource       map[string]int64        `json:"usedResource,omitempty"`
+	MaxUsedResource    map[string]int64        `json:"maxUsedResource,omitempty"`
+	PendingResource    map[string]int64        `json:"pendingResource,omitempty"`
+	Partition          string                  `json:"partition"` // no omitempty, partition should not be empty
+	QueueName          string                  `json:"queueName"` // no omitempty, queue name should not be empty
+	SubmissionTime     int64                   `json:"submissionTime,omitempty"`
+	FinishedTime       *int64                  `json:"finishedTime,omitempty"`
+	Requests           []*AllocationAskDAOInfo `json:"requests,omitempty"`
+	Allocations        []*AllocationDAOInfo    `json:"allocations,omitempty"`
+	State              string                  `json:"applicationState,omitempty"`
+	User               string                  `json:"user,omitempty"`
+	Groups             []string                `json:"groups,omitempty"`
+	RejectedMessage    string                  `json:"rejectedMessage,omitempty"`
+	StateLog           []*StateDAOInfo         `json:"stateLog,omitempty"`
+	PlaceholderData    []*PlaceholderDAOInfo   `json:"placeholderData,omitempty"`
+	HasReserved        bool                    `json:"hasReserved,omitempty"`
+	Reservations       []string                `json:"reservations,omitempty"`
+	MaxRequestPriority int32                   `json:"maxRequestPriority,omitempty"`
+	StartTime          int64                   `json:"startTime,omitempty"`
+	ResourceHistory    ResourceHistory         `json:"resourceHistory,omitempty"`
 }
 
 type StateDAOInfo struct {
@@ -63,4 +57,10 @@ type PlaceholderDAOInfo struct {
 	MinResource   map[string]int64 `json:"minResource,omitempty"`
 	Replaced      int64            `json:"replaced,omitempty"`
 	TimedOut      int64            `json:"timedout,omitempty"`
+}
+
+type ResourceHistory struct {
+	ResourceUsage       map[string]map[string]int64 `json:"resourceUsage,omitempty"`
+	PreemptedResource   map[string]map[string]int64 `json:"preemptedResource,omitempty"`
+	PlaceholderResource map[string]map[string]int64 `json:"placeholderResource,omitempty"`
 }

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1694,29 +1694,25 @@ func TestGetPartitionApplicationsByStateHandler(t *testing.T) {
 	defaultPartition.AddRejectedApplication(app3, rejectedMessage)
 
 	// test get active app
-	sum1 := app1.GetApplicationSummary(defaultPartition.RmID)
-	sum2 := app2.GetApplicationSummary(defaultPartition.RmID)
-	expectedActiveDao := []*dao.ApplicationDAOInfo{getApplicationDAO(app1, sum1), getApplicationDAO(app2, sum2)}
+	expectedActiveDao := []*dao.ApplicationDAOInfo{getApplicationDAO(app1), getApplicationDAO(app2)}
 	checkLegalGetAppsRequest(t, "/ws/v1/partition/default/applications/Active", httprouter.Params{
 		httprouter.Param{Key: "partition", Value: partitionNameWithoutClusterID},
 		httprouter.Param{Key: "state", Value: "Active"}}, expectedActiveDao)
 
 	// test get active app with running state
-	expectedRunningDao := []*dao.ApplicationDAOInfo{getApplicationDAO(app2, sum2)}
+	expectedRunningDao := []*dao.ApplicationDAOInfo{getApplicationDAO(app2)}
 	checkLegalGetAppsRequest(t, "/ws/v1/partition/default/applications/Active?status=Running", httprouter.Params{
 		httprouter.Param{Key: "partition", Value: partitionNameWithoutClusterID},
 		httprouter.Param{Key: "state", Value: "Active"}}, expectedRunningDao)
 
 	// test get completed app
-	sum3 := app3.GetApplicationSummary(defaultPartition.RmID)
-	expectedCompletedDao := []*dao.ApplicationDAOInfo{getApplicationDAO(app3, sum3)}
+	expectedCompletedDao := []*dao.ApplicationDAOInfo{getApplicationDAO(app3)}
 	checkLegalGetAppsRequest(t, "/ws/v1/partition/default/applications/Completed", httprouter.Params{
 		httprouter.Param{Key: "partition", Value: partitionNameWithoutClusterID},
 		httprouter.Param{Key: "state", Value: "Completed"}}, expectedCompletedDao)
 
 	// test get rejected app
-	sum4 := app4.GetApplicationSummary(defaultPartition.RmID)
-	expectedRejectedDao := []*dao.ApplicationDAOInfo{getApplicationDAO(app4, sum4)}
+	expectedRejectedDao := []*dao.ApplicationDAOInfo{getApplicationDAO(app4)}
 	checkLegalGetAppsRequest(t, "/ws/v1/partition/default/applications/Rejected", httprouter.Params{
 		httprouter.Param{Key: "partition", Value: partitionNameWithoutClusterID},
 		httprouter.Param{Key: "state", Value: "Rejected"}}, expectedRejectedDao)
@@ -1973,9 +1969,9 @@ func TestGetApplicationHandler(t *testing.T) {
 	assert.NilError(t, err, unmarshalError)
 	assert.Equal(t, "app-1", appDao.ApplicationID)
 	assert.Equal(t, app.StartTime().UnixMilli(), appDao.StartTime)
-	assert.Assert(t, resources.EqualsTracked(appSummary.ResourceUsage, appDao.ResourceUsage))
-	assert.Assert(t, resources.EqualsTracked(appSummary.PreemptedResource, appDao.PreemptedResource))
-	assert.Assert(t, resources.EqualsTracked(appSummary.PlaceholderResource, appDao.PlaceholderResource))
+	assert.Assert(t, appSummary.ResourceUsage.EqualsDAO(appDao.ResourceHistory.ResourceUsage))
+	assert.Assert(t, appSummary.PreemptedResource.EqualsDAO(appDao.ResourceHistory.PreemptedResource))
+	assert.Assert(t, appSummary.PlaceholderResource.EqualsDAO(appDao.ResourceHistory.PlaceholderResource))
 }
 
 func assertParamsMissing(t *testing.T, resp *MockResponseWriter) {


### PR DESCRIPTION
### What is this PR for?
Remove the TrackedResource object from the REST response for the application. Moved the tracked resources into a separate object inside the app DAO, as we have done for other complex pieces. Cleanup exposure of the summary object to be testing only. Add DAO retrieval of TrackedResource type for the web handler.

Fixed locking inside the app when logging the summary and cleaning up.

### What type of PR is it?
* [X] - Bug Fix
* [X] - Improvement

### What is the Jira issue?
   [YUNIKORN-2](https://issues.apache.org/jira/browse/YUNIKORN-2925)

### How should this be tested?
Unit tests included

### Questions:
* [X] - It needs documentation.
