### PR TITLE
[YUNIKORN-3333] Fix flaky unit test TestQuotaChangeTryPreemption

### DIFF
--- a/pkg/scheduler/objects/quota_preemptor_test.go
+++ b/pkg/scheduler/objects/quota_preemptor_test.go
@@ -156,29 +156,40 @@ func TestQuotaChangeTryPreemption(t *testing.T) {
 		},
 	})
 
-	suitableVictims := make([]*Allocation, 0)
-	notSuitableVictims := make([]*Allocation, 0)
-	oversizedVictims := make([]*Allocation, 0)
-	overflowVictims := make([]*Allocation, 0)
-	shortfallVictims := make([]*Allocation, 0)
-
-	suitableVictims = append(suitableVictims, createVictim(t, "ask1", node, 5, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})))
-	// ask2 uses {first:8} (smaller than ask1's {first:10}) so it is deterministically sorted first and preempted
-	suitableVictims = append(suitableVictims, createVictim(t, "ask2", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 8})))
-
-	oversizedVictims = append(oversizedVictims, createVictim(t, "ask21", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9})))
-	oversizedVictims = append(oversizedVictims, createVictim(t, "ask3", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11})))
-
-	overflowVictims = append(overflowVictims, createVictim(t, "ask4", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})))
-	overflowVictims = append(overflowVictims, createVictim(t, "ask41", node, 2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 6})))
-	overflowVictims = append(overflowVictims, createVictim(t, "ask42", node, 1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9})))
-
-	shortfallVictims = append(shortfallVictims, createVictim(t, "ask5", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})))
-	shortfallVictims = append(shortfallVictims, createVictim(t, "ask51", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 6})))
-	shortfallVictims = append(shortfallVictims, createVictim(t, "ask52", node, 2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 3})))
-	shortfallVictims = append(shortfallVictims, createVictim(t, "ask53", node, 1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 4})))
-
-	notSuitableVictims = append(notSuitableVictims, createVictim(t, "ask6", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11})))
+	prepareVictims := func(t *testing.T, node *Node, victimType string) []*Allocation {
+		switch victimType {
+		case "suitable":
+			return []*Allocation{
+				createVictim(t, "ask1", node, 5, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})),
+				// ask2 uses {first:8} (smaller than ask1's {first:10}) so it is deterministically sorted first and preempted
+				createVictim(t, "ask2", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 8})),
+			}
+		case "oversized":
+			return []*Allocation{
+				createVictim(t, "ask21", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9})),
+				createVictim(t, "ask3", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11})),
+			}
+		case "overflow":
+			return []*Allocation{
+				createVictim(t, "ask4", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})),
+				createVictim(t, "ask41", node, 2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 6})),
+				createVictim(t, "ask42", node, 1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9})),
+			}
+		case "shortfall":
+			return []*Allocation{
+				createVictim(t, "ask5", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})),
+				createVictim(t, "ask51", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 6})),
+				createVictim(t, "ask52", node, 2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 3})),
+				createVictim(t, "ask53", node, 1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 4})),
+			}
+		case "notSuitable":
+			return []*Allocation{
+				createVictim(t, "ask6", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11})),
+			}
+		default:
+			return []*Allocation{}
+		}
+	}
 
 	oldMax := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 20})
 	newMax := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
@@ -197,25 +208,25 @@ func TestQuotaChangeTryPreemption(t *testing.T) {
 		newMax               *resources.Resource
 		guaranteed           *resources.Resource
 		preemptableResource  *resources.Resource
-		victims              []*Allocation
+		victimType           string
 		claimedResource      *resources.Resource
 		totalExpectedVictims int
 		preemptedKeys        []string
 	}{
-		{"no victims available", leaf, oldMax, newMax, nil, preemptable, []*Allocation{}, nil, 0, []string{}},
-		{"suitable victims available", leaf, oldMax, newMax, nil, suitablePreemptable, suitableVictims, suitablePreemptable, 2, []string{"ask2"}},
-		{"victims available but none is suitable ", leaf, oldMax, newMax, nil, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1}), notSuitableVictims, nil, 1, []string{}},
-		{"skip over sized victims", leaf, oldMax, newMax, nil, preemptable, oversizedVictims, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9}), 2, []string{"ask21"}},
-		{"guaranteed not set", leaf, oldMax, newMax, nil, preemptable, overflowVictims, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}), 3, []string{"ask4"}},
-		{"guaranteed set but lower than max", leaf, oldMax, newMax, lowerGuaranteed, preemptable, overflowVictims, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}), 3, []string{"ask4"}},
-		{"best effort - guaranteed set and equals max", leaf, oldMax, newMax, guaranteed, bestEffortPreemptable, shortfallVictims, bestEffortClaimedResource, 4, []string{"ask52", "ask53"}},
-		{"best effort - guaranteed set, max not set earlier but now", leaf, nil, newMax, guaranteed, bestEffortPreemptable, shortfallVictims, bestEffortClaimedResource, 4, []string{"ask52", "ask53"}},
+		{"no victims available", leaf, oldMax, newMax, nil, preemptable, "empty", nil, 0, []string{}},
+		{"suitable victims available", leaf, oldMax, newMax, nil, suitablePreemptable, "suitable", suitablePreemptable, 2, []string{"ask2"}},
+		{"victims available but none is suitable ", leaf, oldMax, newMax, nil, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1}), "notSuitable", nil, 1, []string{}},
+		{"skip over sized victims", leaf, oldMax, newMax, nil, preemptable, "oversized", resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9}), 2, []string{"ask21"}},
+		{"guaranteed not set", leaf, oldMax, newMax, nil, preemptable, "overflow", resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}), 3, []string{"ask4"}},
+		{"guaranteed set but lower than max", leaf, oldMax, newMax, lowerGuaranteed, preemptable, "overflow", resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}), 3, []string{"ask4"}},
+		{"best effort - guaranteed set and equals max", leaf, oldMax, newMax, guaranteed, bestEffortPreemptable, "shortfall", bestEffortClaimedResource, 4, []string{"ask52", "ask53"}},
+		{"best effort - guaranteed set, max not set earlier but now", leaf, nil, newMax, guaranteed, bestEffortPreemptable, "shortfall", bestEffortClaimedResource, 4, []string{"ask52", "ask53"}},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			leaf.maxResource = tc.oldMax
 			leaf.guaranteedResource = tc.guaranteed
-			asks := tc.victims
+			asks := prepareVictims(t, node, tc.victimType)
 			assignAllocationsToQueue(asks, leaf)
 			leaf.maxResource = tc.newMax
 			leaf.guaranteedResource = tc.guaranteed

--- a/pkg/scheduler/objects/quota_preemptor_test.go
+++ b/pkg/scheduler/objects/quota_preemptor_test.go
@@ -156,40 +156,40 @@ func TestQuotaChangeTryPreemption(t *testing.T) {
 		},
 	})
 
-	prepareVictims := func(t *testing.T, node *Node, victimType string) []*Allocation {
-		switch victimType {
-		case "suitable":
-			return []*Allocation{
-				createVictim(t, "ask1", node, 5, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})),
-				// ask2 uses {first:8} (smaller than ask1's {first:10}) so it is deterministically sorted first and preempted
-				createVictim(t, "ask2", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 8})),
-			}
-		case "oversized":
-			return []*Allocation{
-				createVictim(t, "ask21", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9})),
-				createVictim(t, "ask3", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11})),
-			}
-		case "overflow":
-			return []*Allocation{
-				createVictim(t, "ask4", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})),
-				createVictim(t, "ask41", node, 2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 6})),
-				createVictim(t, "ask42", node, 1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9})),
-			}
-		case "shortfall":
-			return []*Allocation{
-				createVictim(t, "ask5", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})),
-				createVictim(t, "ask51", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 6})),
-				createVictim(t, "ask52", node, 2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 3})),
-				createVictim(t, "ask53", node, 1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 4})),
-			}
-		case "notSuitable":
-			return []*Allocation{
-				createVictim(t, "ask6", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11})),
-			}
-		default:
-			return []*Allocation{}
-		}
-	}
+	suitableVictims := make([]*Allocation, 0)
+	notSuitableVictims := make([]*Allocation, 0)
+	oversizedVictims := make([]*Allocation, 0)
+	overflowVictims := make([]*Allocation, 0)
+	overflowVictims1 := make([]*Allocation, 0)
+	shortfallVictims := make([]*Allocation, 0)
+	shortfallVictims1 := make([]*Allocation, 0)
+
+	suitableVictims = append(suitableVictims, createVictim(t, "ask1", node, 5, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})))
+	// ask2 uses {first:8} (smaller than ask1's {first:10}) so it is deterministically sorted first and preempted
+	suitableVictims = append(suitableVictims, createVictim(t, "ask2", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 8})))
+
+	oversizedVictims = append(oversizedVictims, createVictim(t, "ask21", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9})))
+	oversizedVictims = append(oversizedVictims, createVictim(t, "ask3", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11})))
+
+	overflowVictims = append(overflowVictims, createVictim(t, "ask4", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})))
+	overflowVictims = append(overflowVictims, createVictim(t, "ask41", node, 2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 6})))
+	overflowVictims = append(overflowVictims, createVictim(t, "ask42", node, 1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9})))
+
+	overflowVictims1 = append(overflowVictims1, createVictim(t, "ask4_1", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})))
+	overflowVictims1 = append(overflowVictims1, createVictim(t, "ask41_1", node, 2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 6})))
+	overflowVictims1 = append(overflowVictims1, createVictim(t, "ask42_1", node, 1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9})))
+
+	shortfallVictims = append(shortfallVictims, createVictim(t, "ask5", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})))
+	shortfallVictims = append(shortfallVictims, createVictim(t, "ask51", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 6})))
+	shortfallVictims = append(shortfallVictims, createVictim(t, "ask52", node, 2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 3})))
+	shortfallVictims = append(shortfallVictims, createVictim(t, "ask53", node, 1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 4})))
+
+	shortfallVictims1 = append(shortfallVictims1, createVictim(t, "ask5_1", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})))
+	shortfallVictims1 = append(shortfallVictims1, createVictim(t, "ask51_1", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 6})))
+	shortfallVictims1 = append(shortfallVictims1, createVictim(t, "ask52_1", node, 2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 3})))
+	shortfallVictims1 = append(shortfallVictims1, createVictim(t, "ask53_1", node, 1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 4})))
+
+	notSuitableVictims = append(notSuitableVictims, createVictim(t, "ask6", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11})))
 
 	oldMax := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 20})
 	newMax := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
@@ -208,25 +208,25 @@ func TestQuotaChangeTryPreemption(t *testing.T) {
 		newMax               *resources.Resource
 		guaranteed           *resources.Resource
 		preemptableResource  *resources.Resource
-		victimType           string
+		victims              []*Allocation
 		claimedResource      *resources.Resource
 		totalExpectedVictims int
 		preemptedKeys        []string
 	}{
-		{"no victims available", leaf, oldMax, newMax, nil, preemptable, "empty", nil, 0, []string{}},
-		{"suitable victims available", leaf, oldMax, newMax, nil, suitablePreemptable, "suitable", suitablePreemptable, 2, []string{"ask2"}},
-		{"victims available but none is suitable ", leaf, oldMax, newMax, nil, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1}), "notSuitable", nil, 1, []string{}},
-		{"skip over sized victims", leaf, oldMax, newMax, nil, preemptable, "oversized", resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9}), 2, []string{"ask21"}},
-		{"guaranteed not set", leaf, oldMax, newMax, nil, preemptable, "overflow", resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}), 3, []string{"ask4"}},
-		{"guaranteed set but lower than max", leaf, oldMax, newMax, lowerGuaranteed, preemptable, "overflow", resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}), 3, []string{"ask4"}},
-		{"best effort - guaranteed set and equals max", leaf, oldMax, newMax, guaranteed, bestEffortPreemptable, "shortfall", bestEffortClaimedResource, 4, []string{"ask52", "ask53"}},
-		{"best effort - guaranteed set, max not set earlier but now", leaf, nil, newMax, guaranteed, bestEffortPreemptable, "shortfall", bestEffortClaimedResource, 4, []string{"ask52", "ask53"}},
+		{"no victims available", leaf, oldMax, newMax, nil, preemptable, []*Allocation{}, nil, 0, []string{}},
+		{"suitable victims available", leaf, oldMax, newMax, nil, suitablePreemptable, suitableVictims, suitablePreemptable, 2, []string{"ask2"}},
+		{"victims available but none is suitable ", leaf, oldMax, newMax, nil, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1}), notSuitableVictims, nil, 1, []string{}},
+		{"skip over sized victims", leaf, oldMax, newMax, nil, preemptable, oversizedVictims, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9}), 2, []string{"ask21"}},
+		{"guaranteed not set", leaf, oldMax, newMax, nil, preemptable, overflowVictims, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}), 3, []string{"ask4"}},
+		{"guaranteed set but lower than max", leaf, oldMax, newMax, lowerGuaranteed, preemptable, overflowVictims1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}), 3, []string{"ask4_1"}},
+		{"best effort - guaranteed set and equals max", leaf, oldMax, newMax, guaranteed, bestEffortPreemptable, shortfallVictims, bestEffortClaimedResource, 4, []string{"ask52", "ask53"}},
+		{"best effort - guaranteed set, max not set earlier but now", leaf, nil, newMax, guaranteed, bestEffortPreemptable, shortfallVictims1, bestEffortClaimedResource, 4, []string{"ask52_1", "ask53_1"}},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			leaf.maxResource = tc.oldMax
 			leaf.guaranteedResource = tc.guaranteed
-			asks := prepareVictims(t, node, tc.victimType)
+			asks := tc.victims
 			assignAllocationsToQueue(asks, leaf)
 			leaf.maxResource = tc.newMax
 			leaf.guaranteedResource = tc.guaranteed


### PR DESCRIPTION
### Description
TestQuotaChangeTryPreemption shares victim slices across table-driven sub-tests. Preemption modifies these slices in place (sorting and truncating), so earlier sub-tests corrupt the state for later ones, causing non-deterministic failures.

Replace the shared pre-built victim slices with a prepareVictims factory function called inside each sub-test to create fresh allocations per run.

### Type of change
Please delete options that are not relevant.

- [X] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3333

- [ ] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A