### PR TITLE
[YUNIKORN-3310] Add Counter metric for terminal app states

### DIFF
--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -19,6 +19,8 @@
 package metrics
 
 import (
+	"errors"
+
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"go.uber.org/zap"
@@ -120,8 +122,12 @@ func InitQueueMetrics(name string) *QueueMetrics {
 	// registry (from a previous queue lifecycle), reuse the existing one so
 	// accumulated counts are preserved.
 	if err := prometheus.Register(q.appTerminalMetrics); err != nil {
-		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
-			if existing, ok := are.ExistingCollector.(*prometheus.CounterVec); ok {
+		are := &prometheus.AlreadyRegisteredError{}
+		if errors.As(err, are) {
+			existing, ok := are.ExistingCollector.(*prometheus.CounterVec)
+			if !ok {
+				log.Log(log.Metrics).Warn("existing terminal metrics collector has unexpected type", zap.Error(err))
+			} else {
 				q.appTerminalMetrics = existing
 			}
 		} else {

--- a/pkg/metrics/queue.go
+++ b/pkg/metrics/queue.go
@@ -54,6 +54,7 @@ const (
 // QueueMetrics to declare queue metrics
 type QueueMetrics struct {
 	appMetrics           *prometheus.GaugeVec
+	appTerminalMetrics   *prometheus.CounterVec
 	containerMetrics     *prometheus.CounterVec
 	resourceMetricsLabel *prometheus.GaugeVec
 	// Track known resource types
@@ -91,6 +92,14 @@ func InitQueueMetrics(name string) *QueueMetrics {
 			Help:        "Queue resource metrics. State of the resource includes `guaranteed`, `max`, `allocated`, `pending`, `preempting`, `maxRunningApps`.",
 		}, []string{"state", "resource"})
 
+	q.appTerminalMetrics = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   Namespace,
+			Name:        "queue_app_total",
+			ConstLabels: prometheus.Labels{"queue": name},
+			Help:        "Total number of applications that reached a terminal state. State includes `completed`, `failed`, `rejected`.",
+		}, []string{"state"})
+
 	var queueMetricsList = []prometheus.Collector{
 		q.appMetrics,
 		q.containerMetrics,
@@ -107,6 +116,19 @@ func InitQueueMetrics(name string) *QueueMetrics {
 		}
 	}
 
+	// Register the terminal counter separately — if it already exists in the
+	// registry (from a previous queue lifecycle), reuse the existing one so
+	// accumulated counts are preserved.
+	if err := prometheus.Register(q.appTerminalMetrics); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			if existing, ok := are.ExistingCollector.(*prometheus.CounterVec); ok {
+				q.appTerminalMetrics = existing
+			}
+		} else {
+			log.Log(log.Metrics).Warn("failed to register terminal metrics collector", zap.Error(err))
+		}
+	}
+
 	q.knownResourceTypes = make(map[string]struct{})
 	return q
 }
@@ -119,6 +141,8 @@ func (m *QueueMetrics) UnregisterMetrics() {
 	}
 
 	// Unregister the metrics
+	// appTerminalMetrics is intentionally excluded — it persists in the
+	// Prometheus registry so accumulated counts survive queue recreation.
 	for _, metric := range queueMetricsList {
 		prometheus.Unregister(metric)
 	}
@@ -329,4 +353,16 @@ func (m *QueueMetrics) SetQueuePreemptingResourceMetrics(resourceName string, va
 
 func (m *QueueMetrics) SetQueueMaxRunningAppsMetrics(value uint64) {
 	m.setQueueResource(QueueMaxRunningApps, "apps", float64(value))
+}
+
+func (m *QueueMetrics) IncQueueApplicationsCompletedTotal() {
+	m.appTerminalMetrics.WithLabelValues(AppCompleted).Inc()
+}
+
+func (m *QueueMetrics) IncQueueApplicationsFailedTotal() {
+	m.appTerminalMetrics.WithLabelValues(AppFailed).Inc()
+}
+
+func (m *QueueMetrics) IncQueueApplicationsRejectedTotal() {
+	m.appTerminalMetrics.WithLabelValues(AppRejected).Inc()
 }

--- a/pkg/metrics/queue_test.go
+++ b/pkg/metrics/queue_test.go
@@ -356,6 +356,28 @@ func unregisterQueueMetrics() {
 	qm.knownResourceTypes = make(map[string]struct{})
 }
 
+func TestTerminalMetricsReuse(t *testing.T) {
+	// First registration
+	qm1 := InitQueueMetrics("root.reuse")
+	qm1.IncQueueApplicationsCompletedTotal()
+	qm1.IncQueueApplicationsCompletedTotal()
+
+	// Second registration — simulates queue recreation
+	// Should reuse the existing counter with accumulated values
+	qm2 := InitQueueMetrics("root.reuse")
+
+	metricDto := &dto.Metric{}
+	err := qm2.appTerminalMetrics.WithLabelValues(AppCompleted).Write(metricDto)
+	assert.NilError(t, err)
+	assert.Equal(t, 2, int(*metricDto.Counter.Value))
+
+	// Cleanup
+	prometheus.Unregister(qm2.appMetrics)
+	prometheus.Unregister(qm2.containerMetrics)
+	prometheus.Unregister(qm2.resourceMetricsLabel)
+	prometheus.Unregister(qm2.appTerminalMetrics)
+}
+
 func TestApplicationsTerminalTotal(t *testing.T) {
 	qm = getQueueMetrics()
 	defer unregisterQueueMetrics()

--- a/pkg/metrics/queue_test.go
+++ b/pkg/metrics/queue_test.go
@@ -352,5 +352,29 @@ func unregisterQueueMetrics() {
 	prometheus.Unregister(qm.appMetrics)
 	prometheus.Unregister(qm.containerMetrics)
 	prometheus.Unregister(qm.resourceMetricsLabel)
+	prometheus.Unregister(qm.appTerminalMetrics)
 	qm.knownResourceTypes = make(map[string]struct{})
+}
+
+func TestApplicationsTerminalTotal(t *testing.T) {
+	qm = getQueueMetrics()
+	defer unregisterQueueMetrics()
+
+	qm.IncQueueApplicationsCompletedTotal()
+	qm.IncQueueApplicationsCompletedTotal()
+	qm.IncQueueApplicationsFailedTotal()
+	qm.IncQueueApplicationsRejectedTotal()
+
+	metricDto := &dto.Metric{}
+	err := qm.appTerminalMetrics.WithLabelValues(AppCompleted).Write(metricDto)
+	assert.NilError(t, err)
+	assert.Equal(t, 2, int(*metricDto.Counter.Value))
+
+	err = qm.appTerminalMetrics.WithLabelValues(AppFailed).Write(metricDto)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, int(*metricDto.Counter.Value))
+
+	err = qm.appTerminalMetrics.WithLabelValues(AppRejected).Write(metricDto)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, int(*metricDto.Counter.Value))
 }

--- a/pkg/scheduler/objects/application_state.go
+++ b/pkg/scheduler/objects/application_state.go
@@ -187,7 +187,9 @@ func callbacks() fsm.Callbacks {
 		},
 		fmt.Sprintf("enter_%s", Rejected.String()): func(_ context.Context, event *fsm.Event) {
 			app := event.Args[0].(*Application) //nolint:errcheck
-			metrics.GetQueueMetrics(app.queuePath).IncQueueApplicationsRejected()
+			qm := metrics.GetQueueMetrics(app.queuePath)
+			qm.IncQueueApplicationsRejected()
+			qm.IncQueueApplicationsRejectedTotal()
 			metrics.GetSchedulerMetrics().IncTotalApplicationsRejected()
 			app.setStateTimer(terminatedTimeout, app.stateMachine.Current(), ExpireApplication)
 			app.finishedTime = time.Now()
@@ -248,7 +250,9 @@ func callbacks() fsm.Callbacks {
 		fmt.Sprintf("enter_%s", Completed.String()): func(_ context.Context, event *fsm.Event) {
 			app := event.Args[0].(*Application) //nolint:errcheck
 			metrics.GetSchedulerMetrics().IncTotalApplicationsCompleted()
-			metrics.GetQueueMetrics(app.queuePath).IncQueueApplicationsCompleted()
+			qm := metrics.GetQueueMetrics(app.queuePath)
+			qm.IncQueueApplicationsCompleted()
+			qm.IncQueueApplicationsCompletedTotal()
 			app.setStateTimer(terminatedTimeout, app.stateMachine.Current(), ExpireApplication)
 			app.executeTerminatedCallback()
 			app.clearPlaceholderTimer()
@@ -257,7 +261,9 @@ func callbacks() fsm.Callbacks {
 		fmt.Sprintf("enter_%s", Failed.String()): func(_ context.Context, event *fsm.Event) {
 			app := event.Args[0].(*Application) //nolint:errcheck
 			metrics.GetSchedulerMetrics().IncTotalApplicationsFailed()
-			metrics.GetQueueMetrics(app.queuePath).IncQueueApplicationsFailed()
+			qm := metrics.GetQueueMetrics(app.queuePath)
+			qm.IncQueueApplicationsFailed()
+			qm.IncQueueApplicationsFailedTotal()
 			app.setStateTimer(terminatedTimeout, app.stateMachine.Current(), ExpireApplication)
 			app.executeTerminatedCallback()
 			app.cleanupAsks()


### PR DESCRIPTION
### Description
Dynamic queue removal (YUNIKORN-2908) resets terminal state gauges (completed/failed/rejected) to zero on queue recreation. This adds a CounterVec (`yunikorn_queue_app_total`) for terminal states that persists across queue lifecycle by reusing the existing Prometheus registration.

See https://issues.apache.org/jira/browse/YUNIKORN-3310 for full context.

### Type of change
- [x] Bug Fix

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3310

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
- [x] The PR includes the phrase "Generated by Claude Code", where Claude Code is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Claude Code was used for making the code changes and validations.

Generated by Claude Code

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [ ] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

Testing performed:
* `go build ./...` passes
* `go test ./pkg/metrics/...` passes (including new `TestApplicationsTerminalTotal`)
* `go test ./pkg/scheduler/objects/...` passes
* `go test ./pkg/scheduler/objects/ -race` passes
* Deployed to a test cluster and verified the counter persists across dynamic queue removal and recreation

### Questions:
- [x] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
Tested the changes by deploying yunikorn

<img width="1387" height="110" alt="image" src="https://github.com/user-attachments/assets/6593f9f9-af42-4edc-b0a5-78b43debc07d" />

<img width="1506" height="650" alt="image" src="https://github.com/user-attachments/assets/348b3347-b402-4dd0-98e2-09450a70a12e" />


**Files changed:**
- `pkg/metrics/queue.go` — Add `appTerminalMetrics` CounterVec, register with reuse logic, exclude from `UnregisterMetrics()`, add 3 `Inc*Total()` methods
- `pkg/scheduler/objects/application_state.go` — Increment terminal counters in FSM callbacks for Completed, Failed, and Rejected states
- `pkg/metrics/queue_test.go` — Add `TestApplicationsTerminalTotal`, update `unregisterQueueMetrics()` helper