### PR TITLE
[YUNIKORN-3239] handling infra events and allocation events separately

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -32,7 +32,7 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
-// The Scheduler service that starts the needed sub services
+// Scheduler service that starts the needed sub services
 type Scheduler struct {
 	clusterContext     *ClusterContext  // main context
 	pendingAllocEvents chan interface{} // queue for allocation and application events

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -32,7 +32,7 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
-// Main Scheduler service that starts the needed sub services
+// The Scheduler service that starts the needed sub services
 type Scheduler struct {
 	clusterContext     *ClusterContext  // main context
 	pendingAllocEvents chan interface{} // queue for allocation and application events
@@ -53,7 +53,7 @@ func NewScheduler() *Scheduler {
 	return m
 }
 
-// Start service
+// StartService starts the scheduler service, it will start the event handlers and the main scheduling loop.
 func (s *Scheduler) StartService(handlers handler.EventHandlers, manualSchedule bool) {
 	// set the proxy handler in the context
 	s.clusterContext.setEventHandler(handlers.RMProxyEventHandler)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -49,8 +49,11 @@ func NewScheduler() *Scheduler {
 	m.clusterContext = newClusterContext()
 	// Creating 3 channels for different types of events, the buffer size is set based on the expected event volume and processing speed.
 	// This can help to smooth out the event processing and avoid blocking the RM proxy when there is a sudden burst of events.
+	// A cluster can have hundreds of thousands of allocations, and each allocation can trigger multiple events, so the buffer size for pendingAllocEvents is set to 1 million.
 	m.pendingAllocEvents = make(chan interface{}, 1024*1024)
+	// There can be thousands of infra events in a cluster, so the buffer size for pendingInfraEvents is set to 1000.
 	m.pendingInfraEvents = make(chan interface{}, 1000)
+	// There can be tens of thousands of nodes in a cluster, so the buffer size for pendingNodeEvents is set to 100 thousand.
 	m.pendingNodeEvents = make(chan interface{}, 100*1000)
 	m.activityPending = make(chan bool, 1)
 	m.stop = make(chan struct{})

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -34,18 +34,20 @@ import (
 
 // Main Scheduler service that starts the needed sub services
 type Scheduler struct {
-	clusterContext  *ClusterContext  // main context
-	pendingEvents   chan interface{} // queue for events
-	activityPending chan bool        // activity pending channel
-	stop            chan struct{}    // channel to signal stop request
-	healthChecker   *HealthChecker
-	nodesMonitor    *nodesResourceUsageMonitor
+	clusterContext     *ClusterContext  // main context
+	pendingAllocEvents chan interface{} // queue for allocation and application events
+	pendingInfraEvents chan interface{} // queue for node, config, and registration events
+	activityPending    chan bool        // activity pending channel
+	stop               chan struct{}    // channel to signal stop request
+	healthChecker      *HealthChecker
+	nodesMonitor       *nodesResourceUsageMonitor
 }
 
 func NewScheduler() *Scheduler {
 	m := &Scheduler{}
 	m.clusterContext = newClusterContext()
-	m.pendingEvents = make(chan interface{}, 1024*1024)
+	m.pendingAllocEvents = make(chan interface{}, 1024*1024)
+	m.pendingInfraEvents = make(chan interface{}, 1024*1024)
 	m.activityPending = make(chan bool, 1)
 	m.stop = make(chan struct{})
 	return m
@@ -57,7 +59,8 @@ func (s *Scheduler) StartService(handlers handler.EventHandlers, manualSchedule 
 	s.clusterContext.setEventHandler(handlers.RMProxyEventHandler)
 
 	// Start event handlers
-	go s.handleRMEvent()
+	go s.handleAllocEvent()
+	go s.handleInfraEvent()
 
 	// Start resource monitor if necessary (majorly for testing)
 	s.nodesMonitor = newNodesResourceUsageMonitor(s.clusterContext)
@@ -120,7 +123,12 @@ func (s *Scheduler) internalQuotaPreemption() {
 
 // Implement methods for Scheduler events
 func (s *Scheduler) HandleEvent(ev interface{}) {
-	enqueueAndCheckFull(s.pendingEvents, ev)
+	switch ev.(type) {
+	case *rmevent.RMUpdateAllocationEvent, *rmevent.RMUpdateApplicationEvent:
+		enqueueAndCheckFull(s.pendingAllocEvents, ev)
+	default:
+		enqueueAndCheckFull(s.pendingInfraEvents, ev)
+	}
 }
 
 func enqueueAndCheckFull(queue chan interface{}, ev interface{}) {
@@ -136,15 +144,31 @@ func enqueueAndCheckFull(queue chan interface{}, ev interface{}) {
 	}
 }
 
-func (s *Scheduler) handleRMEvent() {
+func (s *Scheduler) handleAllocEvent() {
 	for {
 		select {
-		case ev := <-s.pendingEvents:
+		case ev := <-s.pendingAllocEvents:
 			switch v := ev.(type) {
 			case *rmevent.RMUpdateAllocationEvent:
 				s.clusterContext.handleRMUpdateAllocationEvent(v)
 			case *rmevent.RMUpdateApplicationEvent:
 				s.clusterContext.handleRMUpdateApplicationEvent(v)
+			default:
+				log.Log(log.Scheduler).Error("Received type is not an acceptable type for allocation event.",
+					zap.Stringer("received type", reflect.TypeOf(v)))
+			}
+			s.registerActivity()
+		case <-s.stop:
+			return
+		}
+	}
+}
+
+func (s *Scheduler) handleInfraEvent() {
+	for {
+		select {
+		case ev := <-s.pendingInfraEvents:
+			switch v := ev.(type) {
 			case *rmevent.RMUpdateNodeEvent:
 				s.clusterContext.handleRMUpdateNodeEvent(v)
 			case *rmevent.RMPartitionsRemoveEvent:
@@ -154,7 +178,7 @@ func (s *Scheduler) handleRMEvent() {
 			case *rmevent.RMConfigUpdateEvent:
 				s.clusterContext.processRMConfigUpdateEvent(v)
 			default:
-				log.Log(log.Scheduler).Error("Received type is not an acceptable type for RM event.",
+				log.Log(log.Scheduler).Error("Received type is not an acceptable type for infrastructure event.",
 					zap.Stringer("received type", reflect.TypeOf(v)))
 			}
 			s.registerActivity()

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -36,7 +36,8 @@ import (
 type Scheduler struct {
 	clusterContext     *ClusterContext  // main context
 	pendingAllocEvents chan interface{} // queue for allocation and application events
-	pendingInfraEvents chan interface{} // queue for node, config, and registration events
+	pendingInfraEvents chan interface{} // queue for config and registration events
+	pendingNodeEvents  chan interface{} // queue for node events
 	activityPending    chan bool        // activity pending channel
 	stop               chan struct{}    // channel to signal stop request
 	healthChecker      *HealthChecker
@@ -46,8 +47,11 @@ type Scheduler struct {
 func NewScheduler() *Scheduler {
 	m := &Scheduler{}
 	m.clusterContext = newClusterContext()
+	// Creating 3 channels for different types of events, the buffer size is set based on the expected event volume and processing speed.
+	// This can help to smooth out the event processing and avoid blocking the RM proxy when there is a sudden burst of events.
 	m.pendingAllocEvents = make(chan interface{}, 1024*1024)
-	m.pendingInfraEvents = make(chan interface{}, 1024*1024)
+	m.pendingInfraEvents = make(chan interface{}, 1000)
+	m.pendingNodeEvents = make(chan interface{}, 100*1000)
 	m.activityPending = make(chan bool, 1)
 	m.stop = make(chan struct{})
 	return m
@@ -61,6 +65,7 @@ func (s *Scheduler) StartService(handlers handler.EventHandlers, manualSchedule 
 	// Start event handlers
 	go s.handleAllocEvent()
 	go s.handleInfraEvent()
+	go s.handleNodeEvent()
 
 	// Start resource monitor if necessary (majorly for testing)
 	s.nodesMonitor = newNodesResourceUsageMonitor(s.clusterContext)
@@ -121,11 +126,13 @@ func (s *Scheduler) internalQuotaPreemption() {
 	}
 }
 
-// Implement methods for Scheduler events
+// HandleEvent is the main entry for handling events from RM proxy, it will dispatch events to different queues based on event type.
 func (s *Scheduler) HandleEvent(ev interface{}) {
 	switch ev.(type) {
 	case *rmevent.RMUpdateAllocationEvent, *rmevent.RMUpdateApplicationEvent:
 		enqueueAndCheckFull(s.pendingAllocEvents, ev)
+	case *rmevent.RMUpdateNodeEvent:
+		enqueueAndCheckFull(s.pendingNodeEvents, ev)
 	default:
 		enqueueAndCheckFull(s.pendingInfraEvents, ev)
 	}
@@ -169,8 +176,6 @@ func (s *Scheduler) handleInfraEvent() {
 		select {
 		case ev := <-s.pendingInfraEvents:
 			switch v := ev.(type) {
-			case *rmevent.RMUpdateNodeEvent:
-				s.clusterContext.handleRMUpdateNodeEvent(v)
 			case *rmevent.RMPartitionsRemoveEvent:
 				s.clusterContext.removePartitionsByRMID(v)
 			case *rmevent.RMRegistrationEvent:
@@ -179,6 +184,24 @@ func (s *Scheduler) handleInfraEvent() {
 				s.clusterContext.processRMConfigUpdateEvent(v)
 			default:
 				log.Log(log.Scheduler).Error("Received type is not an acceptable type for infrastructure event.",
+					zap.Stringer("received type", reflect.TypeOf(v)))
+			}
+			s.registerActivity()
+		case <-s.stop:
+			return
+		}
+	}
+}
+
+func (s *Scheduler) handleNodeEvent() {
+	for {
+		select {
+		case ev := <-s.pendingNodeEvents:
+			switch v := ev.(type) {
+			case *rmevent.RMUpdateNodeEvent:
+				s.clusterContext.handleRMUpdateNodeEvent(v)
+			default:
+				log.Log(log.Scheduler).Error("Received type is not an acceptable type for node event.",
 					zap.Stringer("received type", reflect.TypeOf(v)))
 			}
 			s.registerActivity()

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -182,9 +182,9 @@ func TestHandleEventRouting(t *testing.T) {
 	}
 	assert.Equal(t, len(scheduler.pendingAllocEvents), 2, "expected 2 events on pendingAllocEvents")
 	assert.Equal(t, len(scheduler.pendingInfraEvents), 0, "expected 0 events on pendingInfraEvents")
+	assert.Equal(t, len(scheduler.pendingNodeEvents), 0, "expected 0 events on pendingNodeEvents")
 
 	infraCases := []interface{}{
-		&rmevent.RMUpdateNodeEvent{Request: &si.NodeRequest{}},
 		&rmevent.RMRegistrationEvent{Channel: make(chan *rmevent.Result, 1)},
 		&rmevent.RMConfigUpdateEvent{Channel: make(chan *rmevent.Result, 1)},
 		&rmevent.RMPartitionsRemoveEvent{Channel: make(chan *rmevent.Result, 1)},
@@ -193,16 +193,19 @@ func TestHandleEventRouting(t *testing.T) {
 		scheduler.HandleEvent(ev)
 	}
 	assert.Equal(t, len(scheduler.pendingAllocEvents), 2, "alloc channel should remain unchanged")
-	assert.Equal(t, len(scheduler.pendingInfraEvents), 4, "expected 4 events on pendingInfraEvents")
+	assert.Equal(t, len(scheduler.pendingInfraEvents), 3, "expected 3 events on pendingInfraEvents")
+
+	nodeCase := &rmevent.RMUpdateNodeEvent{Request: &si.NodeRequest{}}
+	scheduler.HandleEvent(nodeCase)
+	assert.Equal(t, len(scheduler.pendingAllocEvents), 2, "alloc channel should remain unchanged")
+	assert.Equal(t, len(scheduler.pendingInfraEvents), 3, "infra channel should remain unchanged")
+	assert.Equal(t, len(scheduler.pendingNodeEvents), 1, "expected 1 event on pendingNodeEvents")
 }
 
 // TestHandleAllocEventGoroutine verifies that the handleAllocEvent goroutine drains
-// pendingAllocEvents and calls registerActivity.
+// pendingAllocEvents and calls registerActivity and stops when signaled.
 func TestHandleAllocEventGoroutine(t *testing.T) {
 	scheduler := NewScheduler()
-	partition, err := newBasePartition()
-	assert.NilError(t, err)
-	scheduler.clusterContext.partitions["test"] = partition
 
 	done := make(chan struct{})
 	go func() {
@@ -232,7 +235,7 @@ func TestHandleAllocEventGoroutine(t *testing.T) {
 }
 
 // TestHandleInfraEventGoroutine verifies that the handleInfraEvent goroutine drains
-// pendingInfraEvents and calls registerActivity.
+// pendingInfraEvents and calls registerActivity and stops when signaled.
 func TestHandleInfraEventGoroutine(t *testing.T) {
 	scheduler := NewScheduler()
 
@@ -268,17 +271,48 @@ func TestHandleInfraEventGoroutine(t *testing.T) {
 	}
 }
 
-// TestInfraEventsNotBlockedByAllocEvents verifies that a full pendingAllocEvents channel
-// does not prevent infra events from being enqueued or processed.
-func TestInfraEventsNotBlockedByAllocEvents(t *testing.T) {
+// TestHandleNodeEventGoroutine verifies that the handleNodeEvent goroutine drains
+// pendingNodeEvents and calls registerActivity.
+func TestHandleNodeEventGoroutine(t *testing.T) {
+	scheduler := NewScheduler()
+
+	scheduler.pendingNodeEvents <- &rmevent.RMUpdateNodeEvent{
+		Request: &si.NodeRequest{},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		scheduler.handleNodeEvent()
+	}()
+
+	// wait for activity signal which proves the event was processed
+	select {
+	case <-scheduler.activityPending:
+		// success
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for activity from handleNodeEvent")
+	}
+
+	close(scheduler.stop)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleNodeEvent goroutine did not stop")
+	}
+}
+
+// TestNodeEventsNotBlockedByAllocEvents verifies that a full pendingAllocEvents channel
+// does not prevent node events from being enqueued or processed.
+func TestNodeEventsNotBlockedByAllocEvents(t *testing.T) {
 	scheduler := NewScheduler()
 	// fill the alloc channel to capacity so it cannot accept more events
 	for i := 0; i < cap(scheduler.pendingAllocEvents); i++ {
 		scheduler.pendingAllocEvents <- &rmevent.RMUpdateAllocationEvent{Request: &si.AllocationRequest{}}
 	}
 
-	// an infra event must still be enqueued without blocking
+	// a node event must still be enqueued without blocking
 	nodeEv := &rmevent.RMUpdateNodeEvent{Request: &si.NodeRequest{}}
 	scheduler.HandleEvent(nodeEv)
-	assert.Equal(t, len(scheduler.pendingInfraEvents), 1, "infra event should be queued even when alloc channel is full")
+	assert.Equal(t, len(scheduler.pendingNodeEvents), 1, "node event should be queued even when alloc channel is full")
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -167,3 +167,118 @@ func TestTriggerQuotaPreemption(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleEventRouting verifies that HandleEvent routes allocation and application
+// events to pendingAllocEvents, and all other events to pendingInfraEvents.
+func TestHandleEventRouting(t *testing.T) {
+	scheduler := NewScheduler()
+
+	allocCases := []interface{}{
+		&rmevent.RMUpdateAllocationEvent{Request: &si.AllocationRequest{}},
+		&rmevent.RMUpdateApplicationEvent{Request: &si.ApplicationRequest{}},
+	}
+	for _, ev := range allocCases {
+		scheduler.HandleEvent(ev)
+	}
+	assert.Equal(t, len(scheduler.pendingAllocEvents), 2, "expected 2 events on pendingAllocEvents")
+	assert.Equal(t, len(scheduler.pendingInfraEvents), 0, "expected 0 events on pendingInfraEvents")
+
+	infraCases := []interface{}{
+		&rmevent.RMUpdateNodeEvent{Request: &si.NodeRequest{}},
+		&rmevent.RMRegistrationEvent{Channel: make(chan *rmevent.Result, 1)},
+		&rmevent.RMConfigUpdateEvent{Channel: make(chan *rmevent.Result, 1)},
+		&rmevent.RMPartitionsRemoveEvent{Channel: make(chan *rmevent.Result, 1)},
+	}
+	for _, ev := range infraCases {
+		scheduler.HandleEvent(ev)
+	}
+	assert.Equal(t, len(scheduler.pendingAllocEvents), 2, "alloc channel should remain unchanged")
+	assert.Equal(t, len(scheduler.pendingInfraEvents), 4, "expected 4 events on pendingInfraEvents")
+}
+
+// TestHandleAllocEventGoroutine verifies that the handleAllocEvent goroutine drains
+// pendingAllocEvents and calls registerActivity.
+func TestHandleAllocEventGoroutine(t *testing.T) {
+	scheduler := NewScheduler()
+	partition, err := newBasePartition()
+	assert.NilError(t, err)
+	scheduler.clusterContext.partitions["test"] = partition
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		scheduler.handleAllocEvent()
+	}()
+
+	// send an allocation update event; an empty request processes cleanly
+	scheduler.pendingAllocEvents <- &rmevent.RMUpdateAllocationEvent{
+		Request: &si.AllocationRequest{},
+	}
+
+	// wait for activity signal which proves the event was dequeued and processed
+	select {
+	case <-scheduler.activityPending:
+		// success
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for activity from handleAllocEvent")
+	}
+
+	close(scheduler.stop)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleAllocEvent goroutine did not stop")
+	}
+}
+
+// TestHandleInfraEventGoroutine verifies that the handleInfraEvent goroutine drains
+// pendingInfraEvents and calls registerActivity.
+func TestHandleInfraEventGoroutine(t *testing.T) {
+	scheduler := NewScheduler()
+
+	resultCh := make(chan *rmevent.Result, 1)
+	scheduler.pendingInfraEvents <- &rmevent.RMRegistrationEvent{
+		Registration: &si.RegisterResourceManagerRequest{
+			RmID:        rmID,
+			PolicyGroup: "default-policy-group",
+			Version:     "0.0.2",
+		},
+		Channel: resultCh,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		scheduler.handleInfraEvent()
+	}()
+
+	// wait for activity signal which proves the event was processed
+	select {
+	case <-scheduler.activityPending:
+		// success
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for activity from handleInfraEvent")
+	}
+
+	close(scheduler.stop)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleInfraEvent goroutine did not stop")
+	}
+}
+
+// TestInfraEventsNotBlockedByAllocEvents verifies that a full pendingAllocEvents channel
+// does not prevent infra events from being enqueued or processed.
+func TestInfraEventsNotBlockedByAllocEvents(t *testing.T) {
+	scheduler := NewScheduler()
+	// fill the alloc channel to capacity so it cannot accept more events
+	for i := 0; i < cap(scheduler.pendingAllocEvents); i++ {
+		scheduler.pendingAllocEvents <- &rmevent.RMUpdateAllocationEvent{Request: &si.AllocationRequest{}}
+	}
+
+	// an infra event must still be enqueued without blocking
+	nodeEv := &rmevent.RMUpdateNodeEvent{Request: &si.NodeRequest{}}
+	scheduler.HandleEvent(nodeEv)
+	assert.Equal(t, len(scheduler.pendingInfraEvents), 1, "infra event should be queued even when alloc channel is full")
+}


### PR DESCRIPTION
### What is this PR for?
In this PR, we are making changes to handle infra events, node events and allocation events separately. 
This will prevent node and allocation events to be getting blocked during spike in infra relate events.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-3239

### How should this be tested?
Test cases are added to the PR

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
