### PR TITLE
[YUNIKORN-2976] Handle multiple require node allocations per node

### DIFF
--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -20,11 +20,24 @@ package common
 
 import "errors"
 
-// InvalidQueueName returned when queue name is invalid
-var InvalidQueueName = errors.New("invalid queue name, max 64 characters consisting of alphanumeric characters and '-', '_', '#', '@', '/', ':' allowed")
+var (
+	// InvalidQueueName returned when queue name is invalid
+	InvalidQueueName = errors.New("invalid queue name, max 64 characters consisting of alphanumeric characters and '-', '_', '#', '@', '/', ':' allowed")
+	// ErrorReservingAlloc returned when an ask that is allocated tries to reserve a node.
+	ErrorReservingAlloc = errors.New("ask already allocated, no reservation allowed")
+	// ErrorDuplicateReserve returned when the same reservation already exists on the application
+	ErrorDuplicateReserve = errors.New("reservation already exists")
+	// ErrorNodeAlreadyReserved returned when the node is already reserved, failing the reservation
+	ErrorNodeAlreadyReserved = errors.New("node is already reserved")
+	// ErrorNodeNotFitReserve returned when the allocation does not fit on an empty node, failing the reservation
+	ErrorNodeNotFitReserve = errors.New("reservation does not fit on node")
+)
 
-const PreemptionPreconditionsFailed = "Preemption preconditions failed"
-const PreemptionDoesNotGuarantee = "Preemption queue guarantees check failed"
-const PreemptionShortfall = "Preemption helped but short of resources"
-const PreemptionDoesNotHelp = "Preemption does not help"
-const NoVictimForRequiredNode = "No fit on required node, preemption does not help"
+// Constant messages for AllocationLog entries
+const (
+	PreemptionPreconditionsFailed = "Preemption preconditions failed"
+	PreemptionDoesNotGuarantee    = "Preemption queue guarantees check failed"
+	PreemptionShortfall           = "Preemption helped but short of resources"
+	PreemptionDoesNotHelp         = "Preemption does not help"
+	NoVictimForRequiredNode       = "No fit on required node, preemption does not help"
+)

--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -48,7 +48,6 @@ type Allocation struct {
 	allowPreemptOther bool
 	originator        bool
 	tags              map[string]string
-	resKeyWithoutNode string // the reservation key without node
 	foreign           bool
 	preemptable       bool
 
@@ -57,9 +56,8 @@ type Allocation struct {
 	allocLog             map[string]*AllocationLogEntry
 	preemptionTriggered  bool
 	preemptCheckTime     time.Time
-	schedulingAttempted  bool              // whether scheduler core has tried to schedule this allocation
-	scaleUpTriggered     bool              // whether this aloocation has triggered autoscaling or not
-	resKeyPerNode        map[string]string // reservation key for a given node
+	schedulingAttempted  bool // whether scheduler core has tried to schedule this allocation
+	scaleUpTriggered     bool // whether this allocation has triggered autoscaling or not
 	allocatedResource    *resources.Resource
 	askEvents            *schedEvt.AskEvents
 	userQuotaCheckFailed bool
@@ -145,8 +143,6 @@ func NewAllocationFromSI(alloc *si.Allocation) *Allocation {
 		allowPreemptOther: alloc.PreemptionPolicy.GetAllowPreemptOther(),
 		originator:        alloc.Originator,
 		allocLog:          make(map[string]*AllocationLogEntry),
-		resKeyPerNode:     make(map[string]string),
-		resKeyWithoutNode: reservationKeyWithoutNode(alloc.ApplicationID, alloc.AllocationKey),
 		askEvents:         schedEvt.NewAskEvents(events.GetEventSystem()),
 		allocated:         allocated,
 		nodeID:            nodeID,
@@ -547,18 +543,6 @@ func (a *Allocation) HasTriggeredScaleUp() bool {
 	a.RLock()
 	defer a.RUnlock()
 	return a.scaleUpTriggered
-}
-
-func (a *Allocation) setReservationKeyForNode(node, resKey string) {
-	a.Lock()
-	defer a.Unlock()
-	a.resKeyPerNode[node] = resKey
-}
-
-func (a *Allocation) getReservationKeyForNode(node string) string {
-	a.RLock()
-	defer a.RUnlock()
-	return a.resKeyPerNode[node]
 }
 
 func (a *Allocation) setHeadroomCheckFailed(headroom *resources.Resource, queue string) {

--- a/pkg/scheduler/objects/allocation_result.go
+++ b/pkg/scheduler/objects/allocation_result.go
@@ -36,10 +36,11 @@ func (art AllocationResultType) String() string {
 }
 
 type AllocationResult struct {
-	ResultType     AllocationResultType
-	Request        *Allocation
-	NodeID         string
-	ReservedNodeID string
+	ResultType            AllocationResultType
+	Request               *Allocation
+	NodeID                string
+	ReservedNodeID        string
+	CancelledReservations int
 }
 
 func (ar *AllocationResult) String() string {

--- a/pkg/scheduler/objects/allocation_test.go
+++ b/pkg/scheduler/objects/allocation_test.go
@@ -51,7 +51,6 @@ func TestNewAsk(t *testing.T) {
 	askStr := ask.String()
 	expected := "allocationKey ask-1, applicationID app-1, Resource map[first:10], Allocated false"
 	assert.Equal(t, askStr, expected, "Strings should have been equal")
-	assert.Equal(t, "app-1|ask-1", ask.resKeyWithoutNode) //nolint:staticcheck
 }
 
 func TestAskAllocateDeallocate(t *testing.T) {

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -452,41 +452,44 @@ func (sa *Application) timeoutPlaceholderProcessing() {
 func (sa *Application) GetReservations() []string {
 	sa.RLock()
 	defer sa.RUnlock()
-	keys := make([]string, 0)
+	keys := make([]string, len(sa.reservations))
+	var i int
 	for key := range sa.reservations {
-		keys = append(keys, key)
+		keys[i] = key
+		i++
 	}
 	return keys
 }
 
-// Return the allocation ask for the key, nil if not found
+// GetAllocationAsk returns the allocation alloc for the key, nil if not found
 func (sa *Application) GetAllocationAsk(allocationKey string) *Allocation {
 	sa.RLock()
 	defer sa.RUnlock()
 	return sa.requests[allocationKey]
 }
 
-// Return the allocated resources for this application
+// GetAllocatedResource returns the currently allocated resources for this application
 func (sa *Application) GetAllocatedResource() *resources.Resource {
 	sa.RLock()
 	defer sa.RUnlock()
 	return sa.allocatedResource.Clone()
 }
 
+// GetMaxAllocatedResource returns the peak of the allocated resources for this application
 func (sa *Application) GetMaxAllocatedResource() *resources.Resource {
 	sa.RLock()
 	defer sa.RUnlock()
 	return sa.maxAllocatedResource.Clone()
 }
 
-// Return the allocated placeholder resources for this application
+// GetPlaceholderResource returns the currently allocated placeholder resources for this application
 func (sa *Application) GetPlaceholderResource() *resources.Resource {
 	sa.RLock()
 	defer sa.RUnlock()
 	return sa.allocatedPlaceholder.Clone()
 }
 
-// Return the total placeholder ask for this application
+// GetPlaceholderAsk returns the total placeholder resource request for this application
 // Is only set on app creation and used when app is added to a queue
 func (sa *Application) GetPlaceholderAsk() *resources.Resource {
 	sa.RLock()
@@ -501,8 +504,8 @@ func (sa *Application) GetPendingResource() *resources.Resource {
 	return sa.pending
 }
 
-// Remove one or more allocation asks from this application.
-// This also removes any reservations that are linked to the ask.
+// RemoveAllocationAsk removes one or more allocation asks from this application.
+// This also removes any reservations that are linked to the allocations.
 // The return value is the number of reservations released
 func (sa *Application) RemoveAllocationAsk(allocKey string) int {
 	sa.Lock()
@@ -517,23 +520,16 @@ func (sa *Application) removeAsksInternal(allocKey string, detail si.EventRecord
 		return 0
 	}
 	var deltaPendingResource *resources.Resource = nil
-	// when allocation key not specified, cleanup all allocation ask
+	// when allocation key is not specified, cleanup all allocations
 	var toRelease int
 	if allocKey == "" {
 		// cleanup all reservations
-		for key, reserve := range sa.reservations {
-			releases, err := sa.unReserveInternal(reserve.node, reserve.ask)
-			if err != nil {
-				log.Log(log.SchedApplication).Warn("Removal of reservation failed while removing all allocation asks",
-					zap.String("appID", sa.ApplicationID),
-					zap.String("reservationKey", key),
-					zap.Error(err))
-				continue
-			}
-			// clean up the queue reservation (one at a time)
-			sa.queue.UnReserve(sa.ApplicationID, releases)
+		for _, reserve := range sa.reservations {
+			releases := sa.unReserveInternal(reserve)
 			toRelease += releases
 		}
+		// clean up the queue reservation
+		sa.queue.UnReserve(sa.ApplicationID, toRelease)
 		// Cleanup total pending resource
 		deltaPendingResource = sa.pending
 		sa.pending = resources.NewResource()
@@ -546,16 +542,8 @@ func (sa *Application) removeAsksInternal(allocKey string, detail si.EventRecord
 		sa.queue.UpdateApplicationPriority(sa.ApplicationID, sa.askMaxPriority)
 	} else {
 		// cleanup the reservation for this allocation
-		for _, key := range sa.GetAskReservations(allocKey) {
-			reserve := sa.reservations[key]
-			releases, err := sa.unReserveInternal(reserve.node, reserve.ask)
-			if err != nil {
-				log.Log(log.SchedApplication).Warn("Removal of reservation failed while removing allocation ask",
-					zap.String("appID", sa.ApplicationID),
-					zap.String("reservationKey", key),
-					zap.Error(err))
-				continue
-			}
+		if reserve, ok := sa.reservations[allocKey]; ok {
+			releases := sa.unReserveInternal(reserve)
 			// clean up the queue reservation
 			sa.queue.UnReserve(sa.ApplicationID, releases)
 			toRelease += releases
@@ -576,7 +564,7 @@ func (sa *Application) removeAsksInternal(allocKey string, detail si.EventRecord
 	}
 	// clean up the queue pending resources
 	sa.queue.decPendingResource(deltaPendingResource)
-	// Check if we need to change state based on the ask removal:
+	// Check if we need to change state based on the removal:
 	// 1) if pending is zero (no more asks left)
 	// 2) if confirmed allocations is zero (no real tasks running)
 	// Change the state to completing.
@@ -816,144 +804,155 @@ func (sa *Application) IsReservedOnNode(nodeID string) bool {
 	}
 	sa.RLock()
 	defer sa.RUnlock()
-	// make sure matches only for the whole nodeID
-	separator := nodeID + "|"
-	for key := range sa.reservations {
-		if strings.HasPrefix(key, separator) {
+	for _, reserved := range sa.reservations {
+		if reserved.nodeID == nodeID {
 			return true
 		}
 	}
 	return false
 }
 
-// Reserve the application for this node and ask combination.
+// Reserve the application for this node and alloc combination.
 // If the reservation fails the function returns false, if the reservation is made it returns true.
-// If the node and ask combination was already reserved for the application this is a noop and returns true.
+// If the node and alloc combination was already reserved for the application this is a noop and returns true.
 func (sa *Application) Reserve(node *Node, ask *Allocation) error {
+	if node == nil || ask == nil {
+		return fmt.Errorf("reservation creation failed node or alloc are nil on appID %s", sa.ApplicationID)
+	}
 	sa.Lock()
 	defer sa.Unlock()
 	return sa.reserveInternal(node, ask)
 }
 
-// Unlocked version for Reserve that really does the work.
+// reserveInternal is the unlocked version for Reserve that really does the work.
 // Must only be called while holding the application lock.
 func (sa *Application) reserveInternal(node *Node, ask *Allocation) error {
+	allocKey := ask.GetAllocationKey()
+	if sa.requests[allocKey] == nil {
+		log.Log(log.SchedApplication).Debug("alloc is not registered to this app",
+			zap.String("app", sa.ApplicationID),
+			zap.String("allocKey", allocKey))
+		return fmt.Errorf("reservation creation failed alloc %s not found on appID %s", allocKey, sa.ApplicationID)
+	}
 	// create the reservation (includes nil checks)
 	nodeReservation := newReservation(node, sa, ask, true)
 	if nodeReservation == nil {
 		log.Log(log.SchedApplication).Debug("reservation creation failed unexpectedly",
 			zap.String("app", sa.ApplicationID),
-			zap.Any("node", node),
-			zap.Any("ask", ask))
-		return fmt.Errorf("reservation creation failed node or ask are nil on appID %s", sa.ApplicationID)
+			zap.Stringer("node", node),
+			zap.Stringer("alloc", ask))
+		return fmt.Errorf("reservation creation failed node or alloc are nil on appID %s", sa.ApplicationID)
 	}
-	allocKey := ask.GetAllocationKey()
-	if sa.requests[allocKey] == nil {
-		log.Log(log.SchedApplication).Debug("ask is not registered to this app",
-			zap.String("app", sa.ApplicationID),
-			zap.String("allocKey", allocKey))
-		return fmt.Errorf("reservation creation failed ask %s not found on appID %s", allocKey, sa.ApplicationID)
-	}
-	if !sa.canAskReserve(ask) {
-		if ask.IsAllocated() {
-			return fmt.Errorf("ask is already allocated")
-		} else {
-			return fmt.Errorf("ask is already reserved")
-		}
+	// the alloc should not have reserved a node yet: do not allow multiple nodes to be reserved
+	if err := sa.canAllocationReserve(ask); err != nil {
+		return err
 	}
 	// check if we can reserve the node before reserving on the app
 	if err := node.Reserve(sa, ask); err != nil {
 		return err
 	}
-	sa.reservations[nodeReservation.getKey()] = nodeReservation
+	sa.reservations[allocKey] = nodeReservation
 	log.Log(log.SchedApplication).Info("reservation added successfully",
 		zap.String("app", sa.ApplicationID),
 		zap.String("node", node.NodeID),
-		zap.String("ask", allocKey))
+		zap.String("alloc", allocKey))
 	return nil
 }
 
-// UnReserve the application for this node and ask combination.
-// This first removes the reservation from the node.
+// UnReserve the application for this node and alloc combination.
 // If the reservation does not exist it returns 0 for reservations removed, if the reservation is removed it returns 1.
 // The error is set if the reservation key cannot be removed from the app or node.
-func (sa *Application) UnReserve(node *Node, ask *Allocation) (int, error) {
+func (sa *Application) UnReserve(node *Node, ask *Allocation) int {
+	log.Log(log.SchedApplication).Info("unreserving allocation from application",
+		zap.String("appID", sa.ApplicationID),
+		zap.Stringer("node", node),
+		zap.Stringer("alloc", ask))
+	if node == nil || ask == nil {
+		return 0
+	}
 	sa.Lock()
 	defer sa.Unlock()
-	return sa.unReserveInternal(node, ask)
+	reserve, ok := sa.reservations[ask.allocationKey]
+	if !ok {
+		log.Log(log.SchedApplication).Debug("reservation not found on application",
+			zap.String("appID", sa.ApplicationID),
+			zap.String("allocationKey", ask.allocationKey))
+		return 0
+	}
+	if reserve.nodeID != node.NodeID {
+		log.Log(log.SchedApplication).Warn("UnReserve: provided info not consistent with reservation",
+			zap.String("appID", sa.ApplicationID),
+			zap.String("node", reserve.nodeID),
+			zap.String("alloc", reserve.allocKey))
+	}
+	return sa.unReserveInternal(reserve)
 }
 
 // Unlocked version for UnReserve that really does the work.
+// This is idempotent and will not fail
 // Must only be called while holding the application lock.
-func (sa *Application) unReserveInternal(node *Node, ask *Allocation) (int, error) {
-	resKey := reservationKey(node, nil, ask)
-	if resKey == "" {
-		log.Log(log.SchedApplication).Debug("unreserve reservation key create failed unexpectedly",
-			zap.String("appID", sa.ApplicationID),
-			zap.Stringer("node", node),
-			zap.Stringer("ask", ask))
-		return 0, fmt.Errorf("reservation key failed node or ask are nil for appID %s", sa.ApplicationID)
+func (sa *Application) unReserveInternal(reserve *reservation) int {
+	// this should not happen
+	if reserve == nil {
+		return 0
 	}
 	// unReserve the node before removing from the app
-	var num int
-	var err error
-	if num, err = node.unReserve(sa, ask); err != nil {
-		return 0, err
-	}
+	num := reserve.node.unReserve(reserve.alloc)
 	// if the unreserve worked on the node check the app
-	if _, found := sa.reservations[resKey]; found {
+	if _, found := sa.reservations[reserve.allocKey]; found {
 		// worked on the node means either found or not but no error, log difference here
 		if num == 0 {
 			log.Log(log.SchedApplication).Info("reservation not found while removing from node, app has reservation",
 				zap.String("appID", sa.ApplicationID),
-				zap.String("nodeID", node.NodeID),
-				zap.String("ask", ask.GetAllocationKey()))
+				zap.String("nodeID", reserve.nodeID),
+				zap.String("alloc", reserve.allocKey))
 		}
-		delete(sa.reservations, resKey)
-		log.Log(log.SchedApplication).Info("reservation removed successfully", zap.String("node", node.NodeID),
-			zap.String("app", ask.GetApplicationID()), zap.String("ask", ask.GetAllocationKey()))
-		return 1, nil
+		delete(sa.reservations, reserve.allocKey)
+		log.Log(log.SchedApplication).Info("reservation removed successfully",
+			zap.String("appID", sa.ApplicationID),
+			zap.String("node", reserve.nodeID),
+			zap.String("alloc", reserve.allocKey))
+		return 1
 	}
 	// reservation was not found
 	log.Log(log.SchedApplication).Info("reservation not found while removing from app",
 		zap.String("appID", sa.ApplicationID),
-		zap.String("nodeID", node.NodeID),
-		zap.String("ask", ask.GetAllocationKey()),
+		zap.String("node", reserve.nodeID),
+		zap.String("alloc", reserve.allocKey),
 		zap.Int("nodeReservationsRemoved", num))
-	return 0, nil
+	return 0
 }
 
-// Return the allocation reservations on any node.
-// The returned array is 0 or more keys into the reservations map.
-// No locking must be called while holding the lock
-func (sa *Application) GetAskReservations(allocKey string) []string {
-	reservationKeys := make([]string, 0)
-	if allocKey == "" {
-		return reservationKeys
-	}
-	for key := range sa.reservations {
-		if strings.HasSuffix(key, allocKey) {
-			reservationKeys = append(reservationKeys, key)
-		}
-	}
-	return reservationKeys
+// IsAllocationReserved returns true if the allocation has been reserved
+func (sa *Application) IsAllocationReserved(allocKey string) bool {
+	sa.RLock()
+	defer sa.RUnlock()
+	return sa.reservations[allocKey] != nil
 }
 
-// Check if the allocation has already been reserved. An ask can never reserve more than one node.
+// getAllocationReservation returns the reservation object for the allocation
 // No locking must be called while holding the lock
-func (sa *Application) canAskReserve(ask *Allocation) bool {
-	allocKey := ask.GetAllocationKey()
-	if ask.IsAllocated() {
-		log.Log(log.SchedApplication).Debug("ask already allocated, no reservation allowed",
-			zap.String("askKey", allocKey))
-		return false
+func (sa *Application) getAllocationReservation(allocKey string) *reservation {
+	return sa.reservations[allocKey]
+}
+
+// canAllocationReserve Check if the allocation has already been reserved. An alloc can never reserve more than one node.
+// No locking must be called while holding the lock
+func (sa *Application) canAllocationReserve(alloc *Allocation) error {
+	allocKey := alloc.GetAllocationKey()
+	if alloc.IsAllocated() {
+		log.Log(log.SchedApplication).Debug("allocation is marked as allocated, no reservation allowed",
+			zap.String("allocationKey", allocKey))
+		return common.ErrorReservingAlloc
 	}
-	if len(sa.GetAskReservations(allocKey)) > 0 {
+	reserved := sa.getAllocationReservation(allocKey)
+	if reserved != nil {
 		log.Log(log.SchedApplication).Debug("reservation already exists",
-			zap.String("askKey", allocKey))
-		return false
+			zap.String("allocKey", allocKey),
+			zap.String("nodeID", reserved.nodeID))
+		return common.ErrorDuplicateReserve
 	}
-	return true
+	return nil
 }
 
 func (sa *Application) getOutstandingRequests(headRoom *resources.Resource, userHeadRoom *resources.Resource, total *[]*Allocation) {
@@ -1045,42 +1044,13 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption
 		requiredNode := request.GetRequiredNode()
 		// does request have any constraint to run on specific node?
 		if requiredNode != "" {
-			// the iterator might not have the node we need as it could be reserved, or we have not added it yet
-			node := getNodeFn(requiredNode)
-			if node == nil {
-				getRateLimitedAppLog().Info("required node is not found (could be transient)",
-					zap.String("application ID", sa.ApplicationID),
-					zap.String("allocationKey", request.GetAllocationKey()),
-					zap.String("required node", requiredNode))
-				return nil
-			}
-			// Are there any non daemon set reservations on specific required node?
-			// Cancel those reservations to run daemon set pods
-			reservations := node.GetReservations()
-			if len(reservations) > 0 {
-				if !sa.cancelReservations(reservations) {
-					return nil
-				}
-			}
-			// we don't care about predicate error messages here
-			result, _ := sa.tryNode(node, request) //nolint:errcheck
+			result := sa.tryRequiredNode(request, getNodeFn)
 			if result != nil {
-				// check if the node was reserved and we allocated after a release
-				if _, ok := sa.reservations[reservationKey(node, nil, request)]; ok {
-					log.Log(log.SchedApplication).Debug("allocation on required node after release",
-						zap.String("appID", sa.ApplicationID),
-						zap.String("nodeID", requiredNode),
-						zap.String("allocationKey", request.GetAllocationKey()))
-					result.ResultType = AllocatedReserved
-					return result
-				}
-				log.Log(log.SchedApplication).Debug("allocation on required node is completed",
-					zap.String("nodeID", node.NodeID),
-					zap.String("allocationKey", request.GetAllocationKey()),
-					zap.Stringer("resultType", result.ResultType))
 				return result
 			}
-			return newReservedAllocationResult(node.NodeID, request)
+			// it did not allocate or reserve: should only happen if the node is not registered yet
+			// just continue with the next request
+			continue
 		}
 
 		iterator := nodeIterator()
@@ -1108,50 +1078,80 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption
 	return nil
 }
 
-func (sa *Application) cancelReservations(reservations []*reservation) bool {
-	for _, res := range reservations {
-		// skip the node
-		if res.ask.GetRequiredNode() != "" {
-			log.Log(log.SchedApplication).Warn("reservation for ask with required node already exists on the node",
-				zap.String("required node", res.node.NodeID),
-				zap.String("existing ask reservation key", res.getKey()))
-			return false
-		}
+// tryRequiredNode tries to place the allocation in the specific node that is set as the required node in the allocation.
+// The first time the allocation is seen it will try to make the allocation on the node. If that does not work it will
+// always trigger the reservation of the node.
+func (sa *Application) tryRequiredNode(request *Allocation, getNodeFn func(string) *Node) *AllocationResult {
+	requiredNode := request.GetRequiredNode()
+	allocationKey := request.GetAllocationKey()
+	// the iterator might not have the node we need as it could be reserved, or we have not added it yet
+	node := getNodeFn(requiredNode)
+	if node == nil {
+		getRateLimitedAppLog().Info("required node is not found (could be transient)",
+			zap.String("application ID", sa.ApplicationID),
+			zap.String("allocationKey", allocationKey),
+			zap.String("required node", requiredNode))
+		return nil
 	}
-	var err error
+	// Are there any reservations on this node that does not specifically require this node?
+	// Cancel any reservations to make room for the allocations that require the node
 	var num int
+	reservations := node.GetReservations()
+	if len(reservations) > 0 {
+		num = sa.cancelReservations(reservations)
+	}
+	// now try the request, we don't care about predicate error messages here
+	result, _ := sa.tryNode(node, request) //nolint:errcheck
+	if result != nil {
+		result.CancelledReservations = num
+		// check if the node was reserved and we allocated after a release
+		if _, ok := sa.reservations[allocationKey]; ok {
+			log.Log(log.SchedApplication).Debug("allocation on required node after release",
+				zap.String("appID", sa.ApplicationID),
+				zap.String("nodeID", requiredNode),
+				zap.String("allocationKey", allocationKey))
+			result.ResultType = AllocatedReserved
+			return result
+		}
+		log.Log(log.SchedApplication).Debug("allocation on required node is completed",
+			zap.String("nodeID", node.NodeID),
+			zap.String("allocationKey", allocationKey),
+			zap.Stringer("resultType", result.ResultType))
+		return result
+	}
+	result = newReservedAllocationResult(node.NodeID, request)
+	result.CancelledReservations = num
+	return result
+}
+
+// cancelReservations will cancel all non required node reservations for a node. The list of reservations passed in is
+// a copy of all reservations of a single node. This is called during the required node allocation cycle only.
+// The returned int value is used to update the partition counter of active reservations.
+func (sa *Application) cancelReservations(reservations []*reservation) int {
+	var released, num int
 	// un reserve all the apps that were reserved on the node
 	for _, res := range reservations {
+		// cleanup if the reservation does not have this node as a requirement
+		if res.alloc.requiredNode != "" {
+			continue
+		}
 		thisApp := res.app.ApplicationID == sa.ApplicationID
 		if thisApp {
-			num, err = sa.unReserveInternal(res.node, res.ask)
-		} else {
-			num, err = res.app.UnReserve(res.node, res.ask)
-		}
-		if err != nil {
-			log.Log(log.SchedApplication).Warn("Unable to cancel reservations on node",
-				zap.String("victim application ID", res.app.ApplicationID),
-				zap.String("victim allocationKey", res.getKey()),
-				zap.String("required node", res.node.NodeID),
-				zap.Int("reservations count", num),
-				zap.String("application ID", sa.ApplicationID))
-			return false
-		} else {
-			log.Log(log.SchedApplication).Info("Cancelled reservation on required node",
-				zap.String("affected application ID", res.app.ApplicationID),
-				zap.String("affected allocationKey", res.getKey()),
-				zap.String("required node", res.node.NodeID),
-				zap.Int("reservations count", num),
-				zap.String("application ID", sa.ApplicationID))
-		}
-		// remove the reservation of the queue
-		if thisApp {
+			num = sa.unReserveInternal(res)
 			sa.queue.UnReserve(sa.ApplicationID, num)
 		} else {
+			num = res.app.UnReserve(res.node, res.alloc)
 			res.app.GetQueue().UnReserve(res.app.ApplicationID, num)
 		}
+		log.Log(log.SchedApplication).Info("Cancelled reservation for required node allocation",
+			zap.String("triggered by appID", sa.ApplicationID),
+			zap.String("affected application ID", res.appID),
+			zap.String("affected allocationKey", res.allocKey),
+			zap.String("required node", res.nodeID),
+			zap.Int("reservations count", num))
+		released += num
 	}
-	return true
+	return released
 }
 
 // tryPlaceholderAllocate tries to replace a placeholder that is allocated with a real allocation
@@ -1238,14 +1238,15 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 	// pick the first fit and try all nodes if that fails give up
 	var allocResult *AllocationResult
 	if phFit != nil && reqFit != nil {
+		resKey := reqFit.GetAllocationKey()
 		iterator.ForEachNode(func(node *Node) bool {
 			if !node.IsSchedulable() {
-				log.Log(log.SchedApplication).Debug("skipping node for placeholder ask as state is unschedulable",
-					zap.String("allocationKey", reqFit.GetAllocationKey()),
+				log.Log(log.SchedApplication).Debug("skipping node for placeholder alloc as state is unschedulable",
+					zap.String("allocationKey", resKey),
 					zap.String("node", node.NodeID))
 				return true
 			}
-			if !node.preAllocateCheck(reqFit.GetAllocatedResource(), reservationKey(nil, sa, reqFit)) {
+			if !node.preAllocateCheck(reqFit.GetAllocatedResource(), resKey) {
 				return true
 			}
 			// skip the node if conditions can not be satisfied
@@ -1257,7 +1258,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 			if !node.TryAddAllocation(reqFit) {
 				log.Log(log.SchedApplication).Debug("Node update failed unexpectedly",
 					zap.String("applicationID", sa.ApplicationID),
-					zap.Stringer("ask", reqFit),
+					zap.Stringer("alloc", reqFit),
 					zap.Stringer("placeholder", phFit))
 				return false
 			}
@@ -1266,7 +1267,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 				log.Log(log.SchedApplication).Warn("allocation of ask failed unexpectedly",
 					zap.Error(err))
 				// unwind node allocation
-				_ = node.RemoveAllocation(reqFit.GetAllocationKey())
+				_ = node.RemoveAllocation(resKey)
 				return false
 			}
 			// allocation worked: on a non placeholder node update resultType and return
@@ -1297,7 +1298,7 @@ func (sa *Application) checkHeadRooms(ask *Allocation, userHeadroom *resources.R
 	return userHeadroom.FitInMaxUndef(ask.GetAllocatedResource()) && headRoom.FitInMaxUndef(ask.GetAllocatedResource())
 }
 
-// Try a reserved allocation of an outstanding reservation
+// tryReservedAllocate tries allocating an outstanding reservation
 func (sa *Application) tryReservedAllocate(headRoom *resources.Resource, nodeIterator func() NodeIterator) *AllocationResult {
 	sa.Lock()
 	defer sa.Unlock()
@@ -1306,14 +1307,14 @@ func (sa *Application) tryReservedAllocate(headRoom *resources.Resource, nodeIte
 
 	// process all outstanding reservations and pick the first one that fits
 	for _, reserve := range sa.reservations {
-		ask := sa.requests[reserve.askKey]
+		ask := sa.requests[reserve.allocKey]
 		// sanity check and cleanup if needed
 		if ask == nil || ask.IsAllocated() {
 			var unreserveAsk *Allocation
 			// if the ask was not found we need to construct one to unreserve
 			if ask == nil {
 				unreserveAsk = &Allocation{
-					allocationKey: reserve.askKey,
+					allocationKey: reserve.allocKey,
 					applicationID: sa.ApplicationID,
 					allocLog:      make(map[string]*AllocationLogEntry),
 				}
@@ -1348,17 +1349,17 @@ func (sa *Application) tryReservedAllocate(headRoom *resources.Resource, nodeIte
 
 	// try this on all other nodes
 	for _, reserve := range sa.reservations {
-		// Other nodes cannot be tried if the ask has a required node
-		ask := reserve.ask
-		if ask.GetRequiredNode() != "" {
+		// Other nodes cannot be tried if a required node is requested
+		alloc := reserve.alloc
+		if alloc.GetRequiredNode() != "" {
 			continue
 		}
 		iterator := nodeIterator()
 		if iterator != nil {
-			if !sa.checkHeadRooms(ask, userHeadroom, headRoom) {
+			if !sa.checkHeadRooms(alloc, userHeadroom, headRoom) {
 				continue
 			}
-			result := sa.tryNodesNoReserve(ask, iterator, reserve.nodeID)
+			result := sa.tryNodesNoReserve(alloc, iterator, reserve.nodeID)
 			// have a candidate return it, including the node that was reserved
 			if result != nil {
 				return result
@@ -1413,8 +1414,8 @@ func (sa *Application) tryRequiredNodePreemption(reserve *reservation, ask *Allo
 	return false
 }
 
-// Try all the nodes for a reserved request that have not been tried yet.
-// This should never result in a reservation as the ask is already reserved
+// tryNodesNoReserve tries all the nodes for a reserved request that have not been tried yet.
+// This should never result in a reservation as the allocation is already reserved
 func (sa *Application) tryNodesNoReserve(ask *Allocation, iterator NodeIterator, reservedNode string) *AllocationResult {
 	var allocResult *AllocationResult
 	iterator.ForEachNode(func(node *Node) bool {
@@ -1449,14 +1450,13 @@ func (sa *Application) tryNodesNoReserve(ask *Allocation, iterator NodeIterator,
 func (sa *Application) tryNodes(ask *Allocation, iterator NodeIterator) *AllocationResult {
 	var nodeToReserve *Node
 	scoreReserved := math.Inf(1)
-	// check if the ask is reserved or not
+	// check if the alloc is reserved or not
 	allocKey := ask.GetAllocationKey()
-	reservedAsks := sa.GetAskReservations(allocKey)
-	allowReserve := !ask.IsAllocated() && len(reservedAsks) == 0
+	reserved := sa.getAllocationReservation(allocKey)
 	var allocResult *AllocationResult
 	var predicateErrors map[string]int
 	iterator.ForEachNode(func(node *Node) bool {
-		// skip the node if the node is not valid for the ask
+		// skip the node if the node is not schedulable
 		if !node.IsSchedulable() {
 			log.Log(log.SchedApplication).Debug("skipping node for ask as state is unschedulable",
 				zap.String("allocationKey", allocKey),
@@ -1478,28 +1478,23 @@ func (sa *Application) tryNodes(ask *Allocation, iterator NodeIterator) *Allocat
 		// allocation worked so return
 		if result != nil {
 			metrics.GetSchedulerMetrics().ObserveTryNodeLatency(tryNodeStart)
-			// check if the node was reserved for this ask: if it is set the resultType and return
-			// NOTE: this is a safeguard as reserved nodes should never be part of the iterator
-			// but we have no locking
-			if _, ok := sa.reservations[reservationKey(node, nil, ask)]; ok {
-				log.Log(log.SchedApplication).Debug("allocate found reserved ask during non reserved allocate",
-					zap.String("appID", sa.ApplicationID),
-					zap.String("nodeID", node.NodeID),
-					zap.String("allocationKey", allocKey))
+			// check if the alloc had a reservation: if it has set the resultType and return
+			if reserved != nil {
+				if reserved.nodeID != node.NodeID {
+					// we have a different node reserved for this alloc
+					log.Log(log.SchedApplication).Debug("allocate picking reserved alloc during non reserved allocate",
+						zap.String("appID", sa.ApplicationID),
+						zap.String("reserved nodeID", reserved.nodeID),
+						zap.String("allocationKey", allocKey))
+					result.ReservedNodeID = reserved.nodeID
+				} else {
+					// NOTE: this is a safeguard as reserved nodes should never be part of the iterator
+					log.Log(log.SchedApplication).Debug("allocate found reserved alloc during non reserved allocate",
+						zap.String("appID", sa.ApplicationID),
+						zap.String("nodeID", node.NodeID),
+						zap.String("allocationKey", allocKey))
+				}
 				result.ResultType = AllocatedReserved
-				allocResult = result
-				return false
-			}
-			// we could also have a different node reserved for this ask if it has pick one of
-			// the reserved nodes to unreserve (first one in the list)
-			if len(reservedAsks) > 0 {
-				nodeID := strings.TrimSuffix(reservedAsks[0], "|"+allocKey)
-				log.Log(log.SchedApplication).Debug("allocate picking reserved ask during non reserved allocate",
-					zap.String("appID", sa.ApplicationID),
-					zap.String("nodeID", nodeID),
-					zap.String("allocationKey", allocKey))
-				result.ResultType = AllocatedReserved
-				result.ReservedNodeID = nodeID
 				allocResult = result
 				return false
 			}
@@ -1509,14 +1504,14 @@ func (sa *Application) tryNodes(ask *Allocation, iterator NodeIterator) *Allocat
 		}
 		// nothing allocated should we look at a reservation?
 		askAge := time.Since(ask.GetCreateTime())
-		if allowReserve && askAge > reservationDelay {
+		if reserved == nil && askAge > reservationDelay {
 			log.Log(log.SchedApplication).Debug("app reservation check",
 				zap.String("allocationKey", allocKey),
 				zap.Time("createTime", ask.GetCreateTime()),
 				zap.Duration("askAge", askAge),
 				zap.Duration("reservationDelay", reservationDelay))
 			score := node.GetFitInScoreForAvailableResource(ask.GetAllocatedResource())
-			// Record the so-far best node to reserve
+			// Record the best node so-far to reserve
 			if score < scoreReserved {
 				scoreReserved = score
 				nodeToReserve = node
@@ -1540,7 +1535,7 @@ func (sa *Application) tryNodes(ask *Allocation, iterator NodeIterator) *Allocat
 			zap.String("appID", sa.ApplicationID),
 			zap.String("nodeID", nodeToReserve.NodeID),
 			zap.String("allocationKey", allocKey),
-			zap.Int("reservations", len(reservedAsks)))
+			zap.Int("reservations", len(sa.reservations)))
 		// skip the node if conditions can not be satisfied
 		if nodeToReserve.preReserveConditions(ask) != nil {
 			return nil
@@ -1552,11 +1547,12 @@ func (sa *Application) tryNodes(ask *Allocation, iterator NodeIterator) *Allocat
 	return nil
 }
 
-// Try allocating on one specific node
+// tryNode tries allocating on one specific node
 func (sa *Application) tryNode(node *Node, ask *Allocation) (*AllocationResult, error) {
 	toAllocate := ask.GetAllocatedResource()
+	allocationKey := ask.GetAllocationKey()
 	// create the key for the reservation
-	if !node.preAllocateCheck(toAllocate, reservationKey(nil, sa, ask)) {
+	if !node.preAllocateCheck(toAllocate, allocationKey) {
 		// skip schedule onto node
 		return nil, nil
 	}
@@ -1571,13 +1567,13 @@ func (sa *Application) tryNode(node *Node, ask *Allocation) (*AllocationResult, 
 			log.Log(log.SchedApplication).DPanic("queue update failed unexpectedly",
 				zap.Error(err))
 			// revert the node update
-			node.RemoveAllocation(ask.GetAllocationKey())
+			node.RemoveAllocation(allocationKey)
 			return nil, nil
 		}
-		// mark this ask as allocated
+		// mark this alloc as allocated
 		_, err := sa.allocateAsk(ask)
 		if err != nil {
-			log.Log(log.SchedApplication).Warn("allocation of ask failed unexpectedly",
+			log.Log(log.SchedApplication).Warn("allocation of alloc failed unexpectedly",
 				zap.Error(err))
 		}
 		// all is OK, last update for the app

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -292,11 +292,8 @@ func TestAppReservation(t *testing.T) {
 		t.Errorf("reservation should have failed")
 	}
 
-	// unreserve unknown node/ask
-	_, err = app.UnReserve(nil, nil)
-	if err == nil {
-		t.Errorf("illegal reservation release but did not fail")
-	}
+	// unreserve unknown node/alloc
+	assert.Equal(t, app.UnReserve(nil, nil), 0, "illegal reservation release should have returned 0")
 
 	// 2nd reservation for app
 	ask2 := newAllocationAsk("alloc-2", appID1, res)
@@ -309,20 +306,16 @@ func TestAppReservation(t *testing.T) {
 	}
 	err = app.Reserve(node2, ask2)
 	assert.NilError(t, err, "reservation of 2nd node should not have failed")
-	_, err = app.UnReserve(node2, ask2)
-	assert.NilError(t, err, "remove of reservation of 2nd node should not have failed")
+	assert.Equal(t, app.UnReserve(node2, ask2), 1, "remove of reservation of 2nd node should not have failed")
 
 	// unreserve the same should fail
-	_, err = app.UnReserve(node2, ask2)
-	assert.NilError(t, err, "remove twice of reservation of 2nd node should have failed")
+	assert.Equal(t, app.UnReserve(node2, ask2), 0, "remove twice of reservation of 2nd node should return 0")
 
 	// failure case: remove reservation from node, app still needs cleanup
 	var num int
-	num, err = node.unReserve(app, ask)
-	assert.NilError(t, err, "un-reserve on node should not have failed")
+	num = node.unReserve(ask)
 	assert.Equal(t, num, 1, "un-reserve on node should have removed reservation")
-	num, err = app.UnReserve(node, ask)
-	assert.NilError(t, err, "app has reservation should not have failed")
+	num = app.UnReserve(node, ask)
 	assert.Equal(t, num, 1, "un-reserve on app should have removed reservation from app")
 }
 
@@ -338,12 +331,9 @@ func TestAppAllocReservation(t *testing.T) {
 	if app == nil || app.ApplicationID != appID1 {
 		t.Fatalf("app create failed which should not have %v", app)
 	}
-	if app.HasReserved() {
-		t.Fatal("new app should not have reservations")
-	}
-	if len(app.GetAskReservations("")) != 0 {
-		t.Fatal("new app should not have reservation for empty allocKey")
-	}
+	assert.Assert(t, !app.HasReserved(), "new app should not have reservations")
+	assert.Equal(t, len(app.GetReservations()), 0, "new app should not have reservation for empty allocKey")
+
 	queue, err := createRootQueue(nil)
 	assert.NilError(t, err, "queue create failed")
 	app.queue = queue
@@ -360,46 +350,41 @@ func TestAppAllocReservation(t *testing.T) {
 	assert.NilError(t, err, "ask2 should have been added to app")
 	err = app.Reserve(node1, ask)
 	assert.NilError(t, err, "reservation should not have failed")
-	if len(app.GetAskReservations("")) != 0 {
+	if app.getAllocationReservation("") != nil {
 		t.Fatal("app should not have reservation for empty allocKey")
 	}
-	nodeKey1 := nodeID1 + "|" + aKey
-	askReserved := app.GetAskReservations(aKey)
-	if len(askReserved) != 1 || askReserved[0] != nodeKey1 {
-		t.Errorf("app should have reservations for %s on %s and has not", aKey, nodeID1)
+	allocReserved := app.getAllocationReservation(aKey)
+	if allocReserved == nil || allocReserved.nodeID != nodeID1 {
+		t.Fatalf("app should have reservations for %s on %s and has not", aKey, nodeID1)
 	}
 
-	nodeID2 := "node-2"
 	node2 := newNode(nodeID2, map[string]resources.Quantity{"first": 10})
 	err = app.Reserve(node2, ask2)
 	assert.NilError(t, err, "reservation should not have failed: error %v", err)
-	nodeKey2 := nodeID2 + "|" + aKey2
-	askReserved = app.GetAskReservations(aKey2)
-	if len(askReserved) != 1 && askReserved[0] != nodeKey2 {
-		t.Errorf("app should have reservations for %s on %s and has not", aKey, nodeID2)
+	allocReserved = app.getAllocationReservation(aKey2)
+	if allocReserved == nil || allocReserved.nodeID != nodeID2 {
+		t.Fatalf("app should have reservations for %s on %s and has not", aKey, nodeID2)
 	}
 
 	// check duplicate reserve: nothing should change
-	if app.canAskReserve(ask) {
-		t.Error("ask has already reserved, reserve check should have failed")
-	}
+	assert.Assert(t, app.canAllocationReserve(ask) != nil, "alloc has already reserved, reserve check should have failed")
 	node3 := newNode("node-3", map[string]resources.Quantity{"first": 10})
 	err = app.Reserve(node3, ask)
 	if err == nil {
-		t.Errorf("reservation should have failed")
+		t.Fatal("reservation should have failed")
 	}
-	askReserved = app.GetAskReservations(aKey)
-	if len(askReserved) != 1 && askReserved[0] != nodeKey1 {
-		t.Errorf("app should have reservations for node %s and has not: %v", nodeID1, askReserved)
+	allocReserved = app.getAllocationReservation(aKey)
+	if allocReserved == nil || allocReserved.nodeID != nodeID1 {
+		t.Fatalf("app should have reservations for node %s and has not: %v", nodeID1, allocReserved)
 	}
-	askReserved = app.GetAskReservations(aKey2)
-	if len(askReserved) != 1 && askReserved[0] != nodeKey2 {
-		t.Errorf("app should have reservations for node %s and has not: %v", nodeID2, askReserved)
+	allocReserved = app.getAllocationReservation(aKey2)
+	if allocReserved == nil || allocReserved.nodeID != nodeID2 {
+		t.Fatalf("app should have reservations for node %s and has not: %v", nodeID2, allocReserved)
 	}
 	// clean up all asks and reservations
-	reservedAsks := app.RemoveAllocationAsk("")
-	if app.HasReserved() || node1.IsReserved() || node2.IsReserved() || reservedAsks != 2 {
-		t.Errorf("ask removal did not clean up all reservations, reserved released = %d", reservedAsks)
+	reservedRelease := app.RemoveAllocationAsk("")
+	if app.HasReserved() || node1.IsReserved() || node2.IsReserved() || reservedRelease != 2 {
+		t.Fatalf("ask removal did not clean up all reservations, reserved released = %d", reservedRelease)
 	}
 }
 
@@ -495,7 +480,6 @@ func TestAddAllocAsk(t *testing.T) {
 	// test add alloc ask event
 	noEvents := uint64(0)
 	err = common.WaitForCondition(10*time.Millisecond, time.Second, func() bool {
-		fmt.Printf("checking event length: %d\n", eventSystem.Store.CountStoredEvents())
 		noEvents = eventSystem.Store.CountStoredEvents()
 		return noEvents == 2
 	})
@@ -652,7 +636,7 @@ func TestRemoveReservedAllocAsk(t *testing.T) {
 	node := newNode(nodeID1, map[string]resources.Quantity{"first": 10})
 	err = app.Reserve(node, ask2)
 	assert.NilError(t, err, "reservation should not have failed")
-	if len(app.GetAskReservations(allocKey)) != 1 || !node.IsReserved() {
+	if app.getAllocationReservation(allocKey) == nil || !node.IsReserved() {
 		t.Fatalf("app should have reservation for %v on node", allocKey)
 	}
 	before := app.GetPendingResource().Clone()
@@ -671,11 +655,10 @@ func TestRemoveReservedAllocAsk(t *testing.T) {
 
 	err = app.Reserve(node, ask2)
 	assert.NilError(t, err, "reservation should not have failed: error %v", err)
-	if len(app.GetAskReservations(allocKey)) != 1 || !node.IsReserved() {
+	if app.getAllocationReservation(allocKey) == nil || !node.IsReserved() {
 		t.Fatalf("app should have reservation for %v on node", allocKey)
 	}
-	var num int
-	num, err = node.unReserve(app, ask2)
+	num := node.unReserve(ask2)
 	assert.NilError(t, err, "un-reserve on node should not have failed")
 	assert.Equal(t, num, 1, "un-reserve on node should have removed reservation")
 
@@ -1952,6 +1935,134 @@ func TestCanReplace(t *testing.T) {
 			assert.Equal(t, tt.want, app.canReplace(tt.ask), "unexpected replacement")
 		})
 	}
+}
+
+func TestTryRequiredNode(t *testing.T) {
+	node := newNode(nodeID1, map[string]resources.Quantity{"first": 5})
+	nodeMap := map[string]*Node{nodeID1: node}
+	getNode := func(nodeID string) *Node {
+		return nodeMap[nodeID]
+	}
+	resMap := map[string]string{"first": "5"}
+	rootQ, err := createRootQueue(resMap)
+	assert.NilError(t, err, "unexpected error when creating root queue")
+	var childQ *Queue
+	childQ, err = createManagedQueue(rootQ, "child", false, resMap)
+	assert.NilError(t, err, "unexpected error when creating child queue")
+
+	app := newApplication(appID1, "default", "root.child")
+	app.SetQueue(childQ)
+	childQ.applications[appID1] = app
+	allocRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 3})
+	alloc := newAllocation(aKey, nodeID1, allocRes)
+	app.AddAllocation(alloc)
+	node.AddAllocation(alloc)
+
+	ask := newAllocationAsk(aKey2, appID1, allocRes)
+	ask.requiredNode = nodeID1
+	err = app.AddAllocationAsk(ask)
+	assert.NilError(t, err, "unexpected error when adding an ask")
+
+	result := app.tryRequiredNode(ask, getNode)
+	assert.Assert(t, result != nil, "alloc expected")
+	assert.Assert(t, result.Request == ask, "alloc expected for the ask")
+	assert.Equal(t, result.ResultType, Reserved, "expected reserved result")
+	assert.Equal(t, nodeID1, result.NodeID, "wrong node")
+}
+
+func TestTryRequiredNodeCancel(t *testing.T) {
+	node := newNode(nodeID1, map[string]resources.Quantity{"first": 5})
+	nodeMap := map[string]*Node{nodeID1: node}
+	getNode := func(nodeID string) *Node {
+		return nodeMap[nodeID]
+	}
+	resMap := map[string]string{"first": "5"}
+	rootQ, err := createRootQueue(resMap)
+	assert.NilError(t, err, "unexpected error when creating root queue")
+	var childQ *Queue
+	childQ, err = createManagedQueue(rootQ, "child", false, resMap)
+	assert.NilError(t, err, "unexpected error when creating child queue")
+
+	app := newApplication(appID1, "default", "root.child")
+	app.SetQueue(childQ)
+	childQ.applications[appID1] = app
+	allocRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 3})
+	alloc := newAllocation(aKey, nodeID1, allocRes)
+	app.AddAllocation(alloc)
+	node.AddAllocation(alloc)
+
+	ask := newAllocationAsk(aKey2, appID1, allocRes)
+	err = app.AddAllocationAsk(ask)
+	assert.NilError(t, err, "adding new allocation to app failed unexpected")
+	err = app.reserveInternal(node, ask)
+	assert.NilError(t, err, "reserving new allocation on app/node failed unexpected")
+	assert.Assert(t, node.isReservedForAllocation(aKey2), "expecting alloc reservation on node")
+	assert.Assert(t, app.IsAllocationReserved(aKey2), "expecting reservation for alloc-2 on app")
+	assert.Assert(t, app.IsReservedOnNode(nodeID1), "expecting app reservation on node")
+
+	ask = newAllocationAsk(aKey3, appID1, allocRes)
+	ask.requiredNode = nodeID1
+	err = app.AddAllocationAsk(ask)
+	assert.NilError(t, err, "adding new allocation to app failed unexpected")
+	result := app.tryRequiredNode(ask, getNode)
+	assert.Assert(t, result != nil, "alloc expected")
+	assert.Assert(t, result.Request == ask, "alloc expected for the ask")
+	assert.Equal(t, result.ResultType, Reserved, "expected allocated result")
+	assert.Equal(t, result.CancelledReservations, 1, "expected 1 cancelled reservation")
+	assert.Equal(t, nodeID1, result.NodeID, "wrong node")
+	assert.Assert(t, !node.isReservedForAllocation(aKey2), "expecting no reservation for alloc-2 on node")
+	assert.Assert(t, !app.IsAllocationReserved(aKey2), "expecting no reservation for alloc-2 on app")
+}
+
+func TestTryRequiredNodeAdd(t *testing.T) {
+	node := newNode(nodeID1, map[string]resources.Quantity{"first": 5})
+	nodeMap := map[string]*Node{nodeID1: node}
+	getNode := func(nodeID string) *Node {
+		return nodeMap[nodeID]
+	}
+	rootQ, err := createRootQueue(map[string]string{"first": "5"})
+	assert.NilError(t, err, "unexpected error when creating root queue")
+	var childQ *Queue
+	childQ, err = createManagedQueue(rootQ, "child", false, map[string]string{"first": "5"})
+	assert.NilError(t, err, "unexpected error when creating child queue")
+
+	app := newApplication(appID1, "default", "root.child")
+	app.SetQueue(childQ)
+	childQ.applications[appID1] = app
+	allocRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 3})
+	alloc := newAllocation(aKey, nodeID1, allocRes)
+	app.AddAllocation(alloc)
+	node.AddAllocation(alloc)
+
+	ask := newAllocationAsk(aKey2, appID1, allocRes)
+	ask.requiredNode = nodeID1
+	err = app.AddAllocationAsk(ask)
+	assert.NilError(t, err, "adding new allocation to app failed unexpected")
+
+	result := app.tryRequiredNode(ask, getNode)
+	assert.Assert(t, result != nil, "alloc expected")
+	assert.Assert(t, result.Request == ask, "alloc expected for the ask")
+	assert.Equal(t, result.ResultType, Reserved, "expected reserved result")
+	assert.Equal(t, nodeID1, result.NodeID, "wrong node")
+
+	// finish processing do what the context would do
+	err = app.reserveInternal(node, ask)
+	assert.NilError(t, err, "reservation processing failed unexpected")
+
+	ask = newAllocationAsk(aKey3, appID1, allocRes)
+	ask.requiredNode = nodeID1
+	err = app.AddAllocationAsk(ask)
+	assert.NilError(t, err, "adding new allocation to app failed unexpected")
+	result = app.tryRequiredNode(ask, getNode)
+	assert.Assert(t, result != nil, "alloc expected")
+	assert.Assert(t, result.Request == ask, "alloc expected for the ask")
+	assert.Equal(t, result.ResultType, Reserved, "expected allocated result")
+	assert.Equal(t, result.CancelledReservations, 0, "expected no cancelled reservation")
+	assert.Equal(t, nodeID1, result.NodeID, "wrong node")
+	assert.Assert(t, node.isReservedForAllocation(aKey2), "expecting reservation for alloc-2 on node")
+	assert.Assert(t, app.IsAllocationReserved(aKey2), "expecting reservation for alloc-2 on app")
+	assert.Assert(t, !node.isReservedForAllocation(aKey3), "expecting no reservation for alloc-3 on node")
+	assert.Assert(t, !app.IsAllocationReserved(aKey3), "expecting no reservation for alloc-3 on app")
 }
 
 func TestTryAllocateNoRequests(t *testing.T) {

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -20,17 +20,17 @@ package objects
 
 import (
 	"fmt"
-	"strings"
 
 	"go.uber.org/zap"
 
+	"github.com/apache/yunikorn-core/pkg/common"
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/events"
 	"github.com/apache/yunikorn-core/pkg/locking"
 	"github.com/apache/yunikorn-core/pkg/log"
 	"github.com/apache/yunikorn-core/pkg/plugins"
 	schedEvt "github.com/apache/yunikorn-core/pkg/scheduler/objects/events"
-	"github.com/apache/yunikorn-scheduler-interface/lib/go/common"
+	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
@@ -110,9 +110,9 @@ func (sn *Node) initializeAttribute(newAttributes map[string]string) {
 		sn.attributes = map[string]string{}
 	}
 
-	sn.Hostname = sn.attributes[common.HostName]
-	sn.Rackname = sn.attributes[common.RackName]
-	sn.Partition = sn.attributes[common.NodePartition]
+	sn.Hostname = sn.attributes[siCommon.HostName]
+	sn.Rackname = sn.attributes[siCommon.RackName]
+	sn.Partition = sn.attributes[siCommon.NodePartition]
 }
 
 // Get an attribute by name. The most used attributes can be directly accessed via the
@@ -129,7 +129,7 @@ func (sn *Node) GetAttributes() map[string]string {
 // Get InstanceType of this node.
 // This is a lock free call because all attributes are considered read only
 func (sn *Node) GetInstanceType() string {
-	itype := sn.GetAttribute(common.InstanceType)
+	itype := sn.GetAttribute(siCommon.InstanceType)
 	if itype != "" {
 		return itype
 	}
@@ -521,7 +521,7 @@ func (sn *Node) preConditions(ask *Allocation, allocate bool) error {
 
 // preAllocateCheck checks if the node should be considered as a possible node to allocate on.
 // No updates are made this only performs a pre allocate checks
-func (sn *Node) preAllocateCheck(res *resources.Resource, resKey string) bool {
+func (sn *Node) preAllocateCheck(res *resources.Resource, allocationKey string) bool {
 	// cannot allocate zero or negative resource
 	if !resources.StrictlyGreaterThanZero(res) {
 		log.Log(log.SchedNode).Debug("pre alloc check: requested resource is zero",
@@ -530,10 +530,10 @@ func (sn *Node) preAllocateCheck(res *resources.Resource, resKey string) bool {
 	}
 	// check if the node is reserved for this app/alloc
 	if sn.IsReserved() {
-		if !sn.isReservedForApp(resKey) {
-			log.Log(log.SchedNode).Debug("pre alloc check: node reserved for different app or ask",
+		if !sn.isReservedForAllocation(allocationKey) {
+			log.Log(log.SchedNode).Debug("pre alloc check: node reserved for different alloc",
 				zap.String("nodeID", sn.NodeID),
-				zap.String("resKey", resKey))
+				zap.String("allocationKey", allocationKey))
 			return false
 		}
 	}
@@ -544,95 +544,98 @@ func (sn *Node) preAllocateCheck(res *resources.Resource, resKey string) bool {
 	return sn.availableResource.FitIn(res)
 }
 
-// Return if the node has been reserved by any application
+// IsReserved returns true if the node has been reserved for an allocation
 func (sn *Node) IsReserved() bool {
 	sn.RLock()
 	defer sn.RUnlock()
 	return len(sn.reservations) > 0
 }
 
-// isReservedForApp returns true if and only if the node has been reserved by the application
-// NOTE: a return value of false does not mean the node is not reserved by a different app
-func (sn *Node) isReservedForApp(key string) bool {
+// isReservedForAllocation returns true if and only if the node has been reserved by this allocation
+// NOTE: a return value of false does not mean the node is not reserved by a different allocation, use IsReserved
+// to test if the node has any reservation.
+func (sn *Node) isReservedForAllocation(key string) bool {
 	if key == "" {
 		return false
 	}
 	sn.RLock()
 	defer sn.RUnlock()
-	if strings.Contains(key, "|") {
-		return sn.reservations[key] != nil
-	}
-	// make sure matches only for the whole appID
-	separator := key + "|"
-	for resKey := range sn.reservations {
-		if strings.HasPrefix(resKey, separator) {
-			return true
-		}
-	}
-	return false
+	return sn.reservations[key] != nil
 }
 
-// Reserve the node for this application and ask combination, if not reserved yet.
+// Reserve the node for this application and alloc combination.
 // The reservation is checked against the node resources.
-// If the reservation fails the function returns false, if the reservation is made it returns true.
+// If the reservation fails the function returns an error, if the reservation is made it returns nil.
 func (sn *Node) Reserve(app *Application, ask *Allocation) error {
-	defer sn.notifyListeners()
 	sn.Lock()
 	defer sn.Unlock()
-	if len(sn.reservations) > 0 {
-		return fmt.Errorf("node is already reserved, nodeID %s", sn.NodeID)
-	}
 	appReservation := newReservation(sn, app, ask, false)
-	// this should really not happen just guard against panic
-	// either app or ask are nil
+	// this should really not happen just guard against panic either app or alloc are nil
 	if appReservation == nil {
 		log.Log(log.SchedNode).Debug("reservation creation failed unexpectedly",
 			zap.String("nodeID", sn.NodeID),
-			zap.Any("app", app),
-			zap.Any("ask", ask))
-		return fmt.Errorf("reservation creation failed app or ask are nil on nodeID %s", sn.NodeID)
+			zap.Stringer("app", app),
+			zap.Stringer("alloc", ask))
+		return fmt.Errorf("reservation creation failed either app or alloc are nil on nodeID %s", sn.NodeID)
+	}
+	reqNode := ask.requiredNode != ""
+	if !reqNode && len(sn.reservations) > 0 {
+		log.Log(log.SchedNode).Warn("normal reservation on already reserved node",
+			zap.String("nodeID", sn.NodeID),
+			zap.String("new app", appReservation.appID),
+			zap.String("new alloc", appReservation.allocKey))
+		return common.ErrorNodeAlreadyReserved
+	}
+	// allow multiple required node reservations on the same node
+	if reqNode {
+		// make sure all other reservations are for required nodes
+		for _, reserved := range sn.reservations {
+			if reserved.alloc.requiredNode == "" {
+				log.Log(log.SchedNode).Warn("trying to add normal reservation to node with required node reservation",
+					zap.String("nodeID", sn.NodeID),
+					zap.String("existing app", reserved.appID),
+					zap.String("existing alloc", reserved.allocKey),
+					zap.String("new app", appReservation.appID),
+					zap.String("new alloc", appReservation.allocKey))
+				return fmt.Errorf("normal reservation: required node reservation present, nodeID %s", sn.NodeID)
+			}
+		}
 	}
 	// reservation must fit on the empty node
 	if !sn.totalResource.FitIn(ask.GetAllocatedResource()) {
 		log.Log(log.SchedNode).Debug("reservation does not fit on the node",
 			zap.String("nodeID", sn.NodeID),
 			zap.String("appID", app.ApplicationID),
-			zap.String("ask", ask.GetAllocationKey()),
-			zap.Stringer("allocationAsk", ask.GetAllocatedResource()))
-		return fmt.Errorf("reservation does not fit on node %s, appID %s, ask %s", sn.NodeID, app.ApplicationID, ask.GetAllocatedResource().String())
+			zap.String("alloc", ask.GetAllocationKey()),
+			zap.Stringer("requested resources", ask.GetAllocatedResource()))
+		return common.ErrorNodeNotFitReserve
 	}
-	sn.reservations[appReservation.getKey()] = appReservation
+	sn.reservations[ask.allocationKey] = appReservation
 	sn.nodeEvents.SendReservedEvent(sn.NodeID, ask.GetAllocatedResource(), ask.GetAllocationKey())
 	// reservation added successfully
 	return nil
 }
 
-// unReserve the node for this application and ask combination
-// If the reservation does not exist it returns 0 for reservations removed, if the reservation is removed it returns 1.
-// The error is set if the reservation key cannot be generated.
-func (sn *Node) unReserve(app *Application, ask *Allocation) (int, error) {
-	defer sn.notifyListeners()
+// unReserve the node for this application and alloc combination
+// If the reservation does not exist or alloc is nil it returns 0 for reservations removed,
+// if the reservation is removed it returns 1.
+func (sn *Node) unReserve(alloc *Allocation) int {
+	if alloc == nil {
+		return 0
+	}
 	sn.Lock()
 	defer sn.Unlock()
-	resKey := reservationKey(nil, app, ask)
-	if resKey == "" {
-		log.Log(log.SchedNode).Debug("unreserve reservation key create failed unexpectedly",
-			zap.String("nodeID", sn.NodeID),
-			zap.Any("app", app),
-			zap.Any("ask", ask))
-		return 0, fmt.Errorf("reservation key failed app or ask are nil on nodeID %s", sn.NodeID)
-	}
-	if _, ok := sn.reservations[resKey]; ok {
-		delete(sn.reservations, resKey)
-		sn.nodeEvents.SendUnreservedEvent(sn.NodeID, ask.GetAllocatedResource(), ask.GetAllocationKey())
-		return 1, nil
+	if _, ok := sn.reservations[alloc.allocationKey]; ok {
+		delete(sn.reservations, alloc.allocationKey)
+		sn.nodeEvents.SendUnreservedEvent(sn.NodeID, alloc.GetAllocatedResource(), alloc.GetAllocationKey())
+		return 1
 	}
 	// reservation was not found
 	log.Log(log.SchedNode).Debug("reservation not found while removing from node",
 		zap.String("nodeID", sn.NodeID),
-		zap.String("appID", app.ApplicationID),
-		zap.String("ask", ask.GetAllocationKey()))
-	return 0, nil
+		zap.String("alloc", alloc.GetAllocationKey()),
+		zap.String("appID", alloc.GetApplicationID()))
+	return 0
 }
 
 // GetReservations returns all reservation made on this node

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -162,7 +162,7 @@ func (p *Preemptor) initWorkingState() {
 
 	// walk node iterator and track available resources per node
 	p.iterator.ForEachNode(func(node *Node) bool {
-		if !node.IsSchedulable() || (node.IsReserved() && !node.isReservedForApp(reservationKey(nil, p.application, p.ask))) || !node.FitInNode(p.ask.GetAllocatedResource()) {
+		if !node.IsSchedulable() || (node.IsReserved() && !node.isReservedForAllocation(p.ask.GetAllocationKey())) || !node.FitInNode(p.ask.GetAllocatedResource()) {
 			// node is not available, remove any potential victims from consideration
 			delete(allocationsByNode, node.NodeID)
 		} else {

--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -45,6 +45,7 @@ const (
 	appID3        = "app-3"
 	aKey          = "alloc-1"
 	aKey2         = "alloc-2"
+	aKey3         = "alloc-3"
 	nodeID1       = "node-1"
 	nodeID2       = "node-2"
 	instType1     = "itype-1"


### PR DESCRIPTION
### What is this PR for?
If an allocation requires a specific node the scheduler should not consider any other node. We should allow multiple allocations that require the same node to reserve the node at the same time. A required node allocation must be placed on the node before anything else. If other non required node reservations are made on a node remove the existing reservations that do not require that node. Make sure that the releases are tracked correctly in the partition.

After the repeat count removal reservations can be simplified:
- track reservations using the allocation key
- removed the composite key setup
- removed collection listener call on reserve or unreserve of a node

Cleanup testing of the node collection

### What type of PR is it?
* [X] - Bug Fix
* [X] - Improvement

### Todos
 * [X] e2e test in the shim requesting multiple daemon sets at once

### What is the Jira issue?
[YUNIKORN-2976](https://issues.apache.org/jira/browse/YUNIKORN-2976)

### How should this be tested?
unit tests are updated new e2e test should be added
