### PR TITLE
[YUNIKORN-3090] Promethues metrics are improperly labeled for total events

### DIFF
--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -65,15 +65,15 @@ func initEventMetrics() *EventMetrics {
 		prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Subsystem: EventSubsystem,
-			Name:      "total_processed",
-			Help:      "total events processed",
+			Name:      "total_stored",
+			Help:      "total events stored",
 		})
 	metrics.totalEventsNotStored = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Subsystem: EventSubsystem,
-			Name:      "total_processed",
-			Help:      "total events processed",
+			Name:      "total_not_stored",
+			Help:      "total events not stored",
 		})
 	metrics.totalEventsCollected = prometheus.NewGauge(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
### What is this PR for?
Originally there was a duplication of the prometheus metrics labels. This PR resolves that. The gauges used in the code are unchanged as it worked. The metrics just never made it out to prometheus. 


### What type of PR is it?
* [X] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-3090

### How should this be tested?
Build and verify the new metrics in prometheus. Originally the metrics were overwritten. Now there should be 3 separate gauges: total_processed, total_stored, total_not_stored

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
