### PR TITLE
[YUNIKORN-3330] Run predicate checks in Required node preemption

### DIFF
--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -19,6 +19,7 @@
 package objects
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -3510,6 +3511,99 @@ func TestRequiredNodePreemption(t *testing.T) {
 	// check for preemption related events
 	for _, event := range mockEvents.Events {
 		assert.Assert(t, !strings.Contains(strings.ToLower(event.Message), "preemption"), "received a preemption related event")
+	}
+}
+
+func TestRequiredNodePreemptionWithPredicates(t *testing.T) {
+	node := newNode(nodeID1, map[string]resources.Quantity{"first": 20})
+	iterator := getNodeIteratorFn(node)
+	getNode := func(nodeID string) *Node {
+		return node
+	}
+	appQueueMapping := NewAppQueueMapping()
+
+	// set queue
+	rootQ, err := createRootQueue(map[string]string{"first": "20"})
+	assert.NilError(t, err)
+	childQ, err := createManagedQueueWithAppQueueMapping(rootQ, "default", false, map[string]string{"first": "20"}, appQueueMapping)
+	assert.NilError(t, err)
+
+	// register predicate handler
+	preemptions := []mockCommon.Preemption{
+		mockCommon.NewPreemption(true, "ask-2", nodeID1, []string{"ask-1"}, 0, 0),
+	}
+	wrongNodes := make(map[string]int, 1)
+	wrongNodes[nodeID2] = 10
+	rightNodes := make(map[string]int, 1)
+	rightNodes[nodeID1] = 10
+	tests := []struct {
+		name            string
+		mockPlugin      *mockCommon.PreemptionPredicatePlugin
+		result          bool
+		mockPluginError error
+	}{
+		{"nil plugin, so no predicate checks", nil, true, nil},
+		{"prefilter fails", mockCommon.NewPreemptionPredicatePlugin(preemptions, nil, true, false), false, errors.New("fail")},
+		{"prefilter passes but none of the node from iterator is available in feasible nodes", mockCommon.NewPreemptionPredicatePlugin(preemptions, wrongNodes, false, false), false, nil},
+		{"prefilter pass with expected feasible nodes, filter fails", mockCommon.NewPreemptionPredicatePlugin(preemptions, rightNodes, false, true), false, errors.New("fail")},
+		{"both prefilter and filter passes with correct feasible nodes", mockCommon.NewPreemptionPredicatePlugin(preemptions, rightNodes, false, false), true, nil},
+		{"both prefilter and filter passes with empty feasible nodes", mockCommon.NewPreemptionPredicatePlugin(preemptions, nil, false, false), true, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newApplication(appID1, "default", "root.default")
+			app.SetQueue(childQ)
+			childQ.AddApplication(app)
+			appQueueMapping.AddAppQueueMapping(app.ApplicationID, childQ)
+
+			// add an ask
+			askRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 15})
+			ask1 := newAllocationAsk("ask-1", "app-1", askRes)
+			err = app.AddAllocationAsk(ask1)
+			assert.NilError(t, err, "could not add ask-1")
+			preemptionAttemptsRemaining := 1
+
+			// allocate ask
+			headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 50})
+			result := app.tryAllocate(headRoom, true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+			assert.Equal(t, result.ResultType, Allocated, "could not allocate ask-1")
+			assert.Equal(t, result.Request.allocationKey, "ask-1", "unexpected allocation key")
+
+			// add ask2 with required node
+			ask2 := newAllocationAsk("ask-2", "app-1", askRes)
+			ask2.requiredNode = nodeID1
+			err = app.AddAllocationAsk(ask2)
+			assert.NilError(t, err, "could not add ask-2")
+
+			// try to allocate ask2 with node being full - expect a reservation
+			result = app.tryAllocate(headRoom, true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+			assert.Equal(t, result.ResultType, Reserved, "allocation result is not reserved")
+			assert.Equal(t, result.Request.allocationKey, "ask-2", "unexpected allocation key")
+			err = app.Reserve(node, ask2)
+			assert.NilError(t, err, "reservation failed")
+
+			if tt.mockPlugin != nil {
+				plugins.RegisterSchedulerPlugin(tt.mockPlugin)
+			}
+			app.tryReservedAllocate(headRoom, iterator)
+			if tt.result {
+				assert.Assert(t, ask1.IsPreempted(), "ask1 has not been preempted")
+				assert.Assert(t, ask2.HasTriggeredPreemption(), "ask2 has not triggered preemption")
+			} else {
+				assert.Assert(t, !ask1.IsPreempted(), "ask1 preempted")
+				assert.Assert(t, !ask2.HasTriggeredPreemption(), "ask2 triggered preemption")
+			}
+			if tt.mockPluginError != nil {
+				assert.ErrorContains(t, tt.mockPlugin.GetPredicateError(), tt.mockPluginError.Error())
+			}
+			// reset
+			resetQ(t, childQ)
+			resetNode(node)
+			appQueueMapping.RemoveAppQueueMapping(app.ApplicationID)
+			if tt.mockPlugin != nil {
+				plugins.UnregisterSchedulerPlugins()
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/objects/predicates.go
+++ b/pkg/scheduler/objects/predicates.go
@@ -21,7 +21,6 @@ package objects
 import (
 	"fmt"
 	"strings"
-	"sync"
 
 	"go.uber.org/zap"
 
@@ -113,9 +112,7 @@ func (pcr *predicateCheckResult) populateVictims(victimsByNode map[string][]*All
 	}
 }
 
-// preemptPredicateCheck performs a single predicate check and reports the resultType on a channel
-func preemptPredicateCheck(plugin api.ResourceManagerCallback, ch chan<- *predicateCheckResult, wg *sync.WaitGroup, args *si.PreemptionPredicatesArgs) {
-	defer wg.Done()
+func PredicateChecks(plugin api.ResourceManagerCallback, args *si.PreemptionPredicatesArgs) *predicateCheckResult {
 	result := &predicateCheckResult{
 		allocationKey: args.AllocationKey,
 		nodeID:        args.NodeID,
@@ -144,7 +141,7 @@ func preemptPredicateCheck(plugin api.ResourceManagerCallback, ch chan<- *predic
 			result.index = int(response.GetIndex())
 		}
 	}
-	ch <- result
+	return result
 }
 
 func (p *predicateCheckResult) String() string {

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -444,7 +444,10 @@ func (p *Preemptor) checkPreemptionPredicates(predicateChecks []*si.PreemptionPr
 			// add goroutine for checking preemption
 			wg.Add(1)
 			expected++
-			go preemptPredicateCheck(plugin, ch, &wg, args)
+			go func() {
+				defer wg.Done()
+				ch <- PredicateChecks(plugin, args)
+			}()
 		}
 		// wait for completion and close channel
 		go func() {

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -87,6 +87,7 @@ func creatApp1WithTwoDifferentAllocations(
 	} else {
 		alloc2 = newAllocationWithKey("alloc2", appID1, nodeID1, resources.NewResourceFromMap(app2Rec))
 		alloc2.createTime = ask2.createTime
+		app1.AddAllocation(alloc2)
 		if !node1.TryAddAllocation(alloc2) {
 			return nil, nil, fmt.Errorf("node alloc2 failed")
 		}
@@ -120,6 +121,35 @@ func creatApp2(
 	return app2, ask3, nil
 }
 
+<<<<<<< HEAD
+=======
+func resetNode(node *Node) {
+	for _, v := range node.allocations {
+		node.RemoveAllocation(v.allocationKey)
+	}
+	node.reservations = make(map[string]*reservation)
+}
+
+func resetQ(t *testing.T, queue *Queue) {
+	for _, v := range queue.GetCopyOfApps() {
+		for _, a := range v.allocations {
+			v.RemoveAllocation(a.allocationKey, si.TerminationType_STOPPED_BY_RM)
+			err := queue.DecAllocatedResource(a.GetAllocatedResource())
+			assert.NilError(t, err)
+		}
+		for _, req := range v.requests {
+			v.RemoveAllocationAsk(req.allocationKey)
+		}
+		for _, r := range v.reservations {
+			v.unReserveInternal(r)
+		}
+		v.queue.UnReserve(v.ApplicationID, len(v.reservations))
+		queue.RemoveApplication(v)
+	}
+	queue.applications = make(map[string]*Application)
+}
+
+>>>>>>> 4b253b5 ([YUNIKORN-3330] Run predicate checks in Required node preemption)
 func TestCheckPreconditions(t *testing.T) {
 	node := newNode("node1", map[string]resources.Quantity{"first": 5})
 	iterator := getNodeIteratorFn(node)
@@ -345,20 +375,57 @@ func TestTryPreemption(t *testing.T) {
 
 	// register predicate handler
 	preemptions := []mock.Preemption{
-		mock.NewPreemption(true, "alloc3", nodeID1, []string{"alloc1"}, 0, 0),
+		mock.NewPreemption(true, "alloc3", nodeID1, []string{"alloc2"}, 0, 0),
 	}
-	plugin := mock.NewPreemptionPredicatePlugin(nil, nil, preemptions)
-	plugins.RegisterSchedulerPlugin(plugin)
-	defer plugins.UnregisterSchedulerPlugins()
-
-	result, ok := preemptor.TryPreemption()
-	assert.Assert(t, result != nil, "no result")
-	assert.NilError(t, plugin.GetPredicateError())
-	assert.Assert(t, ok, "no victims found")
-	assert.Equal(t, "alloc3", result.Request.GetAllocationKey(), "wrong alloc")
-	assert.Check(t, alloc1.IsPreempted(), "alloc1 not preempted")
-	assert.Check(t, !alloc2.IsPreempted(), "alloc2 preempted")
-	assert.Equal(t, len(ask3.GetAllocationLog()), 0)
+	wrongNodes := make(map[string]int, 1)
+	wrongNodes[nodeID2] = 10
+	rightNodes := make(map[string]int, 1)
+	rightNodes[nodeID1] = 10
+	tests := []struct {
+		name            string
+		mockPlugin      *mock.PreemptionPredicatePlugin
+		result          bool
+		mockPluginError error
+	}{
+		{"prefilter fails", mock.NewPreemptionPredicatePlugin(preemptions, nil, true, false), false, errors.New("fail")},
+		{"prefilter passes but none of the node from iterator is available in feasible nodes", mock.NewPreemptionPredicatePlugin(preemptions, wrongNodes, false, false), false, nil},
+		{"prefilter pass with expected feasible nodes, filter fails", mock.NewPreemptionPredicatePlugin(preemptions, rightNodes, false, true), false, errors.New("fail")},
+		{"both prefilter and filter passes with correct feasible nodes", mock.NewPreemptionPredicatePlugin(preemptions, rightNodes, false, false), true, nil},
+		{"both prefilter and filter passes with empty feasible nodes", mock.NewPreemptionPredicatePlugin(preemptions, nil, false, false), true, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alloc1, alloc2, err := creatApp1(childQ1, node, nil, map[string]resources.Quantity{"first": 5, "pods": 1}, appQueueMapping)
+			assert.NilError(t, err)
+			app2, ask3, err := creatApp2(childQ2, map[string]resources.Quantity{"first": 5, "pods": 1}, "alloc3", appQueueMapping)
+			assert.NilError(t, err)
+			childQ2.incPendingResource(ask3.GetAllocatedResource())
+			headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "pods": 3})
+			preemptor := NewPreemptor(app2, headRoom, 30*time.Second, ask3, iterator(), false)
+			plugins.RegisterSchedulerPlugin(tt.mockPlugin)
+			result, ok := preemptor.TryPreemption()
+			if tt.result {
+				assert.Assert(t, result != nil, "no result")
+				assert.NilError(t, tt.mockPlugin.GetPredicateError())
+				assert.Assert(t, ok, "no victims found")
+				assert.Equal(t, "alloc3", result.Request.GetAllocationKey(), "wrong alloc")
+				assert.Check(t, !alloc1.IsPreempted(), "alloc1 not preempted")
+				assert.Check(t, alloc2.IsPreempted(), "alloc2 preempted")
+				assert.Equal(t, len(ask3.GetAllocationLog()), 0)
+				childQ1.DecPreemptingResource(alloc1.GetAllocatedResource())
+			} else {
+				assert.Assert(t, result == nil, "no result")
+			}
+			if tt.mockPluginError != nil {
+				assert.ErrorContains(t, tt.mockPlugin.GetPredicateError(), tt.mockPluginError.Error())
+			}
+			// reset
+			resetQ(t, childQ1)
+			resetQ(t, childQ2)
+			resetNode(node)
+			plugins.UnregisterSchedulerPlugins()
+		})
+	}
 }
 
 func TestTryPreemption_SendEvent(t *testing.T) {
@@ -379,7 +446,7 @@ func TestTryPreemption_SendEvent(t *testing.T) {
 
 	eventSystem := evtMock.NewEventSystem()
 	events := schedEvt.NewAskEvents(eventSystem)
-	alloc1.askEvents = events
+	alloc2.askEvents = events
 
 	app2, ask3, err := creatApp2(childQ2, map[string]resources.Quantity{"first": 5, "pods": 1}, "alloc3", appQueueMapping)
 	assert.NilError(t, err)
@@ -390,7 +457,7 @@ func TestTryPreemption_SendEvent(t *testing.T) {
 
 	// register predicate handler
 	preemptions := []mock.Preemption{
-		mock.NewPreemption(true, "alloc3", nodeID1, []string{"alloc1"}, 0, 0),
+		mock.NewPreemption(true, "alloc3", nodeID1, []string{"alloc2"}, 0, 0),
 	}
 	plugin := mock.NewPreemptionPredicatePlugin(nil, nil, preemptions)
 	plugins.RegisterSchedulerPlugin(plugin)
@@ -401,12 +468,12 @@ func TestTryPreemption_SendEvent(t *testing.T) {
 	assert.NilError(t, plugin.GetPredicateError())
 	assert.Assert(t, ok, "no victims found")
 	assert.Equal(t, "alloc3", result.Request.GetAllocationKey(), "wrong alloc")
-	assert.Check(t, alloc1.IsPreempted(), "alloc1 not preempted")
-	assert.Check(t, !alloc2.IsPreempted(), "alloc2 preempted")
+	assert.Check(t, !alloc1.IsPreempted(), "alloc1 not preempted")
+	assert.Check(t, alloc2.IsPreempted(), "alloc2 preempted")
 	assert.Equal(t, 1, len(eventSystem.Events))
 	event := eventSystem.Events[0]
-	assert.Equal(t, alloc1.applicationID, event.ReferenceID)
-	assert.Equal(t, alloc1.allocationKey, event.ObjectID)
+	assert.Equal(t, alloc2.applicationID, event.ReferenceID)
+	assert.Equal(t, alloc2.allocationKey, event.ObjectID)
 	assert.Equal(t, si.EventRecord_NONE, event.EventChangeType)
 	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
 	assert.Equal(t, si.EventRecord_REQUEST, event.Type)
@@ -595,6 +662,7 @@ func TestTryPreemptionOnQueue(t *testing.T) {
 	childQ2, err := createManagedQueueGuaranteed(parentQ, "child2", false, nil, map[string]string{"first": "5"}, appQueneMapping)
 	assert.NilError(t, err)
 
+<<<<<<< HEAD
 	alloc1, alloc2, err := creatApp1(childQ1, node1, node2, map[string]resources.Quantity{"first": 5, "pods": 1}, appQueneMapping)
 	assert.NilError(t, err)
 
@@ -619,6 +687,61 @@ func TestTryPreemptionOnQueue(t *testing.T) {
 	assert.Check(t, !alloc1.IsPreempted(), "alloc1 preempted")
 	assert.Check(t, alloc2.IsPreempted(), "alloc2 not preempted")
 	assert.Equal(t, len(ask3.GetAllocationLog()), 0)
+=======
+	wrongNodes := make(map[string]int, 1)
+	wrongNodes[nodeID3] = 10
+	rightNodes := make(map[string]int, 1)
+	rightNodes[nodeID1] = 10
+	tests := []struct {
+		name            string
+		mockPlugin      *mock.PreemptionPredicatePlugin
+		result          bool
+		mockPluginError error
+	}{
+		{"prefilter fails", mock.NewPreemptionPredicatePlugin(nil, nil, true, false), false, errors.New("fail")},
+		{"prefilter passes but none of the node from iterator is available in feasible nodes", mock.NewPreemptionPredicatePlugin(nil, wrongNodes, false, false), false, nil},
+		{"prefilter pass with expected feasible nodes, filter fails", mock.NewPreemptionPredicatePlugin(nil, rightNodes, false, true), false, errors.New("fail")},
+		{"both prefilter and filter passes with correct feasible nodes", mock.NewPreemptionPredicatePlugin(nil, rightNodes, false, false), true, nil},
+		{"both prefilter and filter passes with empty feasible nodes", mock.NewPreemptionPredicatePlugin(nil, nil, false, false), true, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alloc1, alloc2, err := creatApp1(childQ1, node1, node2, map[string]resources.Quantity{"first": 5, "pods": 1}, appQueueMapping)
+			assert.NilError(t, err)
+			app2, ask3, err := creatApp2(childQ2, map[string]resources.Quantity{"first": 5, "pods": 1}, "alloc3", appQueueMapping)
+			assert.NilError(t, err)
+			headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "pods": 3})
+			preemptor := NewPreemptor(app2, headRoom, 30*time.Second, ask3, iterator(), false)
+			plugins.RegisterSchedulerPlugin(tt.mockPlugin)
+			result, ok := preemptor.TryPreemption()
+			if tt.result {
+				assert.Assert(t, result != nil, "no result")
+				assert.Assert(t, ok, "no victims found")
+				assert.Equal(t, "alloc3", result.Request.GetAllocationKey(), "wrong alloc")
+				nodes := make(map[string]int)
+				nodes[nodeID1] = 1
+				nodes[nodeID2] = 1
+				_, ok = nodes[result.NodeID]
+				assert.Check(t, ok == true, "either node1 or node2 chosen")
+				assert.Check(t, alloc1.IsPreempted() || alloc2.IsPreempted(), "either alloc1 or alloc2 preempted, but not both")
+				assert.Check(t, !alloc1.IsPreempted() || !alloc2.IsPreempted(), "either alloc1 or alloc2 not preempted, but not both")
+				childQ1.DecPreemptingResource(alloc1.GetAllocatedResource())
+				assert.Equal(t, len(ask3.GetAllocationLog()), 0)
+			} else {
+				assert.Assert(t, result == nil, "no result")
+			}
+			if tt.mockPluginError != nil {
+				assert.ErrorContains(t, tt.mockPlugin.GetPredicateError(), tt.mockPluginError.Error())
+			}
+			// reset
+			resetQ(t, childQ1)
+			resetQ(t, childQ2)
+			resetNode(node1)
+			resetNode(node2)
+			plugins.UnregisterSchedulerPlugins()
+		})
+	}
+>>>>>>> 4b253b5 ([YUNIKORN-3330] Run predicate checks in Required node preemption)
 }
 
 // TestTryPreemption_VictimsAvailable_InsufficientResource Test try preemption on queue with simple queue hierarchy. Since Node has enough resources to accomodate, preemption happens because of queue resource constraint.

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -121,8 +121,6 @@ func creatApp2(
 	return app2, ask3, nil
 }
 
-<<<<<<< HEAD
-=======
 func resetNode(node *Node) {
 	for _, v := range node.allocations {
 		node.RemoveAllocation(v.allocationKey)
@@ -149,7 +147,6 @@ func resetQ(t *testing.T, queue *Queue) {
 	queue.applications = make(map[string]*Application)
 }
 
->>>>>>> 4b253b5 ([YUNIKORN-3330] Run predicate checks in Required node preemption)
 func TestCheckPreconditions(t *testing.T) {
 	node := newNode("node1", map[string]resources.Quantity{"first": 5})
 	iterator := getNodeIteratorFn(node)
@@ -377,55 +374,19 @@ func TestTryPreemption(t *testing.T) {
 	preemptions := []mock.Preemption{
 		mock.NewPreemption(true, "alloc3", nodeID1, []string{"alloc2"}, 0, 0),
 	}
-	wrongNodes := make(map[string]int, 1)
-	wrongNodes[nodeID2] = 10
-	rightNodes := make(map[string]int, 1)
-	rightNodes[nodeID1] = 10
-	tests := []struct {
-		name            string
-		mockPlugin      *mock.PreemptionPredicatePlugin
-		result          bool
-		mockPluginError error
-	}{
-		{"prefilter fails", mock.NewPreemptionPredicatePlugin(preemptions, nil, true, false), false, errors.New("fail")},
-		{"prefilter passes but none of the node from iterator is available in feasible nodes", mock.NewPreemptionPredicatePlugin(preemptions, wrongNodes, false, false), false, nil},
-		{"prefilter pass with expected feasible nodes, filter fails", mock.NewPreemptionPredicatePlugin(preemptions, rightNodes, false, true), false, errors.New("fail")},
-		{"both prefilter and filter passes with correct feasible nodes", mock.NewPreemptionPredicatePlugin(preemptions, rightNodes, false, false), true, nil},
-		{"both prefilter and filter passes with empty feasible nodes", mock.NewPreemptionPredicatePlugin(preemptions, nil, false, false), true, nil},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			alloc1, alloc2, err := creatApp1(childQ1, node, nil, map[string]resources.Quantity{"first": 5, "pods": 1}, appQueueMapping)
-			assert.NilError(t, err)
-			app2, ask3, err := creatApp2(childQ2, map[string]resources.Quantity{"first": 5, "pods": 1}, "alloc3", appQueueMapping)
-			assert.NilError(t, err)
-			childQ2.incPendingResource(ask3.GetAllocatedResource())
-			headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "pods": 3})
-			preemptor := NewPreemptor(app2, headRoom, 30*time.Second, ask3, iterator(), false)
-			plugins.RegisterSchedulerPlugin(tt.mockPlugin)
-			result, ok := preemptor.TryPreemption()
-			if tt.result {
-				assert.Assert(t, result != nil, "no result")
-				assert.NilError(t, tt.mockPlugin.GetPredicateError())
-				assert.Assert(t, ok, "no victims found")
-				assert.Equal(t, "alloc3", result.Request.GetAllocationKey(), "wrong alloc")
-				assert.Check(t, !alloc1.IsPreempted(), "alloc1 not preempted")
-				assert.Check(t, alloc2.IsPreempted(), "alloc2 preempted")
-				assert.Equal(t, len(ask3.GetAllocationLog()), 0)
-				childQ1.DecPreemptingResource(alloc1.GetAllocatedResource())
-			} else {
-				assert.Assert(t, result == nil, "no result")
-			}
-			if tt.mockPluginError != nil {
-				assert.ErrorContains(t, tt.mockPlugin.GetPredicateError(), tt.mockPluginError.Error())
-			}
-			// reset
-			resetQ(t, childQ1)
-			resetQ(t, childQ2)
-			resetNode(node)
-			plugins.UnregisterSchedulerPlugins()
-		})
-	}
+	plugin := mock.NewPreemptionPredicatePlugin(nil, nil, preemptions)
+	plugins.RegisterSchedulerPlugin(plugin)
+	defer plugins.UnregisterSchedulerPlugins()
+
+	result, ok := preemptor.TryPreemption()
+	assert.Assert(t, result != nil, "no result")
+	assert.NilError(t, plugin.GetPredicateError())
+	assert.Assert(t, ok, "no victims found")
+	assert.Equal(t, "alloc3", result.Request.GetAllocationKey(), "wrong alloc")
+	assert.Check(t, !alloc1.IsPreempted(), "alloc1 not preempted")
+	assert.Check(t, alloc2.IsPreempted(), "alloc2 preempted")
+	assert.Equal(t, len(ask3.GetAllocationLog()), 0)
+	childQ1.DecPreemptingResource(alloc1.GetAllocatedResource())
 }
 
 func TestTryPreemption_SendEvent(t *testing.T) {
@@ -662,7 +623,6 @@ func TestTryPreemptionOnQueue(t *testing.T) {
 	childQ2, err := createManagedQueueGuaranteed(parentQ, "child2", false, nil, map[string]string{"first": "5"}, appQueneMapping)
 	assert.NilError(t, err)
 
-<<<<<<< HEAD
 	alloc1, alloc2, err := creatApp1(childQ1, node1, node2, map[string]resources.Quantity{"first": 5, "pods": 1}, appQueneMapping)
 	assert.NilError(t, err)
 
@@ -686,62 +646,8 @@ func TestTryPreemptionOnQueue(t *testing.T) {
 	assert.Equal(t, nodeID2, result.NodeID, "wrong node")
 	assert.Check(t, !alloc1.IsPreempted(), "alloc1 preempted")
 	assert.Check(t, alloc2.IsPreempted(), "alloc2 not preempted")
+	childQ1.DecPreemptingResource(alloc1.GetAllocatedResource())
 	assert.Equal(t, len(ask3.GetAllocationLog()), 0)
-=======
-	wrongNodes := make(map[string]int, 1)
-	wrongNodes[nodeID3] = 10
-	rightNodes := make(map[string]int, 1)
-	rightNodes[nodeID1] = 10
-	tests := []struct {
-		name            string
-		mockPlugin      *mock.PreemptionPredicatePlugin
-		result          bool
-		mockPluginError error
-	}{
-		{"prefilter fails", mock.NewPreemptionPredicatePlugin(nil, nil, true, false), false, errors.New("fail")},
-		{"prefilter passes but none of the node from iterator is available in feasible nodes", mock.NewPreemptionPredicatePlugin(nil, wrongNodes, false, false), false, nil},
-		{"prefilter pass with expected feasible nodes, filter fails", mock.NewPreemptionPredicatePlugin(nil, rightNodes, false, true), false, errors.New("fail")},
-		{"both prefilter and filter passes with correct feasible nodes", mock.NewPreemptionPredicatePlugin(nil, rightNodes, false, false), true, nil},
-		{"both prefilter and filter passes with empty feasible nodes", mock.NewPreemptionPredicatePlugin(nil, nil, false, false), true, nil},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			alloc1, alloc2, err := creatApp1(childQ1, node1, node2, map[string]resources.Quantity{"first": 5, "pods": 1}, appQueueMapping)
-			assert.NilError(t, err)
-			app2, ask3, err := creatApp2(childQ2, map[string]resources.Quantity{"first": 5, "pods": 1}, "alloc3", appQueueMapping)
-			assert.NilError(t, err)
-			headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "pods": 3})
-			preemptor := NewPreemptor(app2, headRoom, 30*time.Second, ask3, iterator(), false)
-			plugins.RegisterSchedulerPlugin(tt.mockPlugin)
-			result, ok := preemptor.TryPreemption()
-			if tt.result {
-				assert.Assert(t, result != nil, "no result")
-				assert.Assert(t, ok, "no victims found")
-				assert.Equal(t, "alloc3", result.Request.GetAllocationKey(), "wrong alloc")
-				nodes := make(map[string]int)
-				nodes[nodeID1] = 1
-				nodes[nodeID2] = 1
-				_, ok = nodes[result.NodeID]
-				assert.Check(t, ok == true, "either node1 or node2 chosen")
-				assert.Check(t, alloc1.IsPreempted() || alloc2.IsPreempted(), "either alloc1 or alloc2 preempted, but not both")
-				assert.Check(t, !alloc1.IsPreempted() || !alloc2.IsPreempted(), "either alloc1 or alloc2 not preempted, but not both")
-				childQ1.DecPreemptingResource(alloc1.GetAllocatedResource())
-				assert.Equal(t, len(ask3.GetAllocationLog()), 0)
-			} else {
-				assert.Assert(t, result == nil, "no result")
-			}
-			if tt.mockPluginError != nil {
-				assert.ErrorContains(t, tt.mockPlugin.GetPredicateError(), tt.mockPluginError.Error())
-			}
-			// reset
-			resetQ(t, childQ1)
-			resetQ(t, childQ2)
-			resetNode(node1)
-			resetNode(node2)
-			plugins.UnregisterSchedulerPlugins()
-		})
-	}
->>>>>>> 4b253b5 ([YUNIKORN-3330] Run predicate checks in Required node preemption)
 }
 
 // TestTryPreemption_VictimsAvailable_InsufficientResource Test try preemption on queue with simple queue hierarchy. Since Node has enough resources to accomodate, preemption happens because of queue resource constraint.

--- a/pkg/scheduler/objects/required_node_preemptor.go
+++ b/pkg/scheduler/objects/required_node_preemptor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apache/yunikorn-core/pkg/common"
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 	"github.com/apache/yunikorn-core/pkg/log"
+	"github.com/apache/yunikorn-core/pkg/plugins"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
@@ -67,39 +68,41 @@ func (p *PreemptionContext) tryPreemption() {
 	p.sortAllocations()
 
 	// Are there any victims/asks to preempt?
-	victims := p.GetVictims()
+	var victims []*Allocation
+	var finalVictims []*Allocation
+	victims = p.GetVictims()
 	if len(victims) > 0 {
-		log.Log(log.SchedRequiredNodePreemption).Info("Found victims for required node preemption",
-			zap.String("ds allocation key", p.requiredAsk.GetAllocationKey()),
-			zap.String("allocation name", p.requiredAsk.GetAllocationName()),
-			zap.Int("no.of victims", len(victims)))
-		for _, victim := range victims {
-			err := victim.MarkPreempted()
-			if err != nil {
-				log.Log(log.SchedRequiredNodePreemption).Warn("allocation is already released, so not proceeding further on the daemon set preemption process",
-					zap.String("applicationID", p.requiredAsk.GetApplicationID()),
-					zap.String("allocationKey", victim.GetAllocationKey()))
-				continue
+		finalVictims = p.runPredicates(victims)
+		if len(finalVictims) > 0 {
+			for _, victim := range finalVictims {
+				err := victim.MarkPreempted()
+				if err != nil {
+					log.Log(log.SchedRequiredNodePreemption).Warn("allocation is already released, so not proceeding further on the daemon set preemption process",
+						zap.String("applicationID", p.requiredAsk.GetApplicationID()),
+						zap.String("allocationKey", victim.GetAllocationKey()))
+					continue
+				}
+				if victimQueue := p.application.queue.GetQueueByAppID(victim.GetApplicationID()); victimQueue != nil {
+					victimQueue.IncPreemptingResource(victim.GetAllocatedResource())
+				} else {
+					log.Log(log.SchedRequiredNodePreemption).Warn("BUG: Queue not found for daemon set preemption victim",
+						zap.String("queue", p.application.queue.Name),
+						zap.String("victimApplicationID", victim.GetApplicationID()),
+						zap.String("victimAllocationKey", victim.GetAllocationKey()))
+				}
+				victim.SendPreemptedBySchedulerEvent(p.requiredAsk.GetAllocationKey(), p.requiredAsk.GetApplicationID(), p.application.queuePath)
 			}
-			if victimQueue := p.application.queue.GetQueueByAppID(victim.GetApplicationID()); victimQueue != nil {
-				victimQueue.IncPreemptingResource(victim.GetAllocatedResource())
-			} else {
-				log.Log(log.SchedRequiredNodePreemption).Warn("BUG: Queue not found for daemon set preemption victim",
-					zap.String("queue", p.application.queue.Name),
-					zap.String("victimApplicationID", victim.GetApplicationID()),
-					zap.String("victimAllocationKey", victim.GetAllocationKey()))
-			}
-			victim.SendPreemptedBySchedulerEvent(p.requiredAsk.GetAllocationKey(), p.requiredAsk.GetApplicationID(), p.application.queuePath)
+			p.requiredAsk.MarkTriggeredPreemption()
+			p.application.notifyRMAllocationReleased(victims, si.TerminationType_PREEMPTED_BY_SCHEDULER,
+				"preempting allocations to free up resources to run daemon set ask: "+p.requiredAsk.GetAllocationKey())
 		}
-		p.requiredAsk.MarkTriggeredPreemption()
-		p.application.notifyRMAllocationReleased(victims, si.TerminationType_PREEMPTED_BY_SCHEDULER,
-			"preempting allocations to free up resources to run daemon set ask: "+p.requiredAsk.GetAllocationKey())
-	} else {
+	}
+	if len(victims) == 0 || len(finalVictims) == 0 {
 		p.requiredAsk.LogAllocationFailure(common.NoVictimForRequiredNode, true)
 		p.requiredAsk.SendRequiredNodePreemptionFailedEvent(p.node.NodeID)
 		getRateLimitedReqNodeLog().Info("no victim found for required node preemption",
-			zap.String("allocation key", p.requiredAsk.GetAllocationKey()),
-			zap.String("allocation name", p.requiredAsk.GetAllocationName()),
+			zap.String("allocationKey", p.requiredAsk.GetAllocationKey()),
+			zap.String("allocationName", p.requiredAsk.GetAllocationName()),
 			zap.String("node", p.node.NodeID),
 			zap.Int("total allocations", result.totalAllocations),
 			zap.Int("requiredNode allocations", result.requiredNodeAllocations),
@@ -171,12 +174,66 @@ func (p *PreemptionContext) GetVictims() []*Allocation {
 		}
 	}
 
-	// Did we found the useful set of victims?
+	// Did we find the useful set of victims?
 	if len(victims) > 0 && resources.StrictlyGreaterThanOrEquals(
 		resources.Add(currentResource, p.node.GetAvailableResource()), p.requiredAsk.GetAllocatedResource()) {
 		return victims
 	}
 	return nil
+}
+
+// runPredicates Run Predicate checks to confirm whether collected victims from the required node is
+// good enough to move forward on the preemption further or not
+func (p *PreemptionContext) runPredicates(victims []*Allocation) []*Allocation {
+	finalVictims := make([]*Allocation, 0)
+	plugin := plugins.GetResourceManagerCallbackPlugin()
+	if plugin == nil {
+		log.Log(log.SchedRequiredNodePreemption).Debug("No RM callback plugin registered, using chosen victims as is",
+			zap.String("node", p.node.NodeID),
+			zap.String("allocationKey", p.requiredAsk.GetAllocationKey()))
+		return victims
+	} else {
+		// run predicates for this pod before in hand and fetch feasible nodes
+		feasibleNodes, predicatesResult := p.requiredAsk.preAllocateConditions(true)
+		if !predicatesResult {
+			return finalVictims
+		}
+		// Is this node suitable to run the pod?
+		if len(feasibleNodes) > 0 {
+			if _, ok := feasibleNodes[p.node.NodeID]; !ok {
+				log.Log(log.SchedRequiredNodePreemption).Debug("skipping node as it is not feasible to run the pod",
+					zap.String("allocationKey", p.requiredAsk.GetAllocationKey()),
+					zap.String("node", p.node.NodeID))
+				return finalVictims
+			}
+		}
+		keys := make([]string, 0)
+		for _, victim := range victims {
+			keys = append(keys, victim.GetAllocationKey())
+		}
+		args := &si.PreemptionPredicatesArgs{
+			AllocationKey:         p.requiredAsk.GetAllocationKey(),
+			NodeID:                p.node.NodeID,
+			PreemptAllocationKeys: keys,
+			StartIndex:            int32(0),
+		}
+		predicateResult := PredicateChecks(plugin, args)
+		if !predicateResult.success || predicateResult.index == -1 {
+			log.Log(log.SchedRequiredNodePreemption).Debug("running predicate checks failed",
+				zap.String("allocationKey", p.requiredAsk.GetAllocationKey()),
+				zap.String("node", p.node.NodeID))
+			return finalVictims
+		}
+		log.Log(log.SchedRequiredNodePreemption).Info("Found victims for required node preemption",
+			zap.String("allocationKey", p.requiredAsk.GetAllocationKey()),
+			zap.String("allocationName", p.requiredAsk.GetAllocationName()),
+			zap.Int("total victims", len(victims)))
+		victimsByNode := make(map[string][]*Allocation)
+		victimsByNode[p.node.NodeID] = victims
+		predicateResult.populateVictims(victimsByNode)
+		finalVictims = predicateResult.victims
+	}
+	return finalVictims
 }
 
 // for test only


### PR DESCRIPTION
### Description

Run preemption predicate checks for required node preemption. 
- PreFilter checks
- Filter Predicate Checks.
Refactored existing predicate checks functions used for Intra queue preemption to make use of the same even for required node preemption as well
Added new unit tests
Modified existing test cases as well

### Type of change
Please delete options that are not relevant.

- [ ] Bug Fix
- [X] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3330

- [X] I have created a Jira issue for this pull request.
- [ ] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [X] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
