### PR TITLE
[YUNIKORN-3128] Retry pending pods after bind failures

### DIFF
--- a/pkg/scheduler/context_test.go
+++ b/pkg/scheduler/context_test.go
@@ -353,6 +353,36 @@ func TestContext_OnAllocationNotification(t *testing.T) {
 	assert.Assert(t, lastAllocEvent != nil)
 	assert.Equal(t, lastAllocEvent.Allocations[0].AllocationKey, allocKey)
 
+	// rollback update should not trigger new-allocation notifications
+	lastAllocEvent = nil
+	rollbackReq := &si.AllocationRequest{
+		Allocations: []*si.Allocation{
+			{
+				AllocationKey: allocKey,
+				ResourcePerAlloc: &si.Resource{
+					Resources: map[string]*si.Quantity{
+						"first": {Value: 1},
+					},
+				},
+				ApplicationID: appID1,
+				NodeID:        "",
+				PartitionName: pName,
+				AllocationTags: map[string]string{
+					allocationRollbackTag: "true",
+				},
+			},
+		},
+		RmID: "rm:123",
+	}
+	context.handleRMUpdateAllocationEvent(&rmevent.RMUpdateAllocationEvent{Request: rollbackReq})
+	assert.Assert(t, lastAllocEvent == nil, "rollback update unexpectedly generated new allocation event")
+	app := partition.GetApplication(appID1)
+	assert.Assert(t, app != nil)
+	assert.Equal(t, 0, len(app.GetAllAllocations()))
+	ask := app.GetAllocationAsk(allocKey)
+	assert.Assert(t, ask != nil)
+	assert.Assert(t, !ask.IsAllocated(), "ask should be pending after rollback")
+
 	// add a non-Yunikorn allocation
 	lastAllocEvent = nil
 	nonYkAllocReq := &si.AllocationRequest{

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -42,8 +42,11 @@ import (
 	"github.com/apache/yunikorn-core/pkg/scheduler/policies"
 	"github.com/apache/yunikorn-core/pkg/scheduler/ugm"
 	"github.com/apache/yunikorn-core/pkg/webservice/dao"
+	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
+
+const allocationRollbackTag = siCommon.DomainYuniKornInternal + "allocation-rollback"
 
 type PartitionContext struct {
 	RmID string // the RM the partition belongs to
@@ -1336,7 +1339,68 @@ func (pc *PartitionContext) UpdateAllocation(alloc *objects.Allocation) (request
 		return false, true, nil
 	}
 
+	if existing.IsAllocated() && !allocated && isAllocationRollbackRequest(alloc) {
+		log.Log(log.SchedPartition).Info("handling allocation rollback",
+			zap.String("partitionName", pc.Name),
+			zap.String("appID", applicationID),
+			zap.String("allocationKey", allocationKey),
+			zap.String("nodeID", existing.GetNodeID()))
+
+		if existingNode.RemoveAllocation(allocationKey) == nil {
+			metrics.GetSchedulerMetrics().IncSchedulingError()
+			return false, false, fmt.Errorf("failed to remove allocation %s from node %s", allocationKey, existing.GetNodeID())
+		}
+
+		removed := app.RemoveAllocation(allocationKey, si.TerminationType_STOPPED_BY_RM)
+		if removed == nil {
+			metrics.GetSchedulerMetrics().IncSchedulingError()
+			return false, false, fmt.Errorf("failed to remove allocation %s from application %s", allocationKey, applicationID)
+		}
+
+		if err := queue.DecAllocatedResource(existing.GetAllocatedResource()); err != nil {
+			log.Log(log.SchedPartition).Warn("failed to release resources from queue during rollback",
+				zap.String("appID", applicationID),
+				zap.String("allocationKey", allocationKey),
+				zap.Error(err))
+		}
+		metrics.GetQueueMetrics(queue.GetQueuePath()).IncReleasedContainer()
+
+		if _, err := app.DeallocateAsk(allocationKey); err != nil {
+			metrics.GetSchedulerMetrics().IncSchedulingError()
+			return false, false, fmt.Errorf("failed to deallocate ask %s on app %s during rollback: %w", allocationKey, applicationID, err)
+		}
+
+		if app.IsCompleting() {
+			if err := app.HandleApplicationEvent(objects.RunApplication); err != nil {
+				log.Log(log.SchedPartition).Warn("failed to transition application back to running after rollback",
+					zap.String("appID", applicationID),
+					zap.String("allocationKey", allocationKey),
+					zap.Error(err))
+			}
+		}
+
+		existing.SetNodeID("")
+		existing.SetBindTime(time.Time{})
+		pc.updateAllocationCount(-1)
+		if existing.IsPlaceholder() {
+			pc.decPhAllocationCount(1)
+		}
+
+		log.Log(log.SchedPartition).Info("allocation rollback completed",
+			zap.String("partitionName", pc.Name),
+			zap.String("appID", applicationID),
+			zap.String("allocationKey", allocationKey))
+		return false, false, nil
+	}
+
 	return false, false, nil
+}
+
+func isAllocationRollbackRequest(alloc *objects.Allocation) bool {
+	if alloc == nil {
+		return false
+	}
+	return strings.EqualFold(alloc.GetTag(allocationRollbackTag), "true")
 }
 
 func (pc *PartitionContext) handleForeignAllocation(allocationKey, applicationID, nodeID string, node *objects.Node, alloc *objects.Allocation) (requestCreated bool, allocCreated bool, err error) {

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1350,7 +1350,7 @@ func (pc *PartitionContext) UpdateAllocation(alloc *objects.Allocation) (request
 			metrics.GetSchedulerMetrics().IncSchedulingError()
 			return false, false, fmt.Errorf("failed to remove allocation %s from node %s", allocationKey, existing.GetNodeID())
 		}
-
+		// this only removes allocation from the allocations map and the allocation is still present in requests map
 		removed := app.RemoveAllocation(allocationKey, si.TerminationType_STOPPED_BY_RM)
 		if removed == nil {
 			metrics.GetSchedulerMetrics().IncSchedulingError()

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -3729,6 +3729,10 @@ func TestUpdateAllocationRollback(t *testing.T) {
 	assert.NilError(t, err, "failed to add alloc to app")
 	assert.Check(t, allocCreated, "alloc should have been created")
 	assert.Equal(t, partition.GetTotalAllocationCount(), 1)
+	queue := partition.GetQueue("root.leaf")
+	assert.Assert(t, queue != nil)
+	assert.Assert(t, resources.Equals(queue.GetAllocatedResource(), res), "queue allocated resources should match allocation")
+	assertLimits(t, getTestUserGroup(), res)
 
 	rollback := si.Allocation{
 		AllocationKey:    alloc.AllocationKey,
@@ -3755,7 +3759,17 @@ func TestUpdateAllocationRollback(t *testing.T) {
 	node := partition.GetNode(nodeID1)
 	assert.Assert(t, node != nil)
 	assert.Assert(t, resources.IsZero(node.GetAllocatedResource()), "node allocated resources should be zero after rollback")
+	assert.Assert(t, resources.IsZero(queue.GetAllocatedResource()), "queue allocated resources should be zero after rollback")
+	assertLimits(t, getTestUserGroup(), nil)
 	assert.Equal(t, partition.GetTotalAllocationCount(), 0)
+
+	_, allocCreated, err = partition.UpdateAllocation(objects.NewAllocationFromSI(&alloc))
+	assert.NilError(t, err, "failed to re-add allocation after rollback")
+	assert.Check(t, allocCreated, "allocation should be created after rollback")
+	assert.Assert(t, resources.Equals(queue.GetAllocatedResource(), res), "queue allocated resources should be restored after re-allocation")
+	assert.Assert(t, resources.Equals(node.GetAllocatedResource(), res), "node allocated resources should be restored after re-allocation")
+	assert.Equal(t, len(app.GetAllAllocations()), 1)
+	assert.Equal(t, partition.GetTotalAllocationCount(), 1)
 }
 
 func TestUpdateAllocationEmptyNodeWithoutRollbackTagIsNoop(t *testing.T) {

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -3708,6 +3708,94 @@ func TestUpdateAllocation(t *testing.T) {
 	assert.Check(t, !allocCreated, "alloc should not have been created")
 }
 
+func TestUpdateAllocationRollback(t *testing.T) {
+	setupUGM()
+	partition := createQueuesNodes(t)
+
+	app := newApplication(appID1, "default", "root.leaf")
+	err := partition.AddApplication(app)
+	assert.NilError(t, err, "app-1 should have been added to the partition")
+
+	res, err := resources.NewResourceFromConf(map[string]string{"vcore": "10"})
+	assert.NilError(t, err, "failed to create resource")
+	alloc := si.Allocation{
+		AllocationKey:    "ask-key-rollback",
+		ApplicationID:    appID1,
+		NodeID:           nodeID1,
+		ResourcePerAlloc: res.ToProto(),
+	}
+
+	_, allocCreated, err := partition.UpdateAllocation(objects.NewAllocationFromSI(&alloc))
+	assert.NilError(t, err, "failed to add alloc to app")
+	assert.Check(t, allocCreated, "alloc should have been created")
+	assert.Equal(t, partition.GetTotalAllocationCount(), 1)
+
+	rollback := si.Allocation{
+		AllocationKey:    alloc.AllocationKey,
+		ApplicationID:    alloc.ApplicationID,
+		ResourcePerAlloc: alloc.ResourcePerAlloc,
+		AllocationTags: map[string]string{
+			allocationRollbackTag: "true",
+		},
+	}
+
+	_, allocCreated, err = partition.UpdateAllocation(objects.NewAllocationFromSI(&rollback))
+	assert.NilError(t, err, "failed to rollback allocation")
+	assert.Check(t, !allocCreated, "rollback should not create allocation")
+
+	ask := app.GetAllocationAsk(alloc.AllocationKey)
+	assert.Assert(t, ask != nil, "ask should exist after rollback")
+	assert.Assert(t, !ask.IsAllocated(), "ask should be pending after rollback")
+	assert.Equal(t, ask.GetNodeID(), "")
+	assert.Assert(t, resources.IsZero(app.GetAllocatedResource()), "app allocated resources should be zero after rollback")
+	assert.Assert(t, resources.Equals(res, app.GetPendingResource()), "app pending resources should be restored after rollback")
+	assert.Equal(t, len(app.GetAllAllocations()), 0)
+	assert.Assert(t, !app.IsCompleting(), "app should not remain completing after rollback")
+
+	node := partition.GetNode(nodeID1)
+	assert.Assert(t, node != nil)
+	assert.Assert(t, resources.IsZero(node.GetAllocatedResource()), "node allocated resources should be zero after rollback")
+	assert.Equal(t, partition.GetTotalAllocationCount(), 0)
+}
+
+func TestUpdateAllocationEmptyNodeWithoutRollbackTagIsNoop(t *testing.T) {
+	setupUGM()
+	partition := createQueuesNodes(t)
+
+	app := newApplication(appID1, "default", "root.leaf")
+	err := partition.AddApplication(app)
+	assert.NilError(t, err, "app-1 should have been added to the partition")
+
+	res, err := resources.NewResourceFromConf(map[string]string{"vcore": "10"})
+	assert.NilError(t, err, "failed to create resource")
+	alloc := si.Allocation{
+		AllocationKey:    "ask-key-noop",
+		ApplicationID:    appID1,
+		NodeID:           nodeID1,
+		ResourcePerAlloc: res.ToProto(),
+	}
+
+	_, allocCreated, err := partition.UpdateAllocation(objects.NewAllocationFromSI(&alloc))
+	assert.NilError(t, err, "failed to add alloc to app")
+	assert.Check(t, allocCreated, "alloc should have been created")
+
+	noopUpdate := si.Allocation{
+		AllocationKey:    alloc.AllocationKey,
+		ApplicationID:    alloc.ApplicationID,
+		ResourcePerAlloc: alloc.ResourcePerAlloc,
+	}
+
+	_, allocCreated, err = partition.UpdateAllocation(objects.NewAllocationFromSI(&noopUpdate))
+	assert.NilError(t, err, "unexpected error for non-rollback update")
+	assert.Check(t, !allocCreated, "non-rollback update should not create allocation")
+
+	ask := app.GetAllocationAsk(alloc.AllocationKey)
+	assert.Assert(t, ask != nil)
+	assert.Assert(t, ask.IsAllocated(), "ask should remain allocated without rollback tag")
+	assert.Equal(t, ask.GetNodeID(), nodeID1)
+	assert.Equal(t, partition.GetTotalAllocationCount(), 1)
+}
+
 func TestUpdateAllocationWithQuotaPreemption(t *testing.T) {
 	setupUGM()
 	partition := createQuotaPreemptionQueuesNodes(t)


### PR DESCRIPTION
### Description
Short description of this pull request, can be as simple as the commit message used.
First time contributing? Check out the contributing guide: https://yunikorn.apache.org/community/how_to_contribute


### Type of change
Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-XXXXX

- [ ] I have created a Jira issue for this pull request.
- [ ] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [ ] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
