### PR TITLE
[YUNIKORN-3245] Reset queue properties on config update

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -421,8 +421,12 @@ func (sq *Queue) applyConf(conf configs.QueueConfig, silence bool) (*resources.R
 // This function MUST be called holding the lock for the queue.
 func (sq *Queue) setPreemptionTime(oldMaxResource *resources.Resource, oldDelay time.Duration) {
 	// if quota preemption is running nothing we do not have an influence
+	if sq.isQuotaPreemptionRunning {
+		return
+	}
 	// if the delay for the queue is not set do not trigger preemption
-	if sq.isQuotaPreemptionRunning || sq.quotaPreemptionDelay == 0 {
+	if sq.quotaPreemptionDelay == 0 {
+		sq.quotaPreemptionStartTime = time.Time{}
 		return
 	}
 	// if no current limit we should not preempt even if it was set earlier, clear the start time
@@ -670,6 +674,23 @@ func (sq *Queue) setTemplate(conf configs.ChildTemplate) error {
 	return nil
 }
 
+// resetProperties resets values derived from queue properties to their defaults.
+// This function MUST be called holding the lock for the queue.
+func (sq *Queue) resetProperties() {
+	sq.sortType = policies.FifoSortPolicy
+	if !sq.isLeaf {
+		sq.sortType = policies.FairSortPolicy
+	}
+	sq.prioritySortEnabled = true
+	sq.priorityOffset = 0
+	sq.priorityPolicy = policies.DefaultPriorityPolicy
+	sq.preemptionPolicy = policies.DefaultPreemptionPolicy
+	sq.preemptionDelay = configs.DefaultPreemptionDelay
+	sq.unschedAskBackoff = 0
+	sq.askBackoffDelay = configs.DefaultAskBackOffDelay
+	sq.quotaPreemptionDelay = configs.DefaultQuotaPreemptionDelay
+}
+
 // UpdateQueueProperties updates the queue properties defined as text
 func (sq *Queue) UpdateQueueProperties(oldMaxResource *resources.Resource) {
 	sq.Lock()
@@ -679,10 +700,8 @@ func (sq *Queue) UpdateQueueProperties(oldMaxResource *resources.Resource) {
 		sq.sortType = policies.FifoSortPolicy
 		return
 	}
-	if !sq.isLeaf {
-		// set the sorting type for parent queues
-		sq.sortType = policies.FairSortPolicy
-	}
+	oldDelay := sq.quotaPreemptionDelay
+	sq.resetProperties()
 	// walk over all properties and process
 	var err error
 	for key, value := range sq.properties {
@@ -744,13 +763,11 @@ func (sq *Queue) UpdateQueueProperties(oldMaxResource *resources.Resource) {
 					zap.Error(err))
 			}
 		case configs.QuotaPreemptionDelay:
-			oldDelay := sq.quotaPreemptionDelay
 			sq.quotaPreemptionDelay, err = convertDelay(value, configs.DefaultQuotaPreemptionDelay)
 			if err != nil {
 				log.Log(log.SchedQueue).Debug("quota preemption delay configuration error",
 					zap.Error(err))
 			}
-			sq.setPreemptionTime(oldMaxResource, oldDelay)
 		default:
 			// skip unknown properties just log them
 			log.Log(log.SchedQueue).Debug("queue property skipped",
@@ -758,6 +775,7 @@ func (sq *Queue) UpdateQueueProperties(oldMaxResource *resources.Resource) {
 				zap.String("value", value))
 		}
 	}
+	sq.setPreemptionTime(oldMaxResource, oldDelay)
 }
 
 // GetQueuePath returns the fully qualified path of this queue.

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -3452,6 +3452,50 @@ func TestQueueBackoffProperties(t *testing.T) {
 	assert.Equal(t, 30*time.Second, leaf3.GetBackoffDelay())
 }
 
+func TestUpdateQueuePropertiesReset(t *testing.T) {
+	root, err := createRootQueue(nil)
+	assert.NilError(t, err, "failed to create basic root queue")
+
+	leaf, err := createManagedQueue(root, "leaf", false, nil)
+	assert.NilError(t, err, "failed to create managed queue")
+
+	leaf.properties = map[string]string{
+		configs.ApplicationSortPolicy:                    policies.FairSortPolicy.String(),
+		configs.ApplicationSortPriority:                  configs.ApplicationSortPriorityDisabled,
+		configs.PriorityOffset:                           "5",
+		configs.PriorityPolicy:                           policies.FencePriorityPolicy.String(),
+		configs.PreemptionDelay:                          "10s",
+		configs.PreemptionPolicy:                         policies.FencePreemptionPolicy.String(),
+		configs.ApplicationUnschedulableAsksBackoff:      "12",
+		configs.ApplicationUnschedulableAsksBackoffDelay: "20s",
+		configs.QuotaPreemptionDelay:                     "1m",
+	}
+	leaf.UpdateQueueProperties(nil)
+	assert.Equal(t, leaf.sortType, policies.FairSortPolicy)
+	assert.Equal(t, leaf.prioritySortEnabled, false)
+	assert.Equal(t, leaf.priorityOffset, int32(5))
+	assert.Equal(t, leaf.priorityPolicy, policies.FencePriorityPolicy)
+	assert.Equal(t, leaf.preemptionDelay, 10*time.Second)
+	assert.Equal(t, leaf.preemptionPolicy, policies.FencePreemptionPolicy)
+	assert.Equal(t, leaf.unschedAskBackoff, uint64(12))
+	assert.Equal(t, leaf.askBackoffDelay, 20*time.Second)
+	assert.Equal(t, leaf.quotaPreemptionDelay, time.Minute)
+
+	leaf.quotaPreemptionStartTime = time.Now()
+	leaf.properties = map[string]string{}
+	leaf.UpdateQueueProperties(nil)
+	assert.Equal(t, leaf.sortType, policies.FifoSortPolicy)
+	assert.Equal(t, leaf.prioritySortEnabled, true)
+	assert.Equal(t, leaf.priorityOffset, int32(0))
+	assert.Equal(t, leaf.priorityPolicy, policies.DefaultPriorityPolicy)
+	assert.Equal(t, leaf.preemptionDelay, configs.DefaultPreemptionDelay)
+	assert.Equal(t, leaf.preemptionPolicy, policies.DefaultPreemptionPolicy)
+	assert.Equal(t, leaf.unschedAskBackoff, uint64(0))
+	assert.Equal(t, leaf.askBackoffDelay, configs.DefaultAskBackOffDelay)
+	assert.Equal(t, leaf.quotaPreemptionDelay, configs.DefaultQuotaPreemptionDelay)
+	assert.Assert(t, leaf.quotaPreemptionStartTime.IsZero(), "quota preemption start time should reset")
+}
+
 func TestQueue_setPreemptionTime(t *testing.T) {
 	root, e := createRootQueue(nil)
 	assert.NilError(t, e, "failed to create basic root queue")


### PR DESCRIPTION
### What is this PR for?
Reset queue fields derived from properties before applying the current effective property map during queue config updates. This lets removed properties return to defaults while preserving inherited parent properties for existing child queues on reload.

### What type of PR is it?
* [x] - Bug Fix

### Todos
* [x] - Tests

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-3245

### How should this be tested?
* make license-check
* make pseudo
* make check_scripts
* make lint
* make test

### Screenshots (if appropriate)
N/A

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.