### PR TITLE
[YUNIKORN-3320] Add test for required node reservation not cancelled on timeout

### DIFF
--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -3340,6 +3340,47 @@ func TestTryAllocateWithReservedHeadRoomChecking(t *testing.T) {
 	// reset wait timeout
 }
 
+// TestTryReservedAllocateRequiredNodeNotCancelledOnTimeout verifies that required node reservations
+// are not cancelled even if they exceed the reservationWaitTimeout.
+func TestTryReservedAllocateRequiredNodeNotCancelledOnTimeout(t *testing.T) {
+	setupUGM()
+
+	res, err := resources.NewResourceFromConf(map[string]string{"memory": "2G"})
+	assert.NilError(t, err, "failed to create basic resource")
+	headRoom, err := resources.NewResourceFromConf(map[string]string{"memory": "1G"})
+	assert.NilError(t, err, "failed to create basic resource")
+
+	app := newApplication(appID1, "default", "root")
+	ask := newAllocationAsk(aKey, appID1, res)
+	ask.SetRequiredNode(nodeID1)
+	queue, err := createRootQueue(map[string]string{"memory": "1G"})
+	assert.NilError(t, err, "queue create failed")
+	app.queue = queue
+	err = app.AddAllocationAsk(ask)
+	assert.NilError(t, err, "ask should have been added to app")
+
+	node1 := newNodeRes(nodeID1, res)
+	node2 := newNodeRes(nodeID2, res)
+	// reserve on the required node
+	err = app.Reserve(node1, ask)
+	assert.NilError(t, err, "reservation should not have failed")
+
+	iter := getNodeIteratorFn(node1, node2)
+
+	// headroom is insufficient, but reservation should NOT be cancelled (required node)
+	result := app.tryReservedAllocate(headRoom, iter)
+	assert.Assert(t, result == nil, "result is expected to be nil due to insufficient headroom")
+	assert.Equal(t, len(app.reservations), 1, "required node reservation should not be cancelled")
+
+	// set the reservation time to well beyond the timeout
+	app.reservations[ask.allocationKey].createTime = time.Now().Add(-90 * time.Minute)
+
+	// even after timeout, required node reservation must NOT be cancelled
+	result = app.tryReservedAllocate(headRoom, iter)
+	assert.Assert(t, result == nil, "result is expected to be nil due to insufficient headroom")
+	assert.Equal(t, len(app.reservations), 1, "required node reservation must not be cancelled on timeout")
+}
+
 func TestUpdateRunnableStatus(t *testing.T) {
 	app := newApplication(appID0, "default", "root.unknown")
 	assert.Assert(t, app.runnableInQueue)


### PR DESCRIPTION
### Description
Add test coverage for the fix introduced in YUNIKORN-3318 (commit 3dbbb5d) that prevents
required node reservations from being released when the reservationWaitTimeout expires.

The new test `TestTryReservedAllocateRequiredNodeNotCancelledOnTimeout` verifies that
required node (DaemonSet) reservations are NOT cancelled on timeout, complementing the
existing `TestTryAllocateWithReservedHeadRoomChecking` which verifies normal reservations
ARE cancelled.

### Type of change

- [x] Bug Fix

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3320

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
- [x] The PR includes the phrase "Generated by GitHub Copilot (Claude)", where the tool is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [x] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
Test output:
```
go test ./pkg/scheduler/objects/ -run TestTryReservedAllocateRequiredNodeNotCancelledOnTimeout -v
--- PASS: TestTryReservedAllocateRequiredNodeNotCancelledOnTimeout (0.00s)
PASS
```