### PR TITLE
[YUNIKORN-3250] Fix UserGroupCache entries never expiring due to uninitialized clock

### DIFF
--- a/pkg/common/security/usergroup.go
+++ b/pkg/common/security/usergroup.go
@@ -41,7 +41,6 @@ const (
 )
 
 // global variables
-var now time.Time            // One clock to access
 var instance *UserGroupCache // The instance of the cache
 var once = &sync.Once{}      // Make sure we can only create the cache once
 var stopped atomic.Bool      // whether UserGroupCache is stopped (needed for multiple partitions)
@@ -123,8 +122,8 @@ func (c *UserGroupCache) run() {
 
 // Do the real work for the cache cleanup
 func (c *UserGroupCache) cleanUpCache() {
-	oldest := now.Unix() - poscache
-	oldestFailed := now.Unix() - negcache
+	oldest := time.Now().Unix() - poscache
+	oldestFailed := time.Now().Unix() - negcache
 	// clean up the cache so we do not grow out of bounds
 	instance.lock.Lock()
 	defer instance.lock.Unlock()
@@ -173,7 +172,7 @@ func (c *UserGroupCache) ConvertUGI(ugi *si.UserGroupInformation, force bool) (U
 	// If groups are already present we should just convert
 	newUG := UserGroup{User: ugi.User}
 	newUG.Groups = append(newUG.Groups, ugi.Groups...)
-	newUG.resolved = now.Unix()
+	newUG.resolved = time.Now().Unix()
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.ugs[ugi.User] = &newUG
@@ -192,12 +191,12 @@ func (c *UserGroupCache) GetUserGroup(userName string) (UserGroup, error) {
 	c.lock.RLock()
 	ug, ok := c.ugs[userName]
 	c.lock.RUnlock()
-	// return if this was not a negative cache that has not timed out
-	if ok && !ug.failed {
+	// return if valid positive cache hit (not failed and not expired)
+	if ok && !ug.failed && (time.Now().Unix()-ug.resolved) < poscache {
 		return *ug, nil
 	}
-	// nothing returned so create a new one
-	if ug == nil {
+	// create a fresh entry for re-resolution unless we have a fresh negative cache hit
+	if ug == nil || !ug.failed {
 		ug = &UserGroup{
 			User: userName,
 		}
@@ -228,7 +227,7 @@ func (c *UserGroupCache) GetUserGroup(userName string) (UserGroup, error) {
 		}
 	}
 	// all resolved (or not) but use this time stamp
-	ug.resolved = now.Unix()
+	ug.resolved = time.Now().Unix()
 
 	// add it to the cache, even if we fail negative cache is also good to know
 	c.lock.Lock()

--- a/pkg/common/security/usergroup_test.go
+++ b/pkg/common/security/usergroup_test.go
@@ -542,3 +542,54 @@ func TestConvertUGI(t *testing.T) {
 		})
 	}
 }
+
+// TestCleanUpCacheUsesRealTime verifies that cleanUpCache uses real wall-clock time for eviction.
+// Without the Bug 1 fix (var now time.Time never assigned), now.Unix() always returns a
+// large negative constant so the eviction condition is never true and entries live forever.
+func TestCleanUpCacheUsesRealTime(t *testing.T) {
+	testCache := GetUserGroupCache(testResolver, &ConfigReaderMock{}, &LdapAccessMock{})
+	testCache.resetCache()
+
+	_, err := testCache.GetUserGroup("testuser1")
+	assert.NilError(t, err)
+	assert.Equal(t, 1, testCache.getUGsize())
+
+	// Stamp the entry as resolved far in the past (2× TTL ago).
+	testCache.lock.Lock()
+	testCache.ugs["testuser1"].resolved = time.Now().Unix() - 2*poscache
+	testCache.lock.Unlock()
+
+	testCache.cleanUpCache()
+
+	// The entry must be evicted. With the broken var-now bug this assertion fails
+	// because cleanUpCache's threshold is computed from the zero time.Time value.
+	assert.Equal(t, 0, testCache.getUGsize(), "stale entry was not evicted by cleanUpCache — Bug 1 not fixed")
+}
+
+// TestPositiveCacheHitExpiryTriggersRefresh verifies that GetUserGroup re-resolves a user
+// whose positive cache entry has exceeded poscache seconds.
+// Without the Bug 2 fix, the stale entry is returned blindly regardless of age.
+func TestPositiveCacheHitExpiryTriggersRefresh(t *testing.T) {
+	testCache := GetUserGroupCache(testResolver, &ConfigReaderMock{}, &LdapAccessMock{})
+	testCache.resetCache()
+
+	_, err := testCache.GetUserGroup("testuser1")
+	assert.NilError(t, err)
+
+	// Age the cached entry beyond poscache.
+	testCache.lock.Lock()
+	testCache.ugs["testuser1"].resolved = time.Now().Unix() - 2*poscache
+	staleResolved := testCache.ugs["testuser1"].resolved
+	testCache.lock.Unlock()
+
+	// A fresh lookup must re-resolve and stamp a new resolved timestamp.
+	ug, err := testCache.GetUserGroup("testuser1")
+	assert.NilError(t, err)
+	if ug.resolved == staleResolved {
+		t.Error("GetUserGroup returned stale cached entry after TTL expiry — Bug 2 not fixed")
+	}
+
+	// Re-resolution must not duplicate groups (groups are appended during resolveGroups;
+	// if the stale entry's Groups slice is reused the count doubles).
+	assert.Equal(t, 2, len(ug.Groups), "re-resolved groups are duplicated — stale ug.Groups was not reset before re-resolution")
+}


### PR DESCRIPTION
### What is this PR for?
The `UserGroupCache` contained a package-level variable `var now time.Time` that was
declared but never assigned, causing `now.Unix()` to always return the Go zero-time
constant (-62135596800). This made every TTL eviction condition in `cleanUpCache()`
permanently false, so cache entries — including stale LDAP group memberships — lived
forever and could only be cleared by a full scheduler restart.

A second bug allowed `GetUserGroup` to return an expired positive cache entry without
any age check, relying entirely on the background cleaner to evict it first (up to 60s
overage). This also meant that when a stale entry fell through to re-resolution, its
existing `Groups` slice was reused, causing group duplication.

This PR fixes both issues and adds regression tests that fail against the unfixed code.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-3250
 
### How should this be tested?
1. `go test ./pkg/common/security/... -v` — all existing tests must pass
2. `TestCleanUpCacheUsesRealTime` — verifies `cleanUpCache` evicts entries stamped with a real past timestamp; fails without the `now.Unix()` fix
3. `TestPositiveCacheHitExpiryTriggersRefresh` — verifies `GetUserGroup` re-resolves an expired positive entry and returns a fresh `resolved` timestamp with no duplicate groups; fails without the inline TTL check
4. Integration: configure the LDAP resolver, resolve a user, wait >5 minutes, re-submit a job — confirm a fresh LDAP lookup occurs without a scheduler restart

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
