### PR TITLE
[YUNIKORN-3343] Fix flaky Event publisher test TestServiceStartStopInternal

### DIFF
--- a/pkg/events/event_publisher_test.go
+++ b/pkg/events/event_publisher_test.go
@@ -20,6 +20,7 @@ package events
 
 import (
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,24 +40,40 @@ func TestCreateShimPublisher(t *testing.T) {
 
 // StartService() and stop() functions should not cause panic
 func TestServiceStartStopInternal(t *testing.T) {
+	countPublisherGoroutines := func() int {
+		buf := make([]byte, 2*1024)
+		n := runtime.Stack(buf, true)
+		return strings.Count(string(buf[:n]), "(*eventPublisher).start.func1")
+	}
+
+	// wait for any background publisher goroutine to finish exiting
+	err := common.WaitForCondition(time.Millisecond, time.Second, func() bool {
+		return countPublisherGoroutines() == 0
+	})
+	assert.NilError(t, err, "expected initial publisher goroutines count to be 0")
+
 	store := newEventStore(1000)
 	publisher := createShimPublisher(store)
 	defer publisher.stop()
 	assert.Equal(t, publisher.getEventStore(), store)
+
 	// start and stop simulate a restart
-	before := runtime.NumGoroutine()
 	publisher.start()
 	publisher.stop()
-	time.Sleep(10 * time.Millisecond) // tiny sleep to yield
-	assert.Equal(t, before, runtime.NumGoroutine(), "expected no new go routine after start and stop")
+	err = common.WaitForCondition(time.Millisecond, time.Second, func() bool {
+		return countPublisherGoroutines() == 0
+	})
+	assert.NilError(t, err, "expected no new go routine after start and stop")
 
 	// start should not fail or panic
-	before = runtime.NumGoroutine()
 	publisher.start()
-	after := runtime.NumGoroutine()
-	assert.Equal(t, before+1, after, "expected 1 new go routine")
+	err = common.WaitForCondition(time.Millisecond, time.Second, func() bool {
+		return countPublisherGoroutines() == 1
+	})
+	assert.NilError(t, err, "expected 1 new go routine")
+
 	publisher.start()
-	assert.Equal(t, after, runtime.NumGoroutine(), "Already started should not create new go routine")
+	assert.Equal(t, 1, countPublisherGoroutines(), "Already started should not create new go routine")
 }
 
 func TestNoFillWithoutEventPluginRegistered(t *testing.T) {


### PR DESCRIPTION
### Description
Fix flaky unit test TestServiceStartStopInternal in pkg/events.

#### Problem:                                                                                                                                        
`eventPublisher.stop()` signals termination asynchronously. The test previously relied on a hardcoded `time.Sleep(10ms)` and sampled global `runtime.NumGoroutine()`.  Because `stop()` does not block until exit, unreleased goroutines or timing variations cause process-level `runtime.NumGoroutine()` checks to fail (e.g., `2 != 3` or `3 != 2`). Removing `time.Sleep` consistently reproduces these flaky assertion failures under `-race` mode.                         
                                                                                                                                                         
#### Fix:                                                                                                                                            

- Track exact publisher goroutines (`(*eventPublisher).start.func1`) using `runtime.Stack`. 
- Wait for background goroutines to drain (`count == 0`) before running test steps. 
- Replace fixed sleep with `common.WaitForCondition` for deterministic goroutine count assertions.

### Type of change
Please delete options that are not relevant.

- [ ] Bug Fix
- [X] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3343

- [ ] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A