### PR TITLE
YUNIKORN-3296: Fix race between AddEvent and Stop

### DIFF
--- a/pkg/events/event_system.go
+++ b/pkg/events/event_system.go
@@ -220,6 +220,10 @@ func (ec *EventSystemImpl) Stop() {
 	ec.stopped = true
 }
 
+func (ec *EventSystemImpl) isStopped() bool {
+	return ec.stopped || ec.channel == nil
+}
+
 // AddEvent adds an event record to the event system. See the interface for details.
 func (ec *EventSystemImpl) AddEvent(event *si.EventRecord) {
 	if event != nil {
@@ -228,10 +232,10 @@ func (ec *EventSystemImpl) AddEvent(event *si.EventRecord) {
 
 	metrics.GetEventMetrics().IncEventsCreated()
 
-	ec.Lock()
-	defer ec.Unlock()
+	ec.RLock()
+	defer ec.RUnlock()
 
-	if ec.stopped || ec.channel == nil {
+	if ec.isStopped() {
 		metrics.GetEventMetrics().IncEventsNotChanneled()
 		return
 	}

--- a/pkg/events/event_system.go
+++ b/pkg/events/event_system.go
@@ -227,6 +227,15 @@ func (ec *EventSystemImpl) AddEvent(event *si.EventRecord) {
 	}
 
 	metrics.GetEventMetrics().IncEventsCreated()
+
+	ec.Lock()
+	defer ec.Unlock()
+
+	if ec.stopped || ec.channel == nil {
+		metrics.GetEventMetrics().IncEventsNotChanneled()
+		return
+	}
+
 	select {
 	case ec.channel <- event:
 		metrics.GetEventMetrics().IncEventsChanneled()

--- a/pkg/events/event_system_test.go
+++ b/pkg/events/event_system_test.go
@@ -21,6 +21,7 @@ package events
 import (
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -240,4 +241,32 @@ func TestTruncateEventMessage(t *testing.T) {
 
 func getTestString(stringLength int) string {
 	return strings.Repeat("x", stringLength)
+}
+
+// TestAddEventConcurrentStop verifies AddEvent and Stop can run concurrently without data races.
+func TestAddEventConcurrentStop(t *testing.T) {
+	Init()
+	eventSystem := GetEventSystem().(*EventSystemImpl) //nolint:errcheck
+	eventSystem.StartServiceWithPublisher(false)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10000; i++ {
+			eventSystem.AddEvent(&si.EventRecord{
+				Type:    si.EventRecord_REQUEST,
+				Message: strconv.Itoa(i),
+			})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		time.Sleep(time.Millisecond)
+		eventSystem.Stop()
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
What is this PR for?

Fix a data race in EventSystemImpl.AddEvent() during shutdown.

Stop() closes and clears ec.channel while holding the event system mutex. AddEvent() previously accessed ec.channel without synchronization. During TestSchedulerRecoveryQuotaPreemption, scheduler goroutines could still emit events while StopAll() shut down the event system, resulting in a race detected by go test -race.

The reported race was between:

EventSystemImpl.AddEvent()
EventSystemImpl.Stop() (close(ec.channel) / ec.channel = nil)

This race could also lead to a send on closed channel panic.

What type of PR is this?
Bug Fix
What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-3296

How should this be tested?

Run:

go test -race ./pkg/events/...
go test -race -count=20 -run TestSchedulerRecoveryQuotaPreemption ./pkg/scheduler/tests

A new regression test, TestAddEventConcurrentStop, exercises concurrent calls to AddEvent() and Stop().

What does this PR do?

Synchronize AddEvent() with Stop() using the same mutex. If the event system has already been stopped or the channel has been cleared, the event is not sent and is counted as not channeled.

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
