### PR TITLE
YUNIKORN-3304: update e2e test in pre-commit to k8s v1.36

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s: [v1.34.0]
+        k8s: [v1.36.1]
     steps:
       - name: Checkout yunikorn-k8shim source code
         uses: actions/checkout@v6


### PR DESCRIPTION
### Description
- The K8shim has moved out to K8s v1.36 as the latest version but the core PR test still run against v1.34.
- This PR make sure that both K8shim and core run their e2e tests against the latest K8s version(v1.36).

### Type of change
Please delete options that are not relevant.

- [X] Improvement

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3304

- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
