### PR TITLE
[YUNIKORN-3335] flaky test TestQuotaChangeTryPreemptionForParentQueue

### DIFF
--- a/pkg/scheduler/objects/preemption_utilities_test.go
+++ b/pkg/scheduler/objects/preemption_utilities_test.go
@@ -160,6 +160,9 @@ func resetQueue(queue *Queue) {
 	queue.guaranteedResource = nil
 	queue.isQuotaPreemptionRunning = false
 	queue.preemptingResource = nil
+	for _, child := range queue.GetCopyOfChildren() {
+		resetQueue(child)
+	}
 }
 
 // regular pods

--- a/pkg/scheduler/objects/quota_preemptor_test.go
+++ b/pkg/scheduler/objects/quota_preemptor_test.go
@@ -597,7 +597,8 @@ func TestQuotaChangeTryPreemptionForParentQueue(t *testing.T) {
 	}{
 		// claimed = ask1(9)+ask2(10) + ask4(9) + ask6(8)+ask7(9)+ask8(10)+ask9(11)+ask10(12) + ask11(9)+ask12(10)+ask13(11) = 19+9+50+30 = 108
 		{"Guaranteed set on one side of queue hierarchy - suitable victims available", parent, oldMax, newMax, leafGVictims, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 108}), 13, []string{"ask1", "ask2", "ask4", "ask6", "ask7", "ask8", "ask9", "ask10", "ask11", "ask12", "ask13"}},
-		{"Guaranteed set on one side of queue hierarchy - victims available but none suitable", parent, oldMax, newMax, leafGNotSuitableVictims, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 110}), 1, []string{}},
+		// no victim fits the budget, so nothing is claimed even though one candidate is selected
+		{"Guaranteed set on one side of queue hierarchy - victims available but none suitable", parent, oldMax, newMax, leafGNotSuitableVictims, resources.NewResource(), 1, []string{}},
 		// claimed = ask1(9)+ask2(10) + ask4(9) + ask6(8)+ask7(9)+ask8(10)+ask9(11) + ask11(9)+ask12(10) = 19+9+38+19 = 85
 		{"Guaranteed set not set on any queue - suitable victims available", parent1, oldMax, newMax, leafVictims, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 85}), 14, []string{"ask1", "ask2", "ask4", "ask6", "ask7", "ask8", "ask9", "ask11", "ask12"}},
 		// each leaf preempts the smaller victim (ask_even = {first:12}), claimed = 5 × 12 = 60
@@ -621,7 +622,7 @@ func TestQuotaChangeTryPreemptionForParentQueue(t *testing.T) {
 			}
 			assertPreemptedAllocationKeys(t, allAllocs, tc.preemptedKeys)
 			time.Sleep(500 * time.Millisecond)
-			assertQuotaPreemptionEvent(t, len(tc.preemptedKeys), "Quota Preemption results summary: preemptable resources: "+resources.Multiply(preemptableResource, -1).String()+", claimed resources: "+tc.claimedResources.String()+", selected victims: "+strconv.Itoa(tc.totalVictims)+", preempted victims: "+strconv.Itoa(len(tc.preemptedKeys)), eventSystem.Store.CollectEvents())
+			assertQuotaPreemptionEvent(t, tc.totalVictims, "Quota Preemption results summary: preemptable resources: "+resources.Multiply(preemptableResource, -1).String()+", claimed resources: "+tc.claimedResources.String()+", selected victims: "+strconv.Itoa(tc.totalVictims)+", preempted victims: "+strconv.Itoa(len(tc.preemptedKeys)), eventSystem.Store.CollectEvents())
 			for _, v := range tc.victims {
 				removeAllocationAsks(node, v)
 			}
@@ -651,9 +652,9 @@ func assertPreemptedAllocationKeys(t *testing.T, allocations []*Allocation, expe
 	}
 }
 
-func assertQuotaPreemptionEvent(t *testing.T, victims int, results string, records []*si.EventRecord) {
+func assertQuotaPreemptionEvent(t *testing.T, selectedVictims int, results string, records []*si.EventRecord) {
 	recordsLen := len(records)
-	if victims > 0 {
+	if selectedVictims > 0 {
 		assert.Equal(t, si.EventRecord_QUEUE, records[recordsLen-1].Type)
 		assert.Equal(t, si.EventRecord_SET, records[recordsLen-1].EventChangeType)
 		assert.Equal(t, si.EventRecord_QUEUE_PREEMPTION, records[recordsLen-1].EventChangeDetail)


### PR DESCRIPTION
## Description
  The resetQueue() function only cleared state on the specified queue, but did not recursively reset its child queues. As a result, child queues retained leftover allocatedResource values across subtests in TestQuotaChangeTryPreemptionForParentQueue.
  
   This PR updates resetQueue() to recursively clear child queues, aligns assertQuotaPreemptionEvent()` with production event emission logic (selectedVictims > 0), and corrects the expected claimedResources in Subtest 2.                                                               
  
Note: The primary flaky root cause (where `createVictim` offsets crossed hour boundaries during `HH:04:00~HH:04:59` due to `time.Hour`  truncation) was already resolved in [#1118](https://github.com/apache/yunikorn-core/pull/1118). This PR fixes the additional subtest state leakage discovered during investigation to ensure test reliability.

### Type of change
Please delete options that are not relevant.

- [X] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3335

- [ ] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A