### PR TITLE
[YUNIKORN-2153]Optimize Placement of predicateCheckResult for Better Maintainability

### DIFF
--- a/pkg/scheduler/objects/predicates.go
+++ b/pkg/scheduler/objects/predicates.go
@@ -149,7 +149,7 @@ func preemptPredicateCheck(plugin api.ResourceManagerCallback, ch chan<- *predic
 
 func (p *predicateCheckResult) String() string {
 	if p.nodeID == "" {
-		return "empty predicate result"
+		return ""
 	}
 	var result strings.Builder
 	result.WriteString(fmt.Sprintf("node: %s, ", p.nodeID))

--- a/pkg/scheduler/objects/predicates.go
+++ b/pkg/scheduler/objects/predicates.go
@@ -1,0 +1,169 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package objects
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/apache/yunikorn-core/pkg/log"
+	"github.com/apache/yunikorn-scheduler-interface/lib/go/api"
+	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
+	"go.uber.org/zap"
+)
+
+type predicateCheckResult struct {
+	allocationKey string
+	nodeID        string
+	success       bool
+	index         int
+	victims       []*Allocation
+}
+
+func (pcr *predicateCheckResult) betterThan(other *predicateCheckResult, allocationsByNode map[string][]*Allocation) bool {
+	return pcr.getSolutionScore(allocationsByNode) < other.getSolutionScore(allocationsByNode)
+}
+
+func (pcr *predicateCheckResult) getSolutionScore(allocationsByNode map[string][]*Allocation) uint64 {
+	if pcr == nil || !pcr.success {
+		return scoreUnfit
+	}
+	allocations, ok := allocationsByNode[pcr.nodeID]
+	if !ok {
+		return scoreUnfit
+	}
+
+	var score uint64 = 0
+	if pcr.index < 0 {
+		return score
+	}
+	if pcr.index >= len(allocations) {
+		// shouldn't happen
+		return scoreUnfit
+	}
+	for i := 0; i <= pcr.index; i++ {
+		allocation := allocations[i]
+		if allocation.IsOriginator() {
+			score |= scoreOriginator
+		}
+		if !allocation.IsAllowPreemptSelf() {
+			score |= scoreNoPreempt
+		}
+	}
+	score += uint64(pcr.index) + 1 // need to add 1 to differentiate between no preemption and preempt 1 container
+
+	return score
+}
+
+func (pcr *predicateCheckResult) isSatisfactory(allocationsByNode map[string][]*Allocation) bool {
+	return pcr.getSolutionScore(allocationsByNode) < scoreFitMax
+}
+
+func (pcr *predicateCheckResult) populateVictims(victimsByNode map[string][]*Allocation) {
+	if pcr == nil {
+		return
+	}
+	pcr.victims = nil
+	if !pcr.success {
+		return
+	}
+
+	// abort if node was not found
+	victimList, ok := victimsByNode[pcr.nodeID]
+	if !ok {
+		log.Log(log.SchedPreemption).Warn("BUG: Unable to find node in victim map", zap.String("nodeID", pcr.nodeID))
+		pcr.success = false
+		pcr.index = -1
+		return
+	}
+
+	// abort if index is too large
+	if pcr.index >= len(victimList) {
+		log.Log(log.SchedPreemption).Warn("BUG: Got invalid index into allocation list",
+			zap.String("nodeID", pcr.nodeID),
+			zap.Int("index", pcr.index),
+			zap.Int("length", len(victimList)))
+		pcr.success = false
+		pcr.index = -1
+		return
+	}
+
+	pcr.victims = make([]*Allocation, 0)
+	for i := 0; i <= pcr.index; i++ {
+		victim := victimList[i]
+		pcr.victims = append(pcr.victims, victim)
+	}
+}
+
+// preemptPredicateCheck performs a single predicate check and reports the resultType on a channel
+func preemptPredicateCheck(plugin api.ResourceManagerCallback, ch chan<- *predicateCheckResult, wg *sync.WaitGroup, args *si.PreemptionPredicatesArgs) {
+	defer wg.Done()
+	result := &predicateCheckResult{
+		allocationKey: args.AllocationKey,
+		nodeID:        args.NodeID,
+		success:       false,
+		index:         -1,
+	}
+	if len(args.PreemptAllocationKeys) == 0 {
+		// normal check; there are sufficient resources to run on this node
+		if err := plugin.Predicates(&si.PredicatesArgs{
+			AllocationKey: args.AllocationKey,
+			NodeID:        args.NodeID,
+			Allocate:      true,
+		}); err == nil {
+			result.success = true
+			result.index = -1
+		} else {
+			log.Log(log.SchedPreemption).Debug("Normal predicate check failed",
+				zap.String("AllocationKey", args.AllocationKey),
+				zap.String("NodeID", args.NodeID),
+				zap.Error(err))
+		}
+	} else if response := plugin.PreemptionPredicates(args); response != nil {
+		// preemption check; at least one allocation will need preemption
+		result.success = response.GetSuccess()
+		if result.success {
+			result.index = int(response.GetIndex())
+		}
+	}
+	ch <- result
+}
+
+func (p *predicateCheckResult) String() string {
+	if p.nodeID == "" {
+		return "empty predicate result"
+	}
+	var result strings.Builder
+	result.WriteString(fmt.Sprintf("node: %s, ", p.nodeID))
+	result.WriteString(fmt.Sprintf("alloc: %s, ", p.allocationKey))
+	result.WriteString(fmt.Sprintf("success: %v, ", p.success))
+	result.WriteString(fmt.Sprintf("index: %d", p.index))
+	if len(p.victims) > 0 {
+		result.WriteString(", victims: [")
+		for i, victim := range p.victims {
+			if i > 0 {
+				result.WriteString(", ")
+			}
+			result.WriteString(victim.String())
+		}
+		result.WriteString("]")
+	}
+	return result.String()
+}

--- a/pkg/scheduler/objects/predicates.go
+++ b/pkg/scheduler/objects/predicates.go
@@ -23,10 +23,11 @@ import (
 	"strings"
 	"sync"
 
+	"go.uber.org/zap"
+
 	"github.com/apache/yunikorn-core/pkg/log"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/api"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
-	"go.uber.org/zap"
 )
 
 type predicateCheckResult struct {

--- a/pkg/scheduler/objects/predicates_test.go
+++ b/pkg/scheduler/objects/predicates_test.go
@@ -21,8 +21,9 @@ package objects
 import (
 	"testing"
 
-	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 	"gotest.tools/v3/assert"
+
+	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
 func TestSolutionScoring(t *testing.T) {

--- a/pkg/scheduler/objects/predicates_test.go
+++ b/pkg/scheduler/objects/predicates_test.go
@@ -1,0 +1,70 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package objects
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSolutionScoring(t *testing.T) {
+	singleAlloc := scoreMap(nodeID1, []bool{false}, []bool{true})
+	singleOriginator := scoreMap(nodeID1, []bool{true}, []bool{true})
+	singleNoPreempt := scoreMap(nodeID1, []bool{false}, []bool{false})
+	dual := scoreMap(nodeID1, []bool{true, false}, []bool{true, false})
+
+	var none *predicateCheckResult = nil
+	assert.Equal(t, scoreUnfit, none.getSolutionScore(singleAlloc), "wrong score for nil")
+
+	missing := &predicateCheckResult{nodeID: "missing", success: true, index: 0}
+	assert.Equal(t, scoreUnfit, missing.getSolutionScore(singleAlloc), "wrong score for missing")
+
+	failure := &predicateCheckResult{nodeID: nodeID1, success: false, index: -1}
+	assert.Equal(t, scoreUnfit, failure.getSolutionScore(singleAlloc), "wrong score for failure")
+
+	overrun := &predicateCheckResult{nodeID: nodeID1, success: true, index: 1}
+	assert.Equal(t, scoreUnfit, overrun.getSolutionScore(singleAlloc), "wrong score for overrun")
+
+	noOp := &predicateCheckResult{nodeID: nodeID1, success: true, index: -1}
+	assert.Equal(t, uint64(0), noOp.getSolutionScore(singleAlloc), "wrong score for noop")
+
+	ideal := &predicateCheckResult{nodeID: nodeID1, success: true, index: 0}
+	assert.Equal(t, uint64(1), ideal.getSolutionScore(singleAlloc), "wrong score for ideal")
+
+	originator := &predicateCheckResult{nodeID: nodeID1, success: true, index: 0}
+	assert.Equal(t, scoreOriginator+1, originator.getSolutionScore(singleOriginator), "wrong score for originator")
+
+	noPreempt := &predicateCheckResult{nodeID: nodeID1, success: true, index: 0}
+	assert.Equal(t, scoreNoPreempt+1, noPreempt.getSolutionScore(singleNoPreempt), "wrong score for no-preempt")
+
+	both := &predicateCheckResult{nodeID: nodeID1, success: true, index: 1}
+	assert.Equal(t, scoreOriginator+scoreNoPreempt+2, both.getSolutionScore(dual), "wrong score for both")
+
+	assert.Check(t, noOp.betterThan(none, singleAlloc), "noop should be better than nil")
+	assert.Check(t, noOp.betterThan(ideal, singleAlloc), "noop should be better than ideal")
+}
+
+func scoreMap(nodeID string, orig, self []bool) map[string][]*Allocation {
+	alloc := make([]*Allocation, 0)
+	for i := range orig {
+		alloc = append(alloc, allocForScore(orig[i], self[i]))
+	}
+	return map[string][]*Allocation{nodeID: alloc}
+}

--- a/pkg/scheduler/objects/predicates_test.go
+++ b/pkg/scheduler/objects/predicates_test.go
@@ -21,6 +21,7 @@ package objects
 import (
 	"testing"
 
+	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 	"gotest.tools/v3/assert"
 )
 
@@ -241,4 +242,14 @@ func scoreMap(nodeID string, orig, self []bool) map[string][]*Allocation {
 		alloc = append(alloc, allocForScore(orig[i], self[i]))
 	}
 	return map[string][]*Allocation{nodeID: alloc}
+}
+
+func allocForScore(originator bool, allowPreemptSelf bool) *Allocation {
+	return NewAllocationFromSI(&si.Allocation{
+		AllocationKey:    "alloc1",
+		ApplicationID:    appID1,
+		Originator:       originator,
+		NodeID:           nodeID1,
+		PreemptionPolicy: &si.PreemptionPolicy{AllowPreemptSelf: allowPreemptSelf},
+	})
 }

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -30,7 +30,6 @@ import (
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/log"
 	"github.com/apache/yunikorn-core/pkg/plugins"
-	"github.com/apache/yunikorn-scheduler-interface/lib/go/api"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
@@ -659,89 +658,6 @@ func (p *Preemptor) TryPreemption() (*AllocationResult, bool) {
 	return newReservedAllocationResult(nodeID, p.ask), true
 }
 
-type predicateCheckResult struct {
-	allocationKey string
-	nodeID        string
-	success       bool
-	index         int
-	victims       []*Allocation
-}
-
-func (pcr *predicateCheckResult) betterThan(other *predicateCheckResult, allocationsByNode map[string][]*Allocation) bool {
-	return pcr.getSolutionScore(allocationsByNode) < other.getSolutionScore(allocationsByNode)
-}
-
-func (pcr *predicateCheckResult) getSolutionScore(allocationsByNode map[string][]*Allocation) uint64 {
-	if pcr == nil || !pcr.success {
-		return scoreUnfit
-	}
-	allocations, ok := allocationsByNode[pcr.nodeID]
-	if !ok {
-		return scoreUnfit
-	}
-
-	var score uint64 = 0
-	if pcr.index < 0 {
-		return score
-	}
-	if pcr.index >= len(allocations) {
-		// shouldn't happen
-		return scoreUnfit
-	}
-	for i := 0; i <= pcr.index; i++ {
-		allocation := allocations[i]
-		if allocation.IsOriginator() {
-			score |= scoreOriginator
-		}
-		if !allocation.IsAllowPreemptSelf() {
-			score |= scoreNoPreempt
-		}
-	}
-	score += uint64(pcr.index) + 1 // need to add 1 to differentiate between no preemption and preempt 1 container
-
-	return score
-}
-
-func (pcr *predicateCheckResult) isSatisfactory(allocationsByNode map[string][]*Allocation) bool {
-	return pcr.getSolutionScore(allocationsByNode) < scoreFitMax
-}
-
-func (pcr *predicateCheckResult) populateVictims(victimsByNode map[string][]*Allocation) {
-	if pcr == nil {
-		return
-	}
-	pcr.victims = nil
-	if !pcr.success {
-		return
-	}
-
-	// abort if node was not found
-	victimList, ok := victimsByNode[pcr.nodeID]
-	if !ok {
-		log.Log(log.SchedPreemption).Warn("BUG: Unable to find node in victim map", zap.String("nodeID", pcr.nodeID))
-		pcr.success = false
-		pcr.index = -1
-		return
-	}
-
-	// abort if index is too large
-	if pcr.index >= len(victimList) {
-		log.Log(log.SchedPreemption).Warn("BUG: Got invalid index into allocation list",
-			zap.String("nodeID", pcr.nodeID),
-			zap.Int("index", pcr.index),
-			zap.Int("length", len(victimList)))
-		pcr.success = false
-		pcr.index = -1
-		return
-	}
-
-	pcr.victims = make([]*Allocation, 0)
-	for i := 0; i <= pcr.index; i++ {
-		victim := victimList[i]
-		pcr.victims = append(pcr.victims, victim)
-	}
-}
-
 // Duplicate creates a copy of this snapshot into the given map by queue path
 func (qps *QueuePreemptionSnapshot) Duplicate(copy map[string]*QueuePreemptionSnapshot) *QueuePreemptionSnapshot {
 	if qps == nil {
@@ -936,40 +852,6 @@ func sortVictimsForPreemption(allocationsByNode map[string][]*Allocation) {
 			return leftAsk.GetCreateTime().After(rightAsk.GetCreateTime())
 		})
 	}
-}
-
-// preemptPredicateCheck performs a single predicate check and reports the resultType on a channel
-func preemptPredicateCheck(plugin api.ResourceManagerCallback, ch chan<- *predicateCheckResult, wg *sync.WaitGroup, args *si.PreemptionPredicatesArgs) {
-	defer wg.Done()
-	result := &predicateCheckResult{
-		allocationKey: args.AllocationKey,
-		nodeID:        args.NodeID,
-		success:       false,
-		index:         -1,
-	}
-	if len(args.PreemptAllocationKeys) == 0 {
-		// normal check; there are sufficient resources to run on this node
-		if err := plugin.Predicates(&si.PredicatesArgs{
-			AllocationKey: args.AllocationKey,
-			NodeID:        args.NodeID,
-			Allocate:      true,
-		}); err == nil {
-			result.success = true
-			result.index = -1
-		} else {
-			log.Log(log.SchedPreemption).Debug("Normal predicate check failed",
-				zap.String("AllocationKey", args.AllocationKey),
-				zap.String("NodeID", args.NodeID),
-				zap.Error(err))
-		}
-	} else if response := plugin.PreemptionPredicates(args); response != nil {
-		// preemption check; at least one allocation will need preemption
-		result.success = response.GetSuccess()
-		if result.success {
-			result.index = int(response.GetIndex())
-		}
-	}
-	ch <- result
 }
 
 // batchPreemptionChecks splits predicate checks into groups by batch size

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -1831,13 +1831,3 @@ func TestTryPreemption_OnNode_UGParent_With_UGPreemptorChild_OGVictimChild_As_Si
 	assert.Check(t, !alloc1.IsPreempted(), "alloc1 preempted")
 	assert.Check(t, alloc2.IsPreempted(), "alloc2 not preempted")
 }
-
-func allocForScore(originator bool, allowPreemptSelf bool) *Allocation {
-	return NewAllocationFromSI(&si.Allocation{
-		AllocationKey:    "alloc1",
-		ApplicationID:    appID1,
-		Originator:       originator,
-		NodeID:           nodeID1,
-		PreemptionPolicy: &si.PreemptionPolicy{AllowPreemptSelf: allowPreemptSelf},
-	})
-}

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -1832,51 +1832,6 @@ func TestTryPreemption_OnNode_UGParent_With_UGPreemptorChild_OGVictimChild_As_Si
 	assert.Check(t, alloc2.IsPreempted(), "alloc2 not preempted")
 }
 
-func TestSolutionScoring(t *testing.T) {
-	singleAlloc := scoreMap(nodeID1, []bool{false}, []bool{true})
-	singleOriginator := scoreMap(nodeID1, []bool{true}, []bool{true})
-	singleNoPreempt := scoreMap(nodeID1, []bool{false}, []bool{false})
-	dual := scoreMap(nodeID1, []bool{true, false}, []bool{true, false})
-
-	var none *predicateCheckResult = nil
-	assert.Equal(t, scoreUnfit, none.getSolutionScore(singleAlloc), "wrong score for nil")
-
-	missing := &predicateCheckResult{nodeID: "missing", success: true, index: 0}
-	assert.Equal(t, scoreUnfit, missing.getSolutionScore(singleAlloc), "wrong score for missing")
-
-	failure := &predicateCheckResult{nodeID: nodeID1, success: false, index: -1}
-	assert.Equal(t, scoreUnfit, failure.getSolutionScore(singleAlloc), "wrong score for failure")
-
-	overrun := &predicateCheckResult{nodeID: nodeID1, success: true, index: 1}
-	assert.Equal(t, scoreUnfit, overrun.getSolutionScore(singleAlloc), "wrong score for overrun")
-
-	noOp := &predicateCheckResult{nodeID: nodeID1, success: true, index: -1}
-	assert.Equal(t, uint64(0), noOp.getSolutionScore(singleAlloc), "wrong score for noop")
-
-	ideal := &predicateCheckResult{nodeID: nodeID1, success: true, index: 0}
-	assert.Equal(t, uint64(1), ideal.getSolutionScore(singleAlloc), "wrong score for ideal")
-
-	originator := &predicateCheckResult{nodeID: nodeID1, success: true, index: 0}
-	assert.Equal(t, scoreOriginator+1, originator.getSolutionScore(singleOriginator), "wrong score for originator")
-
-	noPreempt := &predicateCheckResult{nodeID: nodeID1, success: true, index: 0}
-	assert.Equal(t, scoreNoPreempt+1, noPreempt.getSolutionScore(singleNoPreempt), "wrong score for no-preempt")
-
-	both := &predicateCheckResult{nodeID: nodeID1, success: true, index: 1}
-	assert.Equal(t, scoreOriginator+scoreNoPreempt+2, both.getSolutionScore(dual), "wrong score for both")
-
-	assert.Check(t, noOp.betterThan(none, singleAlloc), "noop should be better than nil")
-	assert.Check(t, noOp.betterThan(ideal, singleAlloc), "noop should be better than ideal")
-}
-
-func scoreMap(nodeID string, orig, self []bool) map[string][]*Allocation {
-	alloc := make([]*Allocation, 0)
-	for i := range orig {
-		alloc = append(alloc, allocForScore(orig[i], self[i]))
-	}
-	return map[string][]*Allocation{nodeID: alloc}
-}
-
 func allocForScore(originator bool, allowPreemptSelf bool) *Allocation {
 	return NewAllocationFromSI(&si.Allocation{
 		AllocationKey:    "alloc1",


### PR DESCRIPTION
### What is this PR for?
Create predicate.go to encapsulate the declaration and implementation of `predicateCheckResult`, improves code organization by centralizing predicate-related logic, enhancing maintainability and readability. 


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-2153

### How should this be tested?
1. Unit test
```
#> go tool cover -func=coverage.out | grep predicates.go                    
github.com/apache/yunikorn-core/pkg/scheduler/objects/predicates.go:41:                 betterThan                                      100.0%
github.com/apache/yunikorn-core/pkg/scheduler/objects/predicates.go:45:                 getSolutionScore                                100.0%
github.com/apache/yunikorn-core/pkg/scheduler/objects/predicates.go:76:                 isSatisfactory                                  100.0%
github.com/apache/yunikorn-core/pkg/scheduler/objects/predicates.go:80:                 populateVictims                                 100.0%
github.com/apache/yunikorn-core/pkg/scheduler/objects/predicates.go:117:                preemptPredicateCheck                           100.0%
github.com/apache/yunikorn-core/pkg/scheduler/objects/predicates.go:150:                String                                          100.0%
```
2. Manual Preemtion test
2.1 Create cluster with kind and install yunikorn
2.2 Create pods with low priority but request a lot of resources
2.3 Create a pod with higher priority
2.4 Some of pods created at 2.2 are eviction and pod in 2.3 can be scheduled to k8s cluster

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
