### PR TITLE
[YUNIKORN-3334] Fix flaky unit test TestQuotaChangeTryPreemptionWithDifferentResTypes

### DIFF
--- a/pkg/scheduler/objects/quota_preemptor_test.go
+++ b/pkg/scheduler/objects/quota_preemptor_test.go
@@ -257,24 +257,40 @@ func TestQuotaChangeTryPreemptionWithDifferentResTypes(t *testing.T) {
 		NodeID:     "node",
 		Attributes: nil,
 		SchedulableResource: &si.Resource{
-			Resources: map[string]*si.Quantity{"first": {Value: 100}, "second": {Value: 200}},
+			Resources: map[string]*si.Quantity{"first": {Value: 200}, "second": {Value: 200}},
 		},
 	})
 
-	suitableVictims := make([]*Allocation, 0)
-	overflowVictims := make([]*Allocation, 0)
-	oversizedVictims := make([]*Allocation, 0)
-
-	suitableVictims = append(suitableVictims, createVictim(t, "ask1", node, 5, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "second": 10})))
-	// ask2 uses {first:9, second:9} (smaller than ask1 in both dimensions) to ensure deterministic sort order
-	suitableVictims = append(suitableVictims, createVictim(t, "ask2", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9, "second": 9})))
-
-	oversizedVictims = append(oversizedVictims, createVictim(t, "ask21", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9, "second": 10})))
-	oversizedVictims = append(oversizedVictims, createVictim(t, "ask3", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11, "second": 10})))
-
-	overflowVictims = append(overflowVictims, createVictim(t, "ask4", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5, "second": 10})))
-	overflowVictims = append(overflowVictims, createVictim(t, "ask41", node, 2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 6, "second": 10})))
-	overflowVictims = append(overflowVictims, createVictim(t, "ask42", node, 1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9, "second": 10})))
+	suitableVictims := []*Allocation{
+		createVictim(t, "ask1", node, 5, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "second": 10})),
+		// ask2 uses {first:9, second:9} (smaller than ask1 in both dimensions) to ensure deterministic sort order
+		createVictim(t, "ask2", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9, "second": 9})),
+	}
+	suitableVictims1 := []*Allocation{
+		createVictim(t, "ask1_1", node, 5, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "second": 10})),
+		createVictim(t, "ask2_1", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9, "second": 9})),
+	}
+	suitableVictims2 := []*Allocation{
+		createVictim(t, "ask1_2", node, 5, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "second": 10})),
+		createVictim(t, "ask2_2", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9, "second": 9})),
+	}
+	suitableVictims3 := []*Allocation{
+		createVictim(t, "ask1_3", node, 5, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "second": 10})),
+		createVictim(t, "ask2_3", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9, "second": 9})),
+	}
+	suitableVictims4 := []*Allocation{
+		createVictim(t, "ask1_4", node, 5, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "second": 10})),
+		createVictim(t, "ask2_4", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9, "second": 9})),
+	}
+	oversizedVictims := []*Allocation{
+		createVictim(t, "ask21", node, 4, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9, "second": 10})),
+		createVictim(t, "ask3", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 11, "second": 10})),
+	}
+	overflowVictims := []*Allocation{
+		createVictim(t, "ask4", node, 3, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5, "second": 10})),
+		createVictim(t, "ask41", node, 2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 6, "second": 10})),
+		createVictim(t, "ask42", node, 1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 9, "second": 10})),
+	}
 
 	oldMax := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 20})
 	newMax := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
@@ -309,22 +325,22 @@ func TestQuotaChangeTryPreemptionWithDifferentResTypes(t *testing.T) {
 		},
 		{"suitable victims available with extra resource types other than defined in max", leaf, nil, newMax, nil,
 			[]test{
-				{suitableVictims, 2, []string{"ask2"}},
+				{suitableVictims1, 2, []string{"ask2_1"}},
 			},
 		},
 		{"suitable victims available with extra resource types other than defined in guaranteed", leaf, nil, newMax, lowerGuaranteed,
 			[]test{
-				{suitableVictims, 2, []string{"ask2"}},
+				{suitableVictims2, 2, []string{"ask2_2"}},
 			},
 		},
 		{"suitable victims available - different res types, adding new res type in max", leaf, oldMax, newMaxWithNewResTypes, nil,
 			[]test{
-				{suitableVictims, 2, []string{"ask2"}},
+				{suitableVictims3, 2, []string{"ask2_3"}},
 			},
 		},
 		{"suitable victims available - different res types, removing existing res type from max", leaf, oldMax, newMaxWithRemovedResTypes, nil,
 			[]test{
-				{suitableVictims, 2, []string{"ask2"}},
+				{suitableVictims4, 2, []string{"ask2_4"}},
 			},
 		},
 		{"overflow victims available with extra resource types other than defined in guaranteed and vice versa", leaf, oldMax, newMax, lowerGuaranteedWithNewResTypes,

--- a/pkg/scheduler/objects/quota_preemptor_test.go
+++ b/pkg/scheduler/objects/quota_preemptor_test.go
@@ -696,9 +696,9 @@ func createQueueSetups(t *testing.T, parent *Queue, leafResG configs.Resources, 
 }
 
 func createVictim(t *testing.T, allocKey string, node *Node, adjustment int, allocRes *resources.Resource) *Allocation {
-	createTime := time.Now()
+	baseTime := time.Now().Truncate(time.Hour).Add(30 * time.Minute)
 	allocation := createAllocation(allocKey, "app1", node.NodeID, true, false, 10, false, allocRes)
-	allocation.createTime = createTime.Add(-time.Minute * time.Duration(adjustment))
+	allocation.createTime = baseTime.Add(-time.Minute * time.Duration(adjustment))
 	assert.Assert(t, node.TryAddAllocation(allocation))
 	return allocation
 }


### PR DESCRIPTION
### Description
Fix flaky unit test TestQuotaChangeTryPreemptionWithDifferentResTypes in quota_preemptor_test.go.                                                                          
                                                                                                                                                                                   
**Root Cause:**                                                                                                                                                                
    In `createVictim`, creation times were calculated relative to `time.Now()` with minute offsets (`-3m`, `-2m`, `-1m`). When unit tests execute within the first 3 minutes of an hour (e.g. 19:01 UTC), `ask4` (-3m) falls into the previous hour, while `ask42` (-1m) falls into the current hour. Since preemption sorting truncates creation times to `time.Hour` and prioritizes younger allocations, `ask42` (current hour) was incorrectly sorted before `ask4` (previous hour), causing intermittent assertion failures (`ask42 != ask4`).
                                                                                                                                                                                   
**Fix & Refactoring:**                                                                                                                                                         
    1. Anchored baseTime in createVictim to the middle of the hour (time.Now().Truncate(time.Hour).Add(30 * time.Minute)) so minute offsets never cross hour boundaries.     
    2. Refactored suitableVictims into independent allocation slices for each subtest to avoid object/state reuse across test cases, updating node capacity to 200 accordingly.


### Type of change
Please delete options that are not relevant.

- [X] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3334

- [ ] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
Duplicate JIRA Note: This flaky test was reported twice under [YUNIKORN-3334](https://issues.apache.org/jira/browse/YUNIKORN-3334) and [YUNIKORN-3342](https://issues.apache.org/jira/browse/YUNIKORN-3342). Using [YUNIKORN-3334](https://issues.apache.org/jira/browse/YUNIKORN-3334) as it is the earlier ticket.
Refactoring Note: The suitableVictims refactoring (separate allocation instances per subtest) is not strictly required to fix the hour-boundary bug, but was included to improve test isolation and prevent future state pollution. Please let me know if you prefer to keep this PR focused solely on the time boundary fix, and I can revert the refactoring commit.