### PR TITLE
[YUNIKORN-3336] event system shutdown leaks go routine or panics

### DIFF
--- a/pkg/events/event_publisher.go
+++ b/pkg/events/event_publisher.go
@@ -50,13 +50,11 @@ func createShimPublisher(store *EventStore) *eventPublisher {
 func (sp *eventPublisher) start() {
 	log.Log(log.Events).Info("Starting event publisher")
 	// handle a restart correctly
-	if sp.stopped.Load() {
-		sp.stopped.Store(false)
-		sp.stopCh = make(chan struct{})
-	} else {
+	if !sp.stopped.CompareAndSwap(true, false) {
 		log.Log(log.Events).Info("Event publisher already running")
 		return
 	}
+	sp.stopCh = make(chan struct{})
 	go func() {
 		for {
 			select {
@@ -78,7 +76,7 @@ func (sp *eventPublisher) start() {
 }
 
 func (sp *eventPublisher) stop() {
-	if sp.stopped.Load() {
+	if !sp.stopped.CompareAndSwap(false, true) {
 		log.Log(log.Events).Info("Event publisher already stopped")
 		return
 	}
@@ -86,7 +84,6 @@ func (sp *eventPublisher) stop() {
 	sp.stopCh <- struct{}{}
 	close(sp.stopCh)
 	sp.stopCh = nil
-	sp.stopped.Store(true)
 }
 
 func (sp *eventPublisher) getEventStore() *EventStore {

--- a/pkg/events/event_publisher.go
+++ b/pkg/events/event_publisher.go
@@ -19,6 +19,7 @@
 package events
 
 import (
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -30,33 +31,44 @@ import (
 // stores the push event internal
 var defaultPushEventInterval = 2 * time.Second
 
-type EventPublisher struct {
+type eventPublisher struct {
 	store             *EventStore
 	pushEventInterval time.Duration
-	stop              chan struct{}
+	stopCh            chan struct{}
+	stopped           atomic.Bool
 }
 
-func CreateShimPublisher(store *EventStore) *EventPublisher {
-	publisher := &EventPublisher{
+func createShimPublisher(store *EventStore) *eventPublisher {
+	publisher := &eventPublisher{
 		store:             store,
 		pushEventInterval: defaultPushEventInterval,
-		stop:              make(chan struct{}),
 	}
+	publisher.stopped.Store(true)
 	return publisher
 }
 
-func (sp *EventPublisher) StartService() {
-	log.Log(log.Events).Info("Starting shim event publisher")
+func (sp *eventPublisher) start() {
+	log.Log(log.Events).Info("Starting event publisher")
+	// handle a restart correctly
+	if sp.stopped.Load() {
+		sp.stopped.Store(false)
+		sp.stopCh = make(chan struct{})
+	} else {
+		log.Log(log.Events).Info("Event publisher already running")
+		return
+	}
 	go func() {
 		for {
 			select {
-			case <-sp.stop:
+			case <-sp.stopCh:
+				log.Log(log.Events).Info("Event publisher exiting")
 				return
 			case <-time.After(sp.pushEventInterval):
 				messages := sp.store.CollectEvents()
 				if len(messages) > 0 {
 					if eventPlugin := plugins.GetResourceManagerCallbackPlugin(); eventPlugin != nil {
-						log.Log(log.Events).Debug("Sending eventChannel", zap.Int("number of messages", len(messages)))
+						log.Log(log.Events).Debug("Sending eventChannel",
+							zap.Int("number of messages", len(messages)))
 						eventPlugin.SendEvent(messages)
 					}
 				}
@@ -65,11 +77,18 @@ func (sp *EventPublisher) StartService() {
 	}()
 }
 
-func (sp *EventPublisher) Stop() {
-	log.Log(log.Events).Info("Stopping shim event publisher")
-	close(sp.stop)
+func (sp *eventPublisher) stop() {
+	if sp.stopped.Load() {
+		log.Log(log.Events).Info("Event publisher already stopped")
+		return
+	}
+	log.Log(log.Events).Info("Stopping event publisher")
+	sp.stopCh <- struct{}{}
+	close(sp.stopCh)
+	sp.stopCh = nil
+	sp.stopped.Store(true)
 }
 
-func (sp *EventPublisher) getEventStore() *EventStore {
+func (sp *eventPublisher) getEventStore() *EventStore {
 	return sp.store
 }

--- a/pkg/events/event_publisher_test.go
+++ b/pkg/events/event_publisher_test.go
@@ -19,6 +19,7 @@
 package events
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -32,25 +33,38 @@ import (
 
 // creating a Publisher with nil store should still provide a non-nil object
 func TestCreateShimPublisher(t *testing.T) {
-	publisher := CreateShimPublisher(nil)
+	publisher := createShimPublisher(nil)
 	assert.Assert(t, publisher != nil, "publisher should not be nil")
 }
 
-// StartService() and Stop() functions should not cause panic
+// StartService() and stop() functions should not cause panic
 func TestServiceStartStopInternal(t *testing.T) {
 	store := newEventStore(1000)
-	publisher := CreateShimPublisher(store)
-	publisher.StartService()
-	defer publisher.Stop()
+	publisher := createShimPublisher(store)
+	defer publisher.stop()
 	assert.Equal(t, publisher.getEventStore(), store)
+	// start and stop simulate a restart
+	before := runtime.NumGoroutine()
+	publisher.start()
+	publisher.stop()
+	time.Sleep(10 * time.Millisecond) // tiny sleep to yield
+	assert.Equal(t, before, runtime.NumGoroutine(), "expected no new go routine after start and stop")
+
+	// start should not fail or panic
+	before = runtime.NumGoroutine()
+	publisher.start()
+	after := runtime.NumGoroutine()
+	assert.Equal(t, before+1, after, "expected 1 new go routine")
+	publisher.start()
+	assert.Equal(t, after, runtime.NumGoroutine(), "Already started should not create new go routine")
 }
 
 func TestNoFillWithoutEventPluginRegistered(t *testing.T) {
 	store := newEventStore(1000)
-	publisher := CreateShimPublisher(store)
+	publisher := createShimPublisher(store)
 	publisher.pushEventInterval = time.Millisecond
-	publisher.StartService()
-	defer publisher.Stop()
+	publisher.start()
+	defer publisher.stop()
 
 	event := &si.EventRecord{
 		Type:          si.EventRecord_REQUEST,
@@ -80,10 +94,10 @@ func TestPublisherSendsEvent(t *testing.T) {
 	}
 
 	store := newEventStore(1000)
-	publisher := CreateShimPublisher(store)
+	publisher := createShimPublisher(store)
 	publisher.pushEventInterval = time.Millisecond
-	publisher.StartService()
-	defer publisher.Stop()
+	publisher.start()
+	defer publisher.stop()
 
 	event := &si.EventRecord{
 		Type:          si.EventRecord_REQUEST,

--- a/pkg/events/event_system.go
+++ b/pkg/events/event_system.go
@@ -21,6 +21,7 @@ package events
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -33,8 +34,10 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
-var once sync.Once
-var ev EventSystem
+var (
+	once sync.Once
+	ev   EventSystem
+)
 
 type EventSystem interface {
 	// AddEvent adds an event record to the event system for processing:
@@ -77,17 +80,48 @@ type EventSystem interface {
 	GetEventStreams() []EventStreamData
 }
 
+// GetEventSystem returns the event system instance. Initialization happens during the first call.
+// This does not start the service or publisher. Call StartService or StartServiceWithPublisher
+// on the returned system to start the service.
+func GetEventSystem() EventSystem {
+	once.Do(func() {
+		Init()
+	})
+	return ev
+}
+
+// Init Initializes the event system.
+// Only exported for testing.
+func Init() {
+	store := newEventStore(getRequestCapacity())
+	buffer := newEventRingBuffer(getRingBufferCapacity())
+	evImpl := &EventSystemImpl{
+		Store:         store,
+		channel:       make(chan *si.EventRecord, configs.DefaultEventChannelSize),
+		eventBuffer:   buffer,
+		eventSystemId: fmt.Sprintf("event-system-%d", time.Now().Unix()),
+		streaming:     NewEventStreaming(buffer),
+	}
+	evImpl.stopped.Store(true)
+	// start the callback for this instance: must be done
+	configs.AddConfigMapCallback(evImpl.eventSystemId, func() {
+		go evImpl.reloadConfig()
+	})
+
+	ev = evImpl
+}
+
 // EventSystemImpl main implementation of the event system which is used for history tracking.
 type EventSystemImpl struct {
 	eventSystemId string
-	Store         *EventStore // storing eventChannel
-	publisher     *EventPublisher
+	Store         *EventStore // storing eventChannel, exported for test
+	publisher     *eventPublisher
 	eventBuffer   *eventRingBuffer
 	streaming     *EventStreaming
 
 	channel chan *si.EventRecord // channelling input eventChannel
-	stop    chan bool            // whether the service is stopped
-	stopped bool
+	stop    chan struct{}        // channel to stop the system
+	stopped atomic.Bool          // whether the service is stopped
 
 	trackingEnabled    bool
 	requestCapacity    uint64
@@ -111,14 +145,6 @@ func (ec *EventSystemImpl) GetEventsFromID(id, count uint64) ([]*si.EventRecord,
 	return ec.eventBuffer.GetEventsFromID(id, count)
 }
 
-// GetEventSystem returns the event system instance. Initialization happens during the first call.
-func GetEventSystem() EventSystem {
-	once.Do(func() {
-		Init()
-	})
-	return ev
-}
-
 // IsEventTrackingEnabled whether history tracking is currently enabled or not.
 func (ec *EventSystemImpl) IsEventTrackingEnabled() bool {
 	ec.RLock()
@@ -126,51 +152,75 @@ func (ec *EventSystemImpl) IsEventTrackingEnabled() bool {
 	return ec.trackingEnabled
 }
 
-// GetRequestCapacity returns the capacity of an intermediate storage which is used by the shim publisher.
-func (ec *EventSystemImpl) GetRequestCapacity() uint64 {
-	ec.RLock()
-	defer ec.RUnlock()
-	return ec.requestCapacity
-}
-
-// GetRingBufferCapacity returns the capacity of the buffer which stores historical elements.
-func (ec *EventSystemImpl) GetRingBufferCapacity() uint64 {
-	ec.RLock()
-	defer ec.RUnlock()
-	return ec.ringBufferCapacity
-}
-
-// Init Initializes the event system.
-// Only exported for testing.
-func Init() {
-	store := newEventStore(getRequestCapacity())
-	buffer := newEventRingBuffer(getRingBufferCapacity())
-	ev = &EventSystemImpl{
-		Store:         store,
-		channel:       make(chan *si.EventRecord, configs.DefaultEventChannelSize),
-		stop:          make(chan bool),
-		stopped:       false,
-		eventBuffer:   buffer,
-		eventSystemId: fmt.Sprintf("event-system-%d", time.Now().Unix()),
-		publisher:     CreateShimPublisher(store),
-		streaming:     NewEventStreaming(buffer),
-	}
-}
-
 // StartService starts the event processing in the background. See the interface for details.
 func (ec *EventSystemImpl) StartService() {
 	ec.StartServiceWithPublisher(true)
 }
 
+// Stop stops the event system, including the shim publisher if it was started.
+func (ec *EventSystemImpl) Stop() {
+	// no need to stop twice
+	if ec.stopped.Load() {
+		return
+	}
+	ec.stopped.Store(true)
+	ec.Lock()
+	defer ec.Unlock()
+	log.Log(log.Events).Info("Stopping event system handler")
+
+	configs.RemoveConfigMapCallback(ec.eventSystemId)
+
+	ec.stop <- struct{}{}
+	if ec.channel != nil {
+		close(ec.channel)
+		ec.channel = nil
+	}
+	if ec.publisher != nil {
+		ec.publisher.stop()
+		ec.publisher = nil
+	}
+}
+
+// GetEventStreams returns the current active event streams.
+func (ec *EventSystemImpl) GetEventStreams() []EventStreamData {
+	return ec.streaming.GetEventStreams()
+}
+
+// AddEvent adds an event record to the event system. See the interface for details.
+func (ec *EventSystemImpl) AddEvent(event *si.EventRecord) {
+	if event != nil {
+		event.Message = truncateEventMessage(event.Message)
+	}
+	// all events get tracked, even ones we drop
+	metrics.GetEventMetrics().IncEventsCreated()
+	// not running just track the metric
+	if ec.stopped.Load() {
+		metrics.GetEventMetrics().IncEventsNotChanneled()
+		return
+	}
+	ec.RLock()
+	defer ec.RUnlock()
+
+	select {
+	case ec.channel <- event:
+		metrics.GetEventMetrics().IncEventsChanneled()
+	default:
+		log.Log(log.Events).Debug("could not add Event to channel")
+		metrics.GetEventMetrics().IncEventsNotChanneled()
+	}
+}
+
 // StartServiceWithPublisher starts the event processing background routines.
 // Only exported for testing.
 func (ec *EventSystemImpl) StartServiceWithPublisher(withPublisher bool) {
+	if !ec.stopped.Load() {
+		log.Log(log.Events).Info("Event system is already running")
+		return
+	}
+	ec.stopped.Store(false)
 	ec.Lock()
 	defer ec.Unlock()
-
-	configs.AddConfigMapCallback(ec.eventSystemId, func() {
-		go ec.reloadConfig()
-	})
+	ec.stop = make(chan struct{})
 
 	ec.trackingEnabled = isTrackingEnabled()
 	ec.ringBufferCapacity = getRingBufferCapacity()
@@ -196,111 +246,40 @@ func (ec *EventSystemImpl) StartServiceWithPublisher(withPublisher bool) {
 		}
 	}()
 	if withPublisher {
-		ec.publisher.StartService()
+		ec.publisher = createShimPublisher(ec.Store)
+		ec.publisher.start()
 	}
 }
 
-// Stop stops the event system.
-func (ec *EventSystemImpl) Stop() {
-	ec.Lock()
-	defer ec.Unlock()
-
-	configs.RemoveConfigMapCallback(ec.eventSystemId)
-
-	if ec.stopped {
-		return
-	}
-
-	ec.stop <- true
-	if ec.channel != nil {
-		close(ec.channel)
-		ec.channel = nil
-	}
-	ec.publisher.Stop()
-	ec.stopped = true
-}
-
-func (ec *EventSystemImpl) isStopped() bool {
-	return ec.stopped || ec.channel == nil
-}
-
-// AddEvent adds an event record to the event system. See the interface for details.
-func (ec *EventSystemImpl) AddEvent(event *si.EventRecord) {
-	if event != nil {
-		event.Message = truncateEventMessage(event.Message)
-	}
-
-	metrics.GetEventMetrics().IncEventsCreated()
-
+// getRequestCapacity returns the capacity of an intermediate storage which is used by the shim publisher.
+func (ec *EventSystemImpl) getRequestCapacity() uint64 {
 	ec.RLock()
 	defer ec.RUnlock()
-
-	if ec.isStopped() {
-		metrics.GetEventMetrics().IncEventsNotChanneled()
-		return
-	}
-
-	select {
-	case ec.channel <- event:
-		metrics.GetEventMetrics().IncEventsChanneled()
-	default:
-		log.Log(log.Events).Debug("could not add Event to channel")
-		metrics.GetEventMetrics().IncEventsNotChanneled()
-	}
+	return ec.requestCapacity
 }
 
-// truncates event message to 1024 characters for k8s compatibility
-func truncateEventMessage(message string) string {
-	const k8sEventMessageLimit = 1024
-	if len(message) <= k8sEventMessageLimit {
-		return message
-	}
-	return message[:k8sEventMessageLimit-3] + "..."
+// getRingBufferCapacity returns the capacity of the buffer which stores historical elements.
+func (ec *EventSystemImpl) getRingBufferCapacity() uint64 {
+	ec.RLock()
+	defer ec.RUnlock()
+	return ec.ringBufferCapacity
 }
 
-func isTrackingEnabled() bool {
-	return common.GetConfigurationBool(configs.GetConfigMap(), configs.CMEventTrackingEnabled, configs.DefaultEventTrackingEnabled)
-}
-
-func getRequestCapacity() uint64 {
-	capacity := common.GetConfigurationUint(configs.GetConfigMap(), configs.CMEventRequestCapacity, configs.DefaultEventRequestCapacity)
-	if capacity == 0 {
-		log.Log(log.Events).Warn("Request capacity is set to 0, using default",
-			zap.String("property", configs.CMEventRequestCapacity),
-			zap.Uint64("default", configs.DefaultEventRequestCapacity))
-		return configs.DefaultEventRequestCapacity
-	}
-	return capacity
-}
-
-func getRingBufferCapacity() uint64 {
-	capacity := common.GetConfigurationUint(configs.GetConfigMap(), configs.CMEventRingBufferCapacity, configs.DefaultEventRingBufferCapacity)
-	if capacity == 0 {
-		log.Log(log.Events).Warn("Ring buffer capacity is set to 0, using default",
-			zap.String("property", configs.CMEventRingBufferCapacity),
-			zap.Uint64("default", configs.DefaultEventRingBufferCapacity))
-		return configs.DefaultEventRingBufferCapacity
-	}
-	return capacity
-}
-
+// isRestartNeeded returns true if the tracking mode has switched from off to on or vice versa.
+// Returns false if tracking mode has not changed
 func (ec *EventSystemImpl) isRestartNeeded() bool {
 	ec.RLock()
 	defer ec.RUnlock()
 	return isTrackingEnabled() != ec.trackingEnabled
 }
 
-// Restart restarts the event system, used during config update.
-func (ec *EventSystemImpl) Restart() {
+// restart restarts the event system, used during config update.
+func (ec *EventSystemImpl) restart() {
 	ec.Stop()
 	ec.StartServiceWithPublisher(true)
 }
 
-// GetEventStreams returns the current active event streams.
-func (ec *EventSystemImpl) GetEventStreams() []EventStreamData {
-	return ec.streaming.GetEventStreams()
-}
-
+// CloseAllStreams closes all existing streams.
 // VisibleForTesting
 func (ec *EventSystemImpl) CloseAllStreams() {
 	ec.streaming.Lock()
@@ -310,6 +289,7 @@ func (ec *EventSystemImpl) CloseAllStreams() {
 	}
 }
 
+// reloadConfig function called by the config
 func (ec *EventSystemImpl) reloadConfig() {
 	ec.Lock()
 	ec.requestCapacity = getRequestCapacity()
@@ -321,6 +301,47 @@ func (ec *EventSystemImpl) reloadConfig() {
 	ec.eventBuffer.Resize(ec.ringBufferCapacity)
 
 	if ec.isRestartNeeded() {
-		ec.Restart()
+		log.Log(log.Events).Info("Restarting event system handler on config reload")
+		ec.restart()
 	}
+}
+
+// truncateEventMessage limits the event message to 1024 characters for k8s compatibility
+func truncateEventMessage(message string) string {
+	const k8sEventMessageLimit = 1024
+	if len(message) <= k8sEventMessageLimit {
+		return message
+	}
+	return message[:k8sEventMessageLimit-3] + "..."
+}
+
+// isTrackingEnabled gets the current state of tracking from the configuration.
+func isTrackingEnabled() bool {
+	return common.GetConfigurationBool(configs.GetConfigMap(), configs.CMEventTrackingEnabled, configs.DefaultEventTrackingEnabled)
+}
+
+// getRequestCapacity returns the size of an intermediate storage from the configuration, using the
+// configs.DefaultEventRequestCapacity if 0 or not defined.
+func getRequestCapacity() uint64 {
+	capacity := common.GetConfigurationUint(configs.GetConfigMap(), configs.CMEventRequestCapacity, configs.DefaultEventRequestCapacity)
+	if capacity == 0 {
+		log.Log(log.Events).Warn("Request capacity is set to 0, using default",
+			zap.String("property", configs.CMEventRequestCapacity),
+			zap.Uint64("default", configs.DefaultEventRequestCapacity))
+		return configs.DefaultEventRequestCapacity
+	}
+	return capacity
+}
+
+// getRingBufferCapacity returns the ring buffer capacity from the configuration, using the
+// configs.DefaultEventRingBufferCapacity if 0 or not defined.
+func getRingBufferCapacity() uint64 {
+	capacity := common.GetConfigurationUint(configs.GetConfigMap(), configs.CMEventRingBufferCapacity, configs.DefaultEventRingBufferCapacity)
+	if capacity == 0 {
+		log.Log(log.Events).Warn("Ring buffer capacity is set to 0, using default",
+			zap.String("property", configs.CMEventRingBufferCapacity),
+			zap.Uint64("default", configs.DefaultEventRingBufferCapacity))
+		return configs.DefaultEventRingBufferCapacity
+	}
+	return capacity
 }

--- a/pkg/events/event_system.go
+++ b/pkg/events/event_system.go
@@ -93,14 +93,20 @@ func GetEventSystem() EventSystem {
 // Init Initializes the event system.
 // Only exported for testing.
 func Init() {
-	store := newEventStore(getRequestCapacity())
-	buffer := newEventRingBuffer(getRingBufferCapacity())
+	// load from config for setting in two places
+	confRequestCapacity := getRequestCapacity()
+	confRingBufferCapacity := getRingBufferCapacity()
+
+	store := newEventStore(confRequestCapacity)
+	buffer := newEventRingBuffer(confRingBufferCapacity)
 	evImpl := &EventSystemImpl{
-		Store:         store,
-		channel:       make(chan *si.EventRecord, configs.DefaultEventChannelSize),
-		eventBuffer:   buffer,
-		eventSystemId: fmt.Sprintf("event-system-%d", time.Now().Unix()),
-		streaming:     NewEventStreaming(buffer),
+		Store:              store,
+		eventBuffer:        buffer,
+		eventSystemId:      fmt.Sprintf("event-system-%d", time.Now().Unix()),
+		streaming:          NewEventStreaming(buffer),
+		trackingEnabled:    isTrackingEnabled(),
+		requestCapacity:    confRequestCapacity,
+		ringBufferCapacity: confRingBufferCapacity,
 	}
 	evImpl.stopped.Store(true)
 	// start the callback for this instance: must be done
@@ -159,16 +165,13 @@ func (ec *EventSystemImpl) StartService() {
 
 // Stop stops the event system, including the shim publisher if it was started.
 func (ec *EventSystemImpl) Stop() {
-	// no need to stop twice
-	if ec.stopped.Load() {
-		return
-	}
-	ec.stopped.Store(true)
 	ec.Lock()
 	defer ec.Unlock()
+	// no need to stop twice
+	if !ec.stopped.CompareAndSwap(false, true) {
+		return
+	}
 	log.Log(log.Events).Info("Stopping event system handler")
-
-	configs.RemoveConfigMapCallback(ec.eventSystemId)
 
 	ec.stop <- struct{}{}
 	if ec.channel != nil {
@@ -193,38 +196,37 @@ func (ec *EventSystemImpl) AddEvent(event *si.EventRecord) {
 	}
 	// all events get tracked, even ones we drop
 	metrics.GetEventMetrics().IncEventsCreated()
+	ec.RLock()
+	defer ec.RUnlock()
 	// not running just track the metric
 	if ec.stopped.Load() {
 		metrics.GetEventMetrics().IncEventsNotChanneled()
 		return
 	}
-	ec.RLock()
-	defer ec.RUnlock()
 
 	select {
 	case ec.channel <- event:
 		metrics.GetEventMetrics().IncEventsChanneled()
 	default:
-		log.Log(log.Events).Debug("could not add Event to channel")
-		metrics.GetEventMetrics().IncEventsNotChanneled()
+		// make sure we do not drop events when running. events generated while turned off are not "dropped"
+		log.Log(log.Events).Info("Event dropped due to channel full or closed",
+			zap.Int("channelSize", len(ec.channel)))
+		metrics.GetEventMetrics().IncEventsDropped()
 	}
 }
 
 // StartServiceWithPublisher starts the event processing background routines.
 // Only exported for testing.
 func (ec *EventSystemImpl) StartServiceWithPublisher(withPublisher bool) {
-	if !ec.stopped.Load() {
+	ec.Lock()
+	defer ec.Unlock()
+	if !ec.stopped.CompareAndSwap(true, false) {
 		log.Log(log.Events).Info("Event system is already running")
 		return
 	}
-	ec.stopped.Store(false)
-	ec.Lock()
-	defer ec.Unlock()
-	ec.stop = make(chan struct{})
-
 	ec.trackingEnabled = isTrackingEnabled()
-	ec.ringBufferCapacity = getRingBufferCapacity()
-	ec.requestCapacity = getRequestCapacity()
+	ec.stop = make(chan struct{})
+	ec.channel = make(chan *si.EventRecord, configs.DefaultEventChannelSize)
 
 	go func() {
 		log.Log(log.Events).Info("Starting event system handler")
@@ -291,17 +293,24 @@ func (ec *EventSystemImpl) CloseAllStreams() {
 
 // reloadConfig function called by the config
 func (ec *EventSystemImpl) reloadConfig() {
+	// load from config for setting in two places
+	confRequestCapacity := getRequestCapacity()
+	confRingBufferCapacity := getRingBufferCapacity()
+
 	ec.Lock()
-	ec.requestCapacity = getRequestCapacity()
-	ec.ringBufferCapacity = getRingBufferCapacity()
+	ec.requestCapacity = confRequestCapacity
+	ec.ringBufferCapacity = confRingBufferCapacity
 	ec.Unlock()
 
 	// resize the ring buffer & event store with new capacity
-	ec.Store.SetStoreSize(ec.requestCapacity)
-	ec.eventBuffer.Resize(ec.ringBufferCapacity)
+	ec.Store.SetStoreSize(confRequestCapacity)
+	ec.eventBuffer.Resize(confRingBufferCapacity)
 
 	if ec.isRestartNeeded() {
 		log.Log(log.Events).Info("Restarting event system handler on config reload")
+		ec.Lock()
+		ec.trackingEnabled = isTrackingEnabled()
+		ec.Unlock()
 		ec.restart()
 	}
 }

--- a/pkg/events/event_system_test.go
+++ b/pkg/events/event_system_test.go
@@ -19,6 +19,7 @@
 package events
 
 import (
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -38,11 +39,16 @@ func TestSimpleStartAndStop(t *testing.T) {
 	eventSystem := GetEventSystem()
 	// adding event to stopped eventSystem does not cause panic
 	eventSystem.AddEvent(nil)
+	before := runtime.NumGoroutine()
 	eventSystem.StartService()
 	defer eventSystem.Stop()
+	after := runtime.NumGoroutine()
+	assert.Equal(t, before+2, after, "expected 2 new go routines: handler and publisher")
 	// add an event
 	eventSystem.AddEvent(nil)
 	eventSystem.Stop()
+	time.Sleep(10 * time.Millisecond) // tiny sleep to yield
+	assert.Equal(t, before, runtime.NumGoroutine(), "expected all go routines to exit")
 	// adding event to stopped eventSystem does not cause panic
 	eventSystem.AddEvent(nil)
 }
@@ -51,7 +57,8 @@ func TestSimpleStartAndStop(t *testing.T) {
 // should be retrieved from the EventStore
 func TestSingleEventStoredCorrectly(t *testing.T) {
 	Init()
-	eventSystem := GetEventSystem().(*EventSystemImpl) //nolint:errcheck
+	eventSystem, ok := GetEventSystem().(*EventSystemImpl)
+	assert.Assert(t, ok, "expected an EventSystemImpl")
 	// don't run publisher, because it can collect the event while we're waiting
 	eventSystem.StartServiceWithPublisher(false)
 	defer eventSystem.Stop()
@@ -84,7 +91,8 @@ func TestSingleEventStoredCorrectly(t *testing.T) {
 
 func TestGetEvents(t *testing.T) {
 	Init()
-	eventSystem := GetEventSystem().(*EventSystemImpl) //nolint:errcheck
+	eventSystem, ok := GetEventSystem().(*EventSystemImpl)
+	assert.Assert(t, ok, "expected an EventSystemImpl")
 	eventSystem.StartServiceWithPublisher(false)
 	defer eventSystem.Stop()
 
@@ -116,13 +124,14 @@ func TestConfigUpdate(t *testing.T) {
 	defer configs.SetConfigMap(map[string]string{})
 
 	Init()
-	eventSystem := GetEventSystem().(*EventSystemImpl) //nolint:errcheck
+	eventSystem, ok := GetEventSystem().(*EventSystemImpl)
+	assert.Assert(t, ok, "expected an EventSystemImpl")
 	eventSystem.StartService()
 	defer eventSystem.Stop()
 
 	assert.Assert(t, eventSystem.IsEventTrackingEnabled())
-	assert.Equal(t, eventSystem.GetRingBufferCapacity(), uint64(configs.DefaultEventRingBufferCapacity))
-	assert.Equal(t, eventSystem.GetRequestCapacity(), uint64(configs.DefaultEventRequestCapacity))
+	assert.Equal(t, eventSystem.getRingBufferCapacity(), uint64(configs.DefaultEventRingBufferCapacity))
+	assert.Equal(t, eventSystem.getRequestCapacity(), uint64(configs.DefaultEventRequestCapacity))
 	assert.Equal(t, eventSystem.eventBuffer.capacity, uint64(configs.DefaultEventRingBufferCapacity))
 
 	// update config and wait for refresh
@@ -142,8 +151,8 @@ func TestConfigUpdate(t *testing.T) {
 	)
 	assert.NilError(t, err, "timed out waiting for config refresh")
 
-	assert.Equal(t, eventSystem.GetRingBufferCapacity(), newRingBufferCapacity)
-	assert.Equal(t, eventSystem.GetRequestCapacity(), newRequestCapacity)
+	assert.Equal(t, eventSystem.getRingBufferCapacity(), newRingBufferCapacity)
+	assert.Equal(t, eventSystem.getRequestCapacity(), newRequestCapacity)
 	assert.Equal(t, eventSystem.eventBuffer.capacity, newRingBufferCapacity)
 }
 
@@ -246,7 +255,8 @@ func getTestString(stringLength int) string {
 // TestAddEventConcurrentStop verifies AddEvent and Stop can run concurrently without data races.
 func TestAddEventConcurrentStop(t *testing.T) {
 	Init()
-	eventSystem := GetEventSystem().(*EventSystemImpl) //nolint:errcheck
+	eventSystem, ok := GetEventSystem().(*EventSystemImpl)
+	assert.Assert(t, ok, "expected an EventSystemImpl")
 	eventSystem.StartServiceWithPublisher(false)
 
 	var wg sync.WaitGroup

--- a/pkg/events/event_system_test.go
+++ b/pkg/events/event_system_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/apache/yunikorn-core/pkg/common"
 	"github.com/apache/yunikorn-core/pkg/common/configs"
+	"github.com/apache/yunikorn-core/pkg/metrics"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
@@ -39,6 +40,7 @@ func TestSimpleStartAndStop(t *testing.T) {
 	eventSystem := GetEventSystem()
 	// adding event to stopped eventSystem does not cause panic
 	eventSystem.AddEvent(nil)
+	time.Sleep(10 * time.Millisecond) // tiny sleep to yield
 	before := runtime.NumGoroutine()
 	eventSystem.StartService()
 	defer eventSystem.Stop()
@@ -48,7 +50,8 @@ func TestSimpleStartAndStop(t *testing.T) {
 	eventSystem.AddEvent(nil)
 	eventSystem.Stop()
 	time.Sleep(10 * time.Millisecond) // tiny sleep to yield
-	assert.Equal(t, before, runtime.NumGoroutine(), "expected all go routines to exit")
+	after = runtime.NumGoroutine()
+	assert.Equal(t, before, after, "expected all go routines to exit")
 	// adding event to stopped eventSystem does not cause panic
 	eventSystem.AddEvent(nil)
 }
@@ -191,6 +194,9 @@ func TestRequestCapacity(t *testing.T) {
 	configs.SetConfigMap(config)
 	capacity = getRequestCapacity()
 	assert.Equal(t, uint64(configs.DefaultEventRequestCapacity), capacity)
+
+	// reset to empty
+	configs.SetConfigMap(map[string]string{})
 }
 
 func TestRingBufferCapacity(t *testing.T) {
@@ -215,6 +221,9 @@ func TestRingBufferCapacity(t *testing.T) {
 	configs.SetConfigMap(config)
 	capacity = getRingBufferCapacity()
 	assert.Equal(t, uint64(configs.DefaultEventRingBufferCapacity), capacity)
+
+	// reset to empty
+	configs.SetConfigMap(map[string]string{})
 }
 
 func TestTruncateEventMessage(t *testing.T) {
@@ -258,6 +267,7 @@ func TestAddEventConcurrentStop(t *testing.T) {
 	eventSystem, ok := GetEventSystem().(*EventSystemImpl)
 	assert.Assert(t, ok, "expected an EventSystemImpl")
 	eventSystem.StartServiceWithPublisher(false)
+	defer eventSystem.Stop()
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -279,4 +289,43 @@ func TestAddEventConcurrentStop(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+// TestAddEventConcurrentStop verifies AddEvent and Stop can run concurrently without data races.
+func TestAddEventAfterRestart(t *testing.T) {
+	Init()
+	eventSystem, ok := GetEventSystem().(*EventSystemImpl)
+	assert.Assert(t, ok, "expected an EventSystemImpl")
+	metrics.GetEventMetrics().Reset()
+	eventSystem.StartServiceWithPublisher(false)
+	defer eventSystem.Stop()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	eventCount := 10000
+	go func() {
+		defer wg.Done()
+		for i := range eventCount {
+			eventSystem.AddEvent(&si.EventRecord{
+				Type:    si.EventRecord_REQUEST,
+				Message: strconv.Itoa(i),
+			})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		time.Sleep(time.Millisecond)
+		eventSystem.restart()
+	}()
+
+	wg.Wait()
+	counted := metrics.GetEventMetrics().GetEventsDropped()
+	assert.Equal(t, counted, 0, "should not have dropped an event")
+	counted = metrics.GetEventMetrics().GetEventsCreated()
+	assert.Equal(t, counted, eventCount, "number of created events incorrect")
+	counted = metrics.GetEventMetrics().GetEventsChanneled()
+	notCounted := metrics.GetEventMetrics().GetEventsNotChanneled()
+	assert.Equal(t, counted+notCounted, eventCount, "total number of (not)channeled events incorrect")
 }

--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -18,12 +18,16 @@
 
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
 
 type EventMetrics struct {
 	totalEventsCreated      prometheus.Gauge
 	totalEventsChanneled    prometheus.Gauge
 	totalEventsNotChanneled prometheus.Gauge
+	totalEventsDropped      prometheus.Gauge
 	totalEventsProcessed    prometheus.Gauge
 	totalEventsStored       prometheus.Gauge
 	totalEventsNotStored    prometheus.Gauge
@@ -53,6 +57,13 @@ func initEventMetrics() *EventMetrics {
 			Subsystem: EventSubsystem,
 			Name:      "total_not_channeled",
 			Help:      "total events not channeled",
+		})
+	metrics.totalEventsDropped = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: EventSubsystem,
+			Name:      "total_dropped",
+			Help:      "total events dropped",
 		})
 	metrics.totalEventsProcessed = prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -93,6 +104,7 @@ func (em *EventMetrics) Reset() {
 	em.totalEventsCreated.Set(0)
 	em.totalEventsChanneled.Set(0)
 	em.totalEventsNotChanneled.Set(0)
+	em.totalEventsDropped.Set(0)
 	em.totalEventsStored.Set(0)
 	em.totalEventsNotStored.Set(0)
 	em.totalEventsProcessed.Set(0)
@@ -110,6 +122,10 @@ func (em *EventMetrics) IncEventsNotChanneled() {
 	em.totalEventsNotChanneled.Inc()
 }
 
+func (em *EventMetrics) IncEventsDropped() {
+	em.totalEventsDropped.Inc()
+}
+
 func (em *EventMetrics) IncEventsProcessed() {
 	em.totalEventsProcessed.Inc()
 }
@@ -124,4 +140,74 @@ func (em *EventMetrics) IncEventsNotStored() {
 
 func (em *EventMetrics) AddEventsCollected(collectedEvents int) {
 	em.totalEventsCollected.Add(float64(collectedEvents))
+}
+
+// Event system metrics
+
+func (em *EventMetrics) GetEventsCreated() int {
+	metricDto := &dto.Metric{}
+	if err := em.totalEventsCreated.Write(metricDto); err == nil {
+		return int(*metricDto.Gauge.Value)
+	}
+	return -1
+}
+
+func (em *EventMetrics) GetEventsChanneled() int {
+	metricDto := &dto.Metric{}
+	if err := em.totalEventsChanneled.Write(metricDto); err == nil {
+		return int(*metricDto.Gauge.Value)
+	}
+	return -1
+}
+
+func (em *EventMetrics) GetEventsNotChanneled() int {
+	metricDto := &dto.Metric{}
+	if err := em.totalEventsNotChanneled.Write(metricDto); err == nil {
+		return int(*metricDto.Gauge.Value)
+	}
+	return -1
+}
+
+func (em *EventMetrics) GetEventsDropped() int {
+	metricDto := &dto.Metric{}
+	if err := em.totalEventsDropped.Write(metricDto); err == nil {
+		return int(*metricDto.Gauge.Value)
+	}
+	return -1
+}
+
+// Publisher metrics
+
+func (em *EventMetrics) GetEventsProcessed() int {
+	metricDto := &dto.Metric{}
+	if err := em.totalEventsProcessed.Write(metricDto); err == nil {
+		return int(*metricDto.Gauge.Value)
+	}
+	return -1
+}
+
+// Event store metrics
+
+func (em *EventMetrics) GetEventsStored() int {
+	metricDto := &dto.Metric{}
+	if err := em.totalEventsStored.Write(metricDto); err == nil {
+		return int(*metricDto.Gauge.Value)
+	}
+	return -1
+}
+
+func (em *EventMetrics) GetEventsNotStored() int {
+	metricDto := &dto.Metric{}
+	if err := em.totalEventsNotStored.Write(metricDto); err == nil {
+		return int(*metricDto.Gauge.Value)
+	}
+	return -1
+}
+
+func (em *EventMetrics) GetEventsCollected() int {
+	metricDto := &dto.Metric{}
+	if err := em.totalEventsCollected.Write(metricDto); err == nil {
+		return int(*metricDto.Gauge.Value)
+	}
+	return -1
 }


### PR DESCRIPTION
### Description
Calling StartService for an existing stopped EventPublisher does not create a new stop channel. Event publisher will ignore start request when already running. Calling stop twice on the EventPublisher panics as it tries to close an already closed channel.

Move config callback setup for event system into the Init() allowing a start from config even when system start did not start the event system. Move stop channel creation into start and stop functions

Cleanup layout in event system and publisher
Remove exports from functions and objects where possible.

### Type of change
- [X] Bug Fix

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3336

- [X] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [X] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
