### PR TITLE
[YUNIKORN-3319] Track reservations released by preemption

### DIFF
--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -590,7 +590,11 @@ func (p *Preemptor) TryPreemption() (*AllocationResult, bool) {
 	}
 
 	// ensure required data structures are populated
-	p.initWorkingState()
+	// building the data structures can cancel reservations on the nodes we walk. Those reservations are
+	// gone whether or not the preemption below succeeds, so the release must be accounted for here
+	// instead of on the return paths: all but one of them bail out without an allocation result.
+	released := p.initWorkingState()
+	p.application.executeReservationReleasedCallback(released)
 
 	// try to find a node to schedule on and victims to preempt
 	nodeID, victims, ok := p.tryNodes()

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -2267,6 +2267,14 @@ func Test_PreemptForAppOnReservedNode(t *testing.T) {
 	app.SetQueue(childQ)
 	childQ.AddApplication(app)
 
+	// the stale reservation below is cancelled while preemption builds its working state, and this run
+	// does not preempt anything. The release must still be reported so the partition level counter can
+	// be corrected. The callback runs on its own go routine, so collect the value over a channel.
+	releasedCh := make(chan int, 2)
+	app.SetReservationReleasedCallback(func(released int) {
+		releasedCh <- released
+	})
+
 	// (1) no-priority ask, RESERVED on node1 ask does not fit in free node resources
 	askLow := newAllocationAsk(aKey, appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}))
 	// must be more than wait timeout (default 60min) + delay (default 2sec) ago
@@ -2292,4 +2300,95 @@ func Test_PreemptForAppOnReservedNode(t *testing.T) {
 	result := app.tryAllocate(resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10}), true, 1*time.Second, &remaining, iterator, iterator, getNode)
 	assert.Assert(t, result != nil, "expected and allocation result back")
 	assert.Equal(t, result.ResultType, Reserved, "expected result type to be Reserved")
+
+	// no victims exist on the node so the preemption itself never runs: the high priority ask is not
+	// marked, and the reservation that was returned belongs to the low priority ask that was released above
+	assert.Check(t, !askHigh.HasTriggeredPreemption(), "preemption should not have been triggered")
+	assert.Equal(t, result.Request.GetAllocationKey(), aKey, "expected the released ask to be reserved again")
+	select {
+	case released := <-releasedCh:
+		assert.Equal(t, released, 1, "expected 1 released reservation to be reported")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the released reservation to be reported")
+	}
+}
+
+// Test_PreemptReleasesReservationsOnSuccess checks the reservation release accounting for the run that
+// does preempt. A stale low priority reservation is cancelled while the working state is built, and the
+// preemption then succeeds on that same node. The release must be reported exactly once, and it must not
+// also be carried on the allocation result: the partition decrements that separately.
+func Test_PreemptReleasesReservationsOnSuccess(t *testing.T) {
+	appQueueMapping := NewAppQueueMapping()
+	node1 := newNode(nodeID1, map[string]resources.Quantity{"first": 5, "pods": 1})
+	node2 := newNode(nodeID2, map[string]resources.Quantity{"first": 5, "pods": 1})
+	iterator := getNodeIteratorFn(node1, node2)
+	rootQ, err := createRootQueue(map[string]string{"first": "10", "pods": "2"})
+	assert.NilError(t, err)
+	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"first": "20"}, map[string]string{"first": "10"}, appQueueMapping)
+	assert.NilError(t, err)
+	childQ1, err := createManagedQueueGuaranteed(parentQ, "child1", false, map[string]string{"first": "10"}, map[string]string{"first": "5"}, appQueueMapping)
+	assert.NilError(t, err)
+	childQ2, err := createManagedQueueGuaranteed(parentQ, "child2", false, map[string]string{"first": "10"}, map[string]string{"first": "5"}, appQueueMapping)
+	assert.NilError(t, err)
+
+	alloc1, alloc2, err := creatApp1(childQ1, node1, node2, map[string]resources.Quantity{"first": 5, "pods": 1}, appQueueMapping)
+	assert.NilError(t, err)
+
+	app2 := newApplication(appID2, "default", childQ2.QueuePath)
+	app2.SetQueue(childQ2)
+	childQ2.AddApplication(app2)
+	appQueueMapping.AddAppQueueMapping(app2.ApplicationID, childQ2)
+
+	releasedCh := make(chan int, 2)
+	app2.SetReservationReleasedCallback(func(released int) {
+		releasedCh <- released
+	})
+
+	// stale low priority ask holding a reservation on the node the preemption will pick
+	askReserved := newAllocationAsk("alloc4", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5, "pods": 1}))
+	askReserved.createTime = time.Now().Add(-90 * time.Minute)
+	assert.NilError(t, app2.AddAllocationAsk(askReserved), "ask addition to app should not have failed")
+	assert.NilError(t, app2.Reserve(node2, askReserved), "reservation on node should not have failed")
+	nodeRes := node2.GetReservations()
+	assert.Equal(t, len(nodeRes), 1, "expected 1 reservation")
+	// must be older than the reservation wait timeout for the cancellation to trigger
+	nodeRes[0].createTime = nodeRes[0].createTime.Add(-90 * time.Minute)
+
+	// higher priority ask that drives the preemption
+	ask3 := newAllocationAskPriority("alloc3", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5, "pods": 1}), 100)
+	assert.NilError(t, app2.AddAllocationAsk(ask3), "ask addition to app should not have failed")
+
+	headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "pods": 3})
+	preemptor := NewPreemptor(app2, headRoom, 30*time.Second, ask3, iterator(), false)
+
+	// register predicate handler
+	preemptions := []mock.Preemption{
+		mock.NewPreemption(true, "alloc3", nodeID2, []string{"alloc2"}, 0, 0),
+	}
+	plugin := mock.NewPreemptionPredicatePlugin(nil, nil, preemptions)
+	plugins.RegisterSchedulerPlugin(plugin)
+	defer plugins.UnregisterSchedulerPlugins()
+
+	result, ok := preemptor.TryPreemption()
+	assert.Assert(t, result != nil, "no result")
+	assert.Assert(t, ok, "no victims found")
+	assert.Equal(t, result.NodeID, nodeID2, "wrong node")
+	assert.Check(t, !alloc1.IsPreempted(), "alloc1 preempted")
+	assert.Check(t, alloc2.IsPreempted(), "alloc2 not preempted")
+	// the release is reported over the callback, not on the result: the partition applies both and would
+	// otherwise decrement twice for the same cancellation
+	assert.Equal(t, result.CancelledReservations, 0, "release must not be carried on the allocation result")
+	assert.Equal(t, len(node2.GetReservations()), 0, "reservation should have been cancelled")
+
+	select {
+	case released := <-releasedCh:
+		assert.Equal(t, released, 1, "expected 1 released reservation to be reported")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the released reservation to be reported")
+	}
+	select {
+	case extra := <-releasedCh:
+		t.Fatalf("released reservation reported twice, second report was %d", extra)
+	case <-time.After(100 * time.Millisecond):
+	}
 }


### PR DESCRIPTION
### Description
`TryPreemption()` called `initWorkingState()` and threw away its return value. That
value is the number of reservations cancelled while the working state is built: as the
node iterator walks the nodes it releases stale, lower priority reservations that block
the ask.

Those cancellations stand whether or not a preemption follows. Five of the six return
paths below that point leave without an allocation result, and the sixth returns a
reserved result that carries no release count, so nothing ever reached the partition.
`PartitionContext.reservations` therefore only drifted upward, and the drift was
permanent for the lifetime of the partition.

The fix reports the count through the `reservationReleasedCallback` that YUNIKORN-3321
added to the application, immediately after `initWorkingState()` returns. One call site
covers every return path.

Generated by Claude Code (Claude Opus 5).

Two notes on the approach:

- The Jira description suggests returning an "empty" `AllocationResult` that only carries
  the release count. That does not work: `Queue.TryAllocate` treats any non-nil result as
  a real allocation or reservation and returns it up the stack (`queue.go`), so an
  accounting-only result would end the scheduling pass for that queue. The callback keeps
  the accounting off the scheduling path.
- The callback fires from inside `TryPreemption()` rather than through a new return value,
  which avoids changing a signature that 30 tests call directly. The release happens while
  the working state is built, regardless of what the preemption decides afterwards, so the
  accounting belongs at that point rather than on the result. As for locking, `NewPreemptor`
  documents that the preemptor "assumes the application lock is held", and `tryAllocate`
  does hold the write lock across this call, so the unlocked read of the callback field is
  safe. `executeReservationReleasedCallback` then hands the body to a separate go routine,
  the same arrangement the placeholder timeout path already uses, so nothing blocks while
  that lock is held.
- There is a second place where a cancelled reservation does not reach the partition
  counter, which I left alone because it is outside what this Jira describes. In
  `tryReservedAllocate` (`application.go`, the wait time expiry branch under the headroom
  check) the reservation is dropped with `unReserveInternal` plus `queue.UnReserve`, and the
  loop then continues without returning a result, so the count reaches the node, the
  application and the queue but never the partition. Happy to fix it here instead if you
  would rather have both in one change, or to open a separate Jira for it.

### Type of change

- [x] Bug Fix

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3319

- [ ] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
- [x] The PR includes the phrase "Generated by Claude Code (Claude Opus 5)", where Claude Code is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [x] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

Both sides of the branch are covered, because the point of the ticket is that the release
has to be reported even when no preemption happens:

- `Test_PreemptForAppOnReservedNode` (extended) drives the no-preemption path through
  `Application.tryAllocate`, so the real lock context is exercised. The stale reservation
  is cancelled, `tryNodes()` finds no candidate, and `TryPreemption()` returns without an
  allocation result. The test asserts the high priority ask was never marked as having
  triggered preemption, and that the release is still reported.
- `Test_PreemptReleasesReservationsOnSuccess` (new) covers the path that does preempt: a
  stale low priority reservation is cancelled on the node the preemption then picks. It
  asserts the release is reported exactly once, and that `CancelledReservations` on the
  result stays zero, since the partition applies that separately and would otherwise
  decrement twice for the same cancellation.

Both tests collect the reported value over a channel, since the callback body runs
asynchronously.

Reverting only the `preemption.go` hunk fails both tests, so they are not vacuous:

    --- FAIL: Test_PreemptForAppOnReservedNode (5.00s)
        preemption_test.go:2312: timed out waiting for the released reservation to be reported
    --- FAIL: Test_PreemptReleasesReservationsOnSuccess (5.00s)
        preemption_test.go:2387: timed out waiting for the released reservation to be reported

`make test_all`:

    running shellcheck
    checking license headers:
      all OK
    running golangci-lint
    0 issues.
    running unit tests
    "go" test ./... -race -tags deadlock -coverprofile="build/coverage.txt" -covermode=atomic
    ok  github.com/apache/yunikorn-core/pkg/scheduler          21.794s  coverage: 75.6% of statements
    ok  github.com/apache/yunikorn-core/pkg/scheduler/objects  10.881s  coverage: 89.5% of statements
    ok  github.com/apache/yunikorn-core/pkg/scheduler/tests    49.821s
    ("go" vet passed, every other package ok, output trimmed)

Repeated runs of the two tests, to check for flakiness and races:

    go test ./pkg/scheduler/objects/ -run 'Test_PreemptForAppOnReservedNode|Test_PreemptReleasesReservationsOnSuccess' -count=1000
    ok  github.com/apache/yunikorn-core/pkg/scheduler/objects  111.534s

    go test -race ./pkg/scheduler/objects/ -run 'Test_PreemptForAppOnReservedNode|Test_PreemptReleasesReservationsOnSuccess' -count=1000
    ok  github.com/apache/yunikorn-core/pkg/scheduler/objects  124.910s

The existing reservation counting tests still pass: `TestReservationTracking` and
`TestRemoveAppWithReservations` in `partition_test.go`, and the `CancelledReservations`
assertions in `TestTryRequiredNode`, `TestTryRequiredNodeReserved`,
`TestTryRequiredNodeCancel` and `TestTryRequiredNodeAdd`.

### Questions:
- The change does not need documentation.
- There are no breaking changes.
- The license files do not need to be updated.
