### PR TITLE
[YUNIKORN-3003] Don't consider already preempted allocations for preemption

### DIFF
--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -354,6 +354,12 @@ func (a *Allocation) MarkPreempted() {
 	a.preempted = true
 }
 
+func (a *Allocation) UnmarkPreempted() {
+	a.Lock()
+	defer a.Unlock()
+	a.preempted = false
+}
+
 // IsPreempted returns whether the allocation has been marked for preemption or not.
 func (a *Allocation) IsPreempted() bool {
 	a.RLock()

--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -354,12 +354,6 @@ func (a *Allocation) MarkPreempted() {
 	a.preempted = true
 }
 
-func (a *Allocation) UnmarkPreempted() {
-	a.Lock()
-	defer a.Unlock()
-	a.preempted = false
-}
-
 // IsPreempted returns whether the allocation has been marked for preemption or not.
 func (a *Allocation) IsPreempted() bool {
 	a.RLock()

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -1885,6 +1885,11 @@ func (sq *Queue) findEligiblePreemptionVictims(results map[string]*QueuePreempti
 					continue
 				}
 
+				// skip allocs which have already been preempted
+				if alloc.IsPreempted() {
+					continue
+				}
+
 				// if we have encountered a fence then all tasks are eligible for preemption
 				// otherwise the task is a candidate if its priority is less than or equal to the ask priority
 				if fenced || int64(alloc.GetPriority()) <= askPriority {

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1886,7 +1886,8 @@ func TestFindEligiblePreemptionVictims(t *testing.T) {
 
 	// verify no victims when no allocations exist
 	snapshot := leaf1.FindEligiblePreemptionVictims(leaf1.QueuePath, ask)
-	assert.Equal(t, 5, len(snapshot), "wrong snapshot count") // leaf1, parent1, root
+
+	assert.Equal(t, 5, len(snapshot), "wrong snapshot count") // root, root.parent1, root.parent1.leaf1, root.parent2, root.parent2.leaf2
 	assert.Equal(t, 0, len(victims(snapshot)), "found victims")
 
 	// add two lower-priority allocs in leaf2
@@ -1973,6 +1974,13 @@ func TestFindEligiblePreemptionVictims(t *testing.T) {
 	assert.Equal(t, 1, len(victims(snapshot)), "wrong victim count")
 	assert.Equal(t, alloc3.allocationKey, victims(snapshot)[0].allocationKey, "wrong alloc")
 	alloc2.released = false
+
+	//alloc2 has already been preempted and should not be considered a valid victim
+	alloc2.MarkPreempted()
+	snapshot = leaf1.FindEligiblePreemptionVictims(leaf1.QueuePath, ask)
+	assert.Equal(t, 1, len(victims(snapshot)), "wrong victim count")
+	assert.Equal(t, alloc3.allocationKey, victims(snapshot)[0].allocationKey, "wrong alloc")
+	alloc2.UnmarkPreempted()
 
 	// setting priority offset on parent2 queue should remove leaf2 victims
 	parent2.priorityOffset = 1001

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1975,12 +1975,15 @@ func TestFindEligiblePreemptionVictims(t *testing.T) {
 	assert.Equal(t, alloc3.allocationKey, victims(snapshot)[0].allocationKey, "wrong alloc")
 	alloc2.released = false
 
-	//alloc2 has already been preempted and should not be considered a valid victim
+	// alloc2 has already been preempted and should not be considered a valid victim
 	alloc2.MarkPreempted()
 	snapshot = leaf1.FindEligiblePreemptionVictims(leaf1.QueuePath, ask)
 	assert.Equal(t, 1, len(victims(snapshot)), "wrong victim count")
 	assert.Equal(t, alloc3.allocationKey, victims(snapshot)[0].allocationKey, "wrong alloc")
-	alloc2.UnmarkPreempted()
+	// recreate alloc2 to restore non-prempted state
+	app2.RemoveAllocation(alloc2.GetAllocationKey(), si.TerminationType_STOPPED_BY_RM)
+	alloc2 = createAllocation("ask2", appID2, nodeID1, true, true, -1000, res)
+	app2.AddAllocation(alloc2)
 
 	// setting priority offset on parent2 queue should remove leaf2 victims
 	parent2.priorityOffset = 1001


### PR DESCRIPTION
### What is this PR for?

We should not consider previously preempted allocations as potential victims for future preemptions.

### What type of PR is it?
* [X] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-3003

### How should this be tested?



* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
