### PR TITLE
[YUNIKORN-3312] fix logger setup in core

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -84,14 +84,15 @@ var (
 	Utils                       = &LoggerHandle{id: 27, name: "core.utils"}
 	Diagnostics                 = &LoggerHandle{id: 28, name: "core.diagnostics"}
 	SchedQuotaChangePreemption  = &LoggerHandle{id: 29, name: "core.scheduler.preemption.quotachange"}
-	SchedRequiredNodePreemption = &LoggerHandle{id: 29, name: "core.scheduler.preemption.requirednode"}
+	SchedRequiredNodePreemption = &LoggerHandle{id: 30, name: "core.scheduler.preemption.requirednode"}
 )
 
 // this tracks all the known logger handles, used to preallocate the real logger instances when configuration changes
 var loggers = []*LoggerHandle{
 	Core, Test, Deprecation, Config, Entrypoint, Events, OpenTracing, Resources, REST, RMProxy, RPC, Metrics,
 	Scheduler, SchedAllocation, SchedApplication, SchedAppUsage, SchedContext, SchedFSM, SchedHealth, SchedNode,
-	SchedPartition, SchedPreemption, SchedQueue, SchedReservation, SchedUGM, SchedNodesUsage, Security, Utils, Diagnostics, SchedQuotaChangePreemption,
+	SchedPartition, SchedPreemption, SchedQueue, SchedReservation, SchedUGM, SchedNodesUsage, Security, Utils,
+	Diagnostics, SchedQuotaChangePreemption, SchedRequiredNodePreemption,
 }
 
 // structure to hold all current logger configuration state

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -39,7 +39,7 @@ func TestLoggerIDs(t *testing.T) {
 	_ = Log(Test)
 
 	// validate logger count
-	assert.Equal(t, 30, len(loggers), "wrong logger count")
+	assert.Equal(t, 31, len(loggers), "wrong logger count")
 
 	// validate that all loggers are populated and have sequential ids
 	for i := 0; i < len(loggers); i++ {


### PR DESCRIPTION
### Description
Fix the duplicate index for the preemption loggers. Add the new preemption logger to the list of known log handles. Fix the unit tests to take into account the extra logger.

### Type of change
- [x] Bug Fix

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3312

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
