### PR TITLE
[YUNIKORN-3326] Change BackoffDeadline field in REST DAO to int64

### DIFF
--- a/pkg/webservice/dao/application_info.go
+++ b/pkg/webservice/dao/application_info.go
@@ -18,8 +18,6 @@
 
 package dao
 
-import "time"
-
 type ApplicationsDAOInfo struct {
 	Applications []ApplicationDAOInfo `json:"applications,omitempty"`
 }
@@ -46,7 +44,7 @@ type ApplicationDAOInfo struct {
 	MaxRequestPriority int32                   `json:"maxRequestPriority,omitempty"`
 	StartTime          int64                   `json:"startTime,omitempty"`
 	ResourceHistory    ResourceHistory         `json:"resourceHistory,omitempty"`
-	BackoffDeadline    *time.Time              `json:"backoffDeadline,omitempty"`
+	BackoffDeadline    *int64                  `json:"backoffDeadline,omitempty"`
 }
 
 type StateDAOInfo struct {

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -353,12 +353,6 @@ func getApplicationDAO(app *objects.Application) *dao.ApplicationDAOInfo {
 		PlaceholderResource: app.GetTrackedDAOMap("placeholderResource"),
 	}
 
-	backoffDeadline := app.GetBackoffDeadline()
-	var backoffDeadlinePtr *time.Time
-	if !backoffDeadline.IsZero() {
-		backoffDeadlinePtr = &backoffDeadline
-	}
-
 	return &dao.ApplicationDAOInfo{
 		ApplicationID:      app.ApplicationID,
 		UsedResource:       app.GetAllocatedResource().DAOMap(),
@@ -381,7 +375,7 @@ func getApplicationDAO(app *objects.Application) *dao.ApplicationDAOInfo {
 		MaxRequestPriority: app.GetAskMaxPriority(),
 		StartTime:          app.StartTime().UnixMilli(),
 		ResourceHistory:    resHistory,
-		BackoffDeadline:    backoffDeadlinePtr,
+		BackoffDeadline:    common.ZeroTimeInUnixNano(app.GetBackoffDeadline()),
 	}
 }
 

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1759,7 +1759,7 @@ func TestGetApplicationHandler(t *testing.T) {
 	getApplication(resp, req)
 	err = json.Unmarshal(resp.outputBytes, &appsDao)
 	assert.NilError(t, err, unmarshalError)
-	assert.Assert(t, deadline.Equal(*appsDao.BackoffDeadline))
+	assert.Equal(t, *appsDao.BackoffDeadline, deadline.UnixNano())
 
 	// test nonexistent partition
 	var req1 *http.Request


### PR DESCRIPTION
### Description
Change `BackoffDeadline` field in `ApplicationDAOInfo` struct from `*time.Time` to `*int64` (UnixNano) to align with YuniKorn REST DAO time encoding standards and ensure system-independent JSON output.


### Type of change
Please delete options that are not relevant.

- [X] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3326

- [ ] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A