### PR TITLE
[YUNIKORN-2854]Add queue maxRunningApps metrics

### DIFF
--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -44,10 +44,11 @@ const (
 	ContainerAllocated = "allocated"
 	ContainerRejected  = "rejected"
 
-	QueueGuaranteed = "guaranteed"
-	QueueMax        = "max"
-	QueuePending    = "pending"
-	QueuePreempting = "preempting"
+	QueueGuaranteed     = "guaranteed"
+	QueueMax            = "max"
+	QueuePending        = "pending"
+	QueuePreempting     = "preempting"
+	QueueMaxRunningApps = "maxRunningApps"
 )
 
 // QueueMetrics to declare queue metrics
@@ -99,7 +100,7 @@ func InitQueueMetrics(name string) *QueueMetrics {
 			Namespace:   Namespace,
 			Name:        "queue_resource",
 			ConstLabels: prometheus.Labels{"queue": name},
-			Help:        "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`.",
+			Help:        "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, 'maxRunningApps'.",
 		}, []string{"state", "resource"})
 
 	q.resourceMetricsSubsystem = prometheus.NewGaugeVec(
@@ -107,7 +108,7 @@ func InitQueueMetrics(name string) *QueueMetrics {
 			Namespace: Namespace,
 			Subsystem: replaceStr,
 			Name:      "queue_resource",
-			Help:      "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`.",
+			Help:      "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, 'maxRunningApps'.",
 		}, []string{"state", "resource"})
 
 	var queueMetricsList = []prometheus.Collector{
@@ -353,4 +354,9 @@ func (m *QueueMetrics) SetQueuePendingResourceMetrics(resourceName string, value
 
 func (m *QueueMetrics) SetQueuePreemptingResourceMetrics(resourceName string, value float64) {
 	m.setQueueResource(QueuePreempting, resourceName, value)
+}
+
+func (m *QueueMetrics) SetQueueMaxRunningAppsResourceMetrics(value uint64) {
+	resourceName := "apps"
+	m.setQueueResource(QueueMaxRunningApps, resourceName, float64(value))
 }

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -100,7 +100,7 @@ func InitQueueMetrics(name string) *QueueMetrics {
 			Namespace:   Namespace,
 			Name:        "queue_resource",
 			ConstLabels: prometheus.Labels{"queue": name},
-			Help:        "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, 'maxRunningApps'.",
+			Help:        "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, `maxRunningApps`.",
 		}, []string{"state", "resource"})
 
 	q.resourceMetricsSubsystem = prometheus.NewGaugeVec(
@@ -108,7 +108,7 @@ func InitQueueMetrics(name string) *QueueMetrics {
 			Namespace: Namespace,
 			Subsystem: replaceStr,
 			Name:      "queue_resource",
-			Help:      "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, 'maxRunningApps'.",
+			Help:      "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, `maxRunningApps`.",
 		}, []string{"state", "resource"})
 
 	var queueMetricsList = []prometheus.Collector{

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -356,7 +356,6 @@ func (m *QueueMetrics) SetQueuePreemptingResourceMetrics(resourceName string, va
 	m.setQueueResource(QueuePreempting, resourceName, value)
 }
 
-func (m *QueueMetrics) SetQueueMaxRunningAppsResourceMetrics(value uint64) {
-	resourceName := "apps"
-	m.setQueueResource(QueueMaxRunningApps, resourceName, float64(value))
+func (m *QueueMetrics) SetQueueMaxRunningAppsMetrics(value uint64) {
+	m.setQueueResource(QueueMaxRunningApps, "apps", float64(value))
 }

--- a/pkg/metrics/queue_test.go
+++ b/pkg/metrics/queue_test.go
@@ -250,8 +250,8 @@ func TestQueueMaxRunningAppsResourceMetrics(t *testing.T) {
 	qm = getQueueMetrics()
 	defer unregisterQueueMetrics()
 
-	qm.SetQueueMaxRunningAppsResourceMetrics(1)
-	verifyResourceMetrics(t, "maxRunningApps", "Apps")
+	qm.SetQueueMaxRunningAppsMetrics(1)
+	verifyResourceMetrics(t, "maxRunningApps", "apps")
 }
 
 func TestRemoveQueueMetrics(t *testing.T) {

--- a/pkg/metrics/queue_test.go
+++ b/pkg/metrics/queue_test.go
@@ -246,6 +246,14 @@ func TestQueuePreemptingResourceMetrics(t *testing.T) {
 	verifyResourceMetrics(t, "preempting", "cpu")
 }
 
+func TestQueueMaxRunningAppsResourceMetrics(t *testing.T) {
+	qm = getQueueMetrics()
+	defer unregisterQueueMetrics()
+
+	qm.SetQueueMaxRunningAppsResourceMetrics(1)
+	verifyResourceMetrics(t, "maxRunningApps", "Apps")
+}
+
 func TestRemoveQueueMetrics(t *testing.T) {
 	testQueueName := "root.test"
 	qm = GetQueueMetrics(testQueueName)

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -125,6 +125,7 @@ func NewConfiguredQueue(conf configs.QueueConfig, parent *Queue) (*Queue, error)
 	sq.parent = parent
 	sq.isManaged = true
 	sq.maxRunningApps = conf.MaxApplications
+	sq.updateMaxRunningAppsResourceMetrics()
 
 	// update the properties
 	if err := sq.applyConf(conf); err != nil {
@@ -223,6 +224,7 @@ func (sq *Queue) applyTemplate(childTemplate *template.Template) {
 	// update metrics for guaranteed and max resource
 	sq.updateGuaranteedResourceMetrics()
 	sq.updateMaxResourceMetrics()
+	sq.updateMaxRunningAppsResourceMetrics()
 }
 
 // getProperties returns a copy of the properties for this queue
@@ -366,6 +368,7 @@ func (sq *Queue) applyConf(conf configs.QueueConfig) error {
 			return err
 		}
 		sq.maxRunningApps = conf.MaxApplications
+		sq.updateMaxRunningAppsResourceMetrics()
 	}
 
 	sq.properties = conf.Properties
@@ -462,6 +465,7 @@ func (sq *Queue) SetMaxRunningApps(maxApps uint64) {
 	sq.Lock()
 	defer sq.Unlock()
 	sq.maxRunningApps = maxApps
+	sq.updateMaxRunningAppsResourceMetrics()
 }
 
 // setTemplate sets the template on the queue based on the config.
@@ -1703,6 +1707,10 @@ func (sq *Queue) updatePreemptingResourceMetrics() {
 	for k, v := range sq.preemptingResource.Resources {
 		metrics.GetQueueMetrics(sq.QueuePath).SetQueuePreemptingResourceMetrics(k, float64(v))
 	}
+}
+
+func (sq *Queue) updateMaxRunningAppsResourceMetrics() {
+	metrics.GetQueueMetrics(sq.QueuePath).SetQueueMaxRunningAppsResourceMetrics(sq.maxRunningApps)
 }
 
 func (sq *Queue) removeMetrics() {

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -125,7 +125,7 @@ func NewConfiguredQueue(conf configs.QueueConfig, parent *Queue) (*Queue, error)
 	sq.parent = parent
 	sq.isManaged = true
 	sq.maxRunningApps = conf.MaxApplications
-	sq.updateMaxRunningAppsResourceMetrics()
+	sq.updateMaxRunningAppsMetrics()
 
 	// update the properties
 	if err := sq.applyConf(conf); err != nil {
@@ -224,7 +224,7 @@ func (sq *Queue) applyTemplate(childTemplate *template.Template) {
 	// update metrics for guaranteed and max resource
 	sq.updateGuaranteedResourceMetrics()
 	sq.updateMaxResourceMetrics()
-	sq.updateMaxRunningAppsResourceMetrics()
+	sq.updateMaxRunningAppsMetrics()
 }
 
 // getProperties returns a copy of the properties for this queue
@@ -368,7 +368,7 @@ func (sq *Queue) applyConf(conf configs.QueueConfig) error {
 			return err
 		}
 		sq.maxRunningApps = conf.MaxApplications
-		sq.updateMaxRunningAppsResourceMetrics()
+		sq.updateMaxRunningAppsMetrics()
 	}
 
 	sq.properties = conf.Properties
@@ -465,7 +465,7 @@ func (sq *Queue) SetMaxRunningApps(maxApps uint64) {
 	sq.Lock()
 	defer sq.Unlock()
 	sq.maxRunningApps = maxApps
-	sq.updateMaxRunningAppsResourceMetrics()
+	sq.updateMaxRunningAppsMetrics()
 }
 
 // setTemplate sets the template on the queue based on the config.
@@ -1709,8 +1709,8 @@ func (sq *Queue) updatePreemptingResourceMetrics() {
 	}
 }
 
-func (sq *Queue) updateMaxRunningAppsResourceMetrics() {
-	metrics.GetQueueMetrics(sq.QueuePath).SetQueueMaxRunningAppsResourceMetrics(sq.maxRunningApps)
+func (sq *Queue) updateMaxRunningAppsMetrics() {
+	metrics.GetQueueMetrics(sq.QueuePath).SetQueueMaxRunningAppsMetrics(sq.maxRunningApps)
 }
 
 func (sq *Queue) removeMetrics() {

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -349,7 +349,7 @@ yunikorn_root_leaf_queue_resource{resource="apps",state="maxRunningApps"} 0
 }
 
 const (
-	QueueResourceMetricHelp = "# HELP %v Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, 'maxRunningApps'."
+	QueueResourceMetricHelp = "# HELP %v Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, `maxRunningApps`."
 	QueueResourceMetricType = "# TYPE %v gauge"
 )
 

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -298,9 +298,11 @@ func TestPendingCalc(t *testing.T) {
 	want := concatQueueResourceMetric(metrics, []string{`
 yunikorn_root_queue_resource{resource="memory",state="pending"} 100
 yunikorn_root_queue_resource{resource="vcores",state="pending"} 10
+yunikorn_root_queue_resource{resource="apps",state="maxRunningApps"} 0
 `, `
 yunikorn_root_leaf_queue_resource{resource="memory",state="pending"} 100
 yunikorn_root_leaf_queue_resource{resource="vcores",state="pending"} 10
+yunikorn_root_leaf_queue_resource{resource="apps",state="maxRunningApps"} 0
 `},
 	)
 	assert.NilError(t, promtu.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(want), metrics...), "unexpected metrics")
@@ -314,9 +316,11 @@ yunikorn_root_leaf_queue_resource{resource="vcores",state="pending"} 10
 	want = concatQueueResourceMetric(metrics, []string{`
 yunikorn_root_queue_resource{resource="memory",state="pending"} 0
 yunikorn_root_queue_resource{resource="vcores",state="pending"} 0
+yunikorn_root_queue_resource{resource="apps",state="maxRunningApps"} 0
 `, `
 yunikorn_root_leaf_queue_resource{resource="memory",state="pending"} 0
 yunikorn_root_leaf_queue_resource{resource="vcores",state="pending"} 0
+yunikorn_root_leaf_queue_resource{resource="apps",state="maxRunningApps"} 0
 `},
 	)
 	assert.NilError(t, promtu.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(want), metrics...), "unexpected metrics")
@@ -334,16 +338,18 @@ yunikorn_root_leaf_queue_resource{resource="vcores",state="pending"} 0
 	want = concatQueueResourceMetric(metrics, []string{`
 yunikorn_root_queue_resource{resource="memory",state="pending"} 0
 yunikorn_root_queue_resource{resource="vcores",state="pending"} 0
+yunikorn_root_queue_resource{resource="apps",state="maxRunningApps"} 0
 `, `
 yunikorn_root_leaf_queue_resource{resource="memory",state="pending"} 0
 yunikorn_root_leaf_queue_resource{resource="vcores",state="pending"} 0
+yunikorn_root_leaf_queue_resource{resource="apps",state="maxRunningApps"} 0
 `},
 	)
 	assert.NilError(t, promtu.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(want), metrics...), "unexpected metrics")
 }
 
 const (
-	QueueResourceMetricHelp = "# HELP %v Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`."
+	QueueResourceMetricHelp = "# HELP %v Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, 'maxRunningApps'."
 	QueueResourceMetricType = "# TYPE %v gauge"
 )
 


### PR DESCRIPTION
### What is this PR for?
Add a new metric - maxRunningApps for Prometheus pull-based monitoring. The `maxapplications` property is an integer value, larger than 1, which allows you to limit the number of running applications for the queue.
I fixed the resource name - "Apps" as I see maxRunningApps is a standalone metrics independent from `resources.Resource`. See https://github.com/apache/yunikorn-core/blob/master/pkg/scheduler/objects/queue.go#L86
```
type Queue struct {
	QueuePath string // Fully qualified path for the queue
	Name      string // Queue name as in the config etc.

	...
	pending             *resources.Resource       // pending resource for the apps in the queue
	allocatedResource   *resources.Resource       // allocated resource for the apps in the queue
	preemptingResource  *resources.Resource       // preempting resource for the apps in the queue
	...
	maxResource            *resources.Resource // When not set, max = nil
	guaranteedResource     *resources.Resource // When not set, Guaranteed == 0
	...
	maxRunningApps         uint64
	runningApps            uint64
```


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2854?filter=-1

### How should this be tested?
1. Deploy k8s cluster with kind
2. forward metrics endpoint by `kubectl port-forward svc/yunikorn-service -n yunikorn 9080:9080`
3. verify metrics are exposed through belowing
```
#> curl -s http://localhost:9080/ws/v1/metrics  | grep yunikorn_root_queue_resource
# HELP yunikorn_root_queue_resource Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, 'maxRunningApps'.   <---- help message is updated
# TYPE yunikorn_root_queue_resource gauge
yunikorn_root_queue_resource{resource="apps",state="maxRunningApps"} 0        <------ new added metrics
yunikorn_root_queue_resource{resource="ephemeral-storage",state="max"} 6.19061035008e+11
yunikorn_root_queue_resource{resource="memory",state="allocated"} 0
yunikorn_root_queue_resource{resource="memory",state="max"} 4.9624363008e+10
yunikorn_root_queue_resource{resource="memory",state="pending"} 0
yunikorn_root_queue_resource{resource="pods",state="allocated"} 3
yunikorn_root_queue_resource{resource="pods",state="max"} 330
yunikorn_root_queue_resource{resource="pods",state="pending"} 0
yunikorn_root_queue_resource{resource="vcore",state="allocated"} 0
yunikorn_root_queue_resource{resource="vcore",state="max"} 36000
yunikorn_root_queue_resource{resource="vcore",state="pending"} 0
```
4. configure maxSunningApps by
```
apiVersion: v1
data:
  queues.yaml: |2
    partitions:
      - name: default
        placementrules:
          - name: tag
            value: namespace
            create: true
        queues:
          - name: root
            submitacl: '*'
            maxapplications: 10
kind: ConfigMap
```
5. Verify metrics are reflected in endpoint
```
#> curl -s http://localhost:9080/ws/v1/metrics  | grep maxRunningApps           
# HELP yunikorn_queue_resource Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, 'maxRunningApps'.
yunikorn_queue_resource{queue="root",resource="apps",state="maxRunningApps"} 10
# HELP yunikorn_root_dev_6kdna_queue_resource Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, 'maxRunningApps'.
# HELP yunikorn_root_dev_ruf38_queue_resource Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, 'maxRunningApps'.
# HELP yunikorn_root_queue_resource Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, 'maxRunningApps'.
yunikorn_root_queue_resource{resource="apps",state="maxRunningApps"} 10
```

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
