### PR TITLE
[YUNIKORN-3092] Reservations can permanently block nodes, leading to …

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -47,7 +47,9 @@ import (
 )
 
 var (
-	reservationDelay          = 2 * time.Second
+	reservationDelay = 2 * time.Second
+	// Make it configurable
+	reservationWaitTimeout    = 60 * time.Minute
 	completingTimeout         = 30 * time.Second
 	terminatedTimeout         = 3 * 24 * time.Hour
 	defaultPlaceholderTimeout = 15 * time.Minute
@@ -202,6 +204,13 @@ func SetReservationDelay(delay time.Duration) {
 	log.Log(log.SchedApplication).Debug("Set reservation delay",
 		zap.Duration("delay", delay))
 	reservationDelay = delay
+}
+
+// SetReservationWaitTimeout How long reservation should wait in queue?
+func SetReservationWaitTimeout(waitTimeout time.Duration) {
+	log.Log(log.SchedApplication).Debug("Set reservation wait timeout",
+		zap.Duration("wait timeout", waitTimeout))
+	reservationWaitTimeout = waitTimeout
 }
 
 // Return the current state or a checked specific state for the application.

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -2248,30 +2248,12 @@ func TestTryAllocatePreemptQueue(t *testing.T) {
 }
 
 func TestTryAllocatePreemptNode(t *testing.T) {
-	node1 := newNode("node1", map[string]resources.Quantity{"first": 20})
-	node2 := newNode("node2", map[string]resources.Quantity{"first": 20})
-	nodeMap := map[string]*Node{"node1": node1, "node2": node2}
-	iterator := getNodeIteratorFn(node1, node2)
-	getNode := func(nodeID string) *Node {
-		return nodeMap[nodeID]
-	}
-
-	rootQ, err := createRootQueue(map[string]string{"first": "40"})
-	assert.NilError(t, err)
-	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"first": "20"}, map[string]string{"first": "10"})
-	assert.NilError(t, err)
-	unlimitedQ, err := createManagedQueueGuaranteed(rootQ, "unlimited", false, nil, nil)
-	assert.NilError(t, err)
-	childQ1, err := createManagedQueueGuaranteed(parentQ, "child1", false, nil, map[string]string{"first": "5"})
-	assert.NilError(t, err)
-	childQ2, err := createManagedQueueGuaranteed(parentQ, "child2", false, nil, map[string]string{"first": "5"})
-	assert.NilError(t, err)
-
+	iterator, getNode, node1, unlimitedQ, childQ1, childQ2 := createPreemptNodeTestSetup(t)
 	app0 := newApplication(appID0, "default", "root.unlimited")
 	app0.SetQueue(unlimitedQ)
 	unlimitedQ.applications[appID0] = app0
 	ask00 := newAllocationAsk("alloc0-0", appID0, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11}))
-	err = app0.AddAllocationAsk(ask00)
+	err := app0.AddAllocationAsk(ask00)
 	assert.NilError(t, err)
 	ask01 := newAllocationAsk("alloc0-1", appID0, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11}))
 	err = app0.AddAllocationAsk(ask01)
@@ -2339,6 +2321,112 @@ func TestTryAllocatePreemptNode(t *testing.T) {
 	// pass the time and try again
 	ask3.createTime = ask3.createTime.Add(-30 * time.Second)
 	result3 = app2.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 18}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	assert.Assert(t, result3 != nil, "result3 expected")
+	assert.Equal(t, Reserved, result3.ResultType, "expected reservation")
+	alloc3 = result3.Request
+	assert.Assert(t, alloc3 != nil, "alloc3 expected")
+	assert.Assert(t, allocs[0].IsPreempted(), "alloc1 should have been preempted")
+}
+
+func createPreemptNodeTestSetup(t *testing.T) (func() NodeIterator, func(NodeID string) *Node, *Node, *Queue, *Queue, *Queue) {
+	node1 := newNode("node1", map[string]resources.Quantity{"first": 20})
+	node2 := newNode("node2", map[string]resources.Quantity{"first": 20})
+	nodeMap := map[string]*Node{"node1": node1, "node2": node2}
+	iterator := getNodeIteratorFn(node1, node2)
+	getNode := func(nodeID string) *Node {
+		return nodeMap[nodeID]
+	}
+
+	rootQ, err := createRootQueue(map[string]string{"first": "40"})
+	assert.NilError(t, err)
+	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"first": "20"}, map[string]string{"first": "10"})
+	assert.NilError(t, err)
+	unlimitedQ, err := createManagedQueueGuaranteed(rootQ, "unlimited", false, nil, nil)
+	assert.NilError(t, err)
+	childQ1, err := createManagedQueueGuaranteed(parentQ, "child1", false, nil, map[string]string{"first": "5"})
+	assert.NilError(t, err)
+	childQ2, err := createManagedQueueGuaranteed(parentQ, "child2", false, nil, map[string]string{"first": "5"})
+	assert.NilError(t, err)
+	return iterator, getNode, node1, unlimitedQ, childQ1, childQ2
+}
+func TestTryAllocatePreemptNodeWithReservations(t *testing.T) {
+	iterator, getNode, node1, unlimitedQ, childQ1, childQ2 := createPreemptNodeTestSetup(t)
+	app0 := newApplication(appID0, "default", "root.unlimited")
+	app0.SetQueue(unlimitedQ)
+	unlimitedQ.applications[appID0] = app0
+	ask00 := newAllocationAsk("alloc0-0", appID0, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11}))
+	err := app0.AddAllocationAsk(ask00)
+	assert.NilError(t, err)
+	ask01 := newAllocationAsk("alloc0-1", appID0, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11}))
+	err = app0.AddAllocationAsk(ask01)
+	assert.NilError(t, err)
+
+	app1 := newApplication(appID1, "default", "root.parent.child1")
+	app1.SetQueue(childQ1)
+	childQ1.applications[appID1] = app1
+	ask1 := newAllocationAsk("alloc1", appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}))
+	err = app1.AddAllocationAsk(ask1)
+	assert.NilError(t, err)
+	ask2 := newAllocationAsk("alloc2", appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}))
+	err = app1.AddAllocationAsk(ask2)
+	assert.NilError(t, err)
+
+	app2 := newApplication(appID2, "default", "root.parent.child2")
+	app2.SetQueue(childQ2)
+	childQ2.applications[appID2] = app2
+	ask3 := newAllocationAsk("alloc3", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}))
+	ask3.allowPreemptOther = true
+	err = app2.AddAllocationAsk(ask3)
+	assert.NilError(t, err)
+
+	app3 := newApplication(appID3, "default", "root.parent.child2")
+	app3.SetQueue(childQ2)
+	childQ2.applications[appID3] = app3
+	ask4 := newAllocationAsk("alloc4", appID3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}))
+	ask4.allowPreemptOther = true
+	ask4.priority = math.MaxInt32
+	err = app3.AddAllocationAsk(ask4)
+	assert.NilError(t, err)
+
+	preemptionAttemptsRemaining := 10
+
+	// consume capacity with 'unlimited' app
+	for _, r := range []*resources.Resource{resources.NewResourceFromMap(map[string]resources.Quantity{"first": 40}), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 39})} {
+		result0 := app0.tryAllocate(r, true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+		assert.Assert(t, result0 != nil, "result0 expected")
+		alloc0 := result0.Request
+		assert.Assert(t, alloc0 != nil, "alloc0 expected")
+		alloc0.SetNodeID(result0.NodeID)
+	}
+
+	// consume remainder of space but not quota
+	allocs := make([]*Allocation, 0)
+	for _, r := range []*resources.Resource{resources.NewResourceFromMap(map[string]resources.Quantity{"first": 28}), resources.NewResourceFromMap(map[string]resources.Quantity{"first": 23})} {
+		var alloc1 *Allocation
+		result1 := app1.tryAllocate(r, true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+		assert.Assert(t, result1 != nil, "result1 expected")
+		alloc1 = result1.Request
+		assert.Assert(t, result1.Request != nil, "alloc1 expected")
+		alloc1.SetNodeID(result1.NodeID)
+		allocs = append(allocs, alloc1)
+	}
+
+	// on first attempt, should see a reservation since we're after the reservation timeout
+	ask3.createTime = ask3.createTime.Add(-10 * time.Second)
+	result3 := app2.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 18}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+	assert.Assert(t, result3 != nil, "result3 expected")
+	alloc3 := result3.Request
+	assert.Assert(t, alloc3 != nil, "alloc3 not expected")
+	assert.Equal(t, "node1", result3.NodeID, "wrong node assignment")
+	assert.Equal(t, Reserved, result3.ResultType, "expected reservation")
+	assert.Assert(t, !allocs[1].IsPreempted(), "alloc2 should not have been preempted")
+	err = node1.Reserve(app2, ask3)
+	assert.NilError(t, err)
+
+	// pass the time and try again
+	ask4.createTime = ask4.createTime.Add(-30 * time.Second)
+	SetReservationWaitTimeout(-60 * time.Second)
+	result3 = app3.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 18}), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
 	assert.Assert(t, result3 != nil, "result3 expected")
 	assert.Equal(t, Reserved, result3.ResultType, "expected reservation")
 	alloc3 = result3.Request

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -161,7 +161,36 @@ func (p *Preemptor) initWorkingState() {
 
 	// walk node iterator and track available resources per node
 	p.iterator.ForEachNode(func(node *Node) bool {
-		if !node.IsSchedulable() || (node.IsReserved() && !node.isReservedForAllocation(p.ask.GetAllocationKey())) || !node.FitInNode(p.ask.GetAllocatedResource()) {
+		hasOtherReservations := false
+		if node.IsReserved() && !node.isReservedForAllocation(p.ask.GetAllocationKey()) {
+			hasOtherReservations = true
+			for _, res := range node.GetReservations() {
+				// Is Allocation daemon set?
+				// Has this allocation already triggered preemption?
+				if res.alloc.requiredNode != "" || res.alloc.HasTriggeredPreemption() {
+					continue
+				}
+				createTime := res.alloc.GetCreateTime()
+				// Take reservation delay also into account
+				waitingTime := reservationWaitTimeout.Seconds() - reservationDelay.Seconds()
+				askAge := time.Since(createTime.Add(time.Duration(waitingTime)))
+
+				// Cancel reservation based on its priority and waiting time in reservation queue
+				if res.alloc.GetPriority() < p.ask.priority && askAge > reservationWaitTimeout {
+					num := res.app.UnReserve(res.node, res.alloc)
+					res.app.GetQueue().UnReserve(res.app.ApplicationID, num)
+					log.Log(log.SchedApplication).Info("Cancelled reservation to consider node for preemption",
+						zap.String("triggered by appID", p.application.ApplicationID),
+						zap.String("triggered by allocationKey", p.ask.allocationKey),
+						zap.String("affected application ID", res.appID),
+						zap.String("affected allocationKey", res.allocKey),
+						zap.String("node", res.nodeID),
+						zap.Int("reservations count", num))
+					hasOtherReservations = false
+				}
+			}
+		}
+		if !node.IsSchedulable() || hasOtherReservations || !node.FitInNode(p.ask.GetAllocatedResource()) {
 			// node is not available, remove any potential victims from consideration
 			delete(allocationsByNode, node.NodeID)
 		} else {


### PR DESCRIPTION
…preemption failure and a stuck scheduler state

### What is this PR for?

Consider even the nodes which has non daemon set reservations and reservation (allocation) not triggered preemption earlier as candidate to increase the chances of preemption. But cancel those reservations only if its priority is lesser than the preemptor priority and waiting in reservation for more than 1 hour.

### What type of PR is it?
* [ ] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-3092

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
