### PR TITLE
[YUNIKORN-3331] Run preemption preconditions before instantiating preemptor

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -1561,10 +1561,8 @@ func (sa *Application) tryPreemption(headRoom *resources.Resource, preemptionDel
 		ask.LogAllocationFailure(common.PreemptionMaxAttemptsExhausted, true)
 		return nil, false
 	}
-	preemptor := NewPreemptor(sa, headRoom, preemptionDelay, ask, iterator, nodesTried)
-
 	// validate prerequisites for preemption of an ask and mark ask for preemption if successful
-	if !preemptor.CheckPreconditions() {
+	if !CheckPreconditions(ask, preemptionDelay) {
 		ask.LogAllocationFailure(common.PreemptionPreconditionsFailed, true)
 		return nil, false
 	}
@@ -1575,6 +1573,7 @@ func (sa *Application) tryPreemption(headRoom *resources.Resource, preemptionDel
 	defer metrics.GetSchedulerMetrics().ObserveTryPreemptionLatency(tryPreemptionStart)
 
 	// attempt preemption
+	preemptor := NewPreemptor(sa, headRoom, preemptionDelay, ask, iterator, nodesTried)
 	return preemptor.TryPreemption()
 }
 

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -89,36 +89,36 @@ func NewPreemptor(application *Application, headRoom *resources.Resource, preemp
 
 // CheckPreconditions performs simple sanity checks designed to determine if preemption should be attempted
 // for an ask. If checks succeed, updates the ask preemption check time.
-func (p *Preemptor) CheckPreconditions() bool {
+func CheckPreconditions(ask *Allocation, preemptionDelay time.Duration) bool {
 	now := time.Now()
 
 	// skip if ask is not allowed to preempt other tasks
-	if !p.ask.IsAllowPreemptOther() {
+	if !ask.IsAllowPreemptOther() {
 		return false
 	}
 
 	// skip if ask has previously triggered preemption
-	if p.ask.HasTriggeredPreemption() {
+	if ask.HasTriggeredPreemption() {
 		return false
 	}
 
 	// skip if ask requires a specific node (this should be handled by required node preemption algorithm)
-	if p.ask.GetRequiredNode() != "" {
+	if ask.GetRequiredNode() != "" {
 		return false
 	}
 
 	// skip if preemption delay has not yet passed
-	if now.Before(p.ask.GetCreateTime().Add(p.preemptionDelay)) {
+	if now.Before(ask.GetCreateTime().Add(preemptionDelay)) {
 		return false
 	}
 
 	// skip if attempt frequency hasn't been reached again
-	if now.Before(p.ask.GetPreemptCheckTime().Add(preemptAttemptFrequency)) {
+	if now.Before(ask.GetPreemptCheckTime().Add(preemptAttemptFrequency)) {
 		return false
 	}
 
 	// mark this ask as having been checked recently to avoid doing extra work in the next scheduling cycle
-	p.ask.UpdatePreemptCheckTime()
+	ask.UpdatePreemptCheckTime()
 
 	return true
 }

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -135,43 +135,44 @@ func TestCheckPreconditions(t *testing.T) {
 	ask.createTime = time.Now().Add(-1 * time.Minute)
 	err = app.AddAllocationAsk(ask)
 	assert.NilError(t, err)
-	preemptor := NewPreemptor(app, resources.NewResource(), 30*time.Second, ask, iterator(), false)
+	// the checks run without a preemptor: they only need the ask and the delay
+	preemptionDelay := 30 * time.Second
 
 	// success case
-	assert.Assert(t, preemptor.CheckPreconditions(), "preconditions failed")
+	assert.Assert(t, CheckPreconditions(ask, preemptionDelay), "preconditions failed")
 	ask.preemptCheckTime = time.Now().Add(-1 * time.Minute)
 
 	// verify ask which opted-out of preempting others is disqualified
 	ask.allowPreemptOther = false
-	assert.Assert(t, !preemptor.CheckPreconditions(), "preconditions succeeded when ask doesn't allow preempt other")
+	assert.Assert(t, !CheckPreconditions(ask, preemptionDelay), "preconditions succeeded when ask doesn't allow preempt other")
 	ask.allowPreemptOther = true
-	assert.Assert(t, preemptor.CheckPreconditions(), "preconditions failed")
+	assert.Assert(t, CheckPreconditions(ask, preemptionDelay), "preconditions failed")
 	ask.preemptCheckTime = time.Now().Add(-1 * time.Minute)
 
 	// verify previously triggered preemption disqualifies ask
 	ask.MarkTriggeredPreemption()
-	assert.Assert(t, !preemptor.CheckPreconditions(), "preconditions succeeded when ask has already triggered preemption")
+	assert.Assert(t, !CheckPreconditions(ask, preemptionDelay), "preconditions succeeded when ask has already triggered preemption")
 	ask.preemptionTriggered = false
-	assert.Assert(t, preemptor.CheckPreconditions(), "preconditions failed")
+	assert.Assert(t, CheckPreconditions(ask, preemptionDelay), "preconditions failed")
 	ask.preemptCheckTime = time.Now().Add(-1 * time.Minute)
 
 	// verify that ask requiring a specific node is disqualified
 	ask.SetRequiredNode("node1")
-	assert.Assert(t, !preemptor.CheckPreconditions(), "preconditions succeeded with ask requiring a specific node")
+	assert.Assert(t, !CheckPreconditions(ask, preemptionDelay), "preconditions succeeded with ask requiring a specific node")
 	ask.SetRequiredNode("")
-	assert.Assert(t, preemptor.CheckPreconditions(), "preconditions failed")
+	assert.Assert(t, CheckPreconditions(ask, preemptionDelay), "preconditions failed")
 	ask.preemptCheckTime = time.Now().Add(-1 * time.Minute)
 
 	// verify that recently created ask is disqualified
 	ask.createTime = time.Now()
-	assert.Assert(t, !preemptor.CheckPreconditions(), "preconditions succeeded with newly-created ask")
+	assert.Assert(t, !CheckPreconditions(ask, preemptionDelay), "preconditions succeeded with newly-created ask")
 	ask.createTime = time.Now().Add(-1 * time.Minute)
-	assert.Assert(t, preemptor.CheckPreconditions(), "preconditions failed")
+	assert.Assert(t, CheckPreconditions(ask, preemptionDelay), "preconditions failed")
 	ask.preemptCheckTime = time.Now().Add(-1 * time.Minute)
 
 	// verify that recently checked ask is disqualified
 	ask.preemptCheckTime = time.Now()
-	assert.Assert(t, !preemptor.CheckPreconditions(), "preconditions succeeded with recently tried ask")
+	assert.Assert(t, !CheckPreconditions(ask, preemptionDelay), "preconditions succeeded with recently tried ask")
 	getNode := func(nodeID string) *Node {
 		return node
 	}
@@ -180,8 +181,8 @@ func TestCheckPreconditions(t *testing.T) {
 	assert.Check(t, result == nil, "unexpected result")
 	assertAllocationLog(t, ask, []string{common.PreemptionPreconditionsFailed, common.PreemptionDoesNotHelp})
 	ask.preemptCheckTime = time.Now().Add(-1 * time.Minute)
-	assert.Assert(t, preemptor.CheckPreconditions(), "preconditions failed")
-	assert.Assert(t, !preemptor.CheckPreconditions(), "preconditions succeeded on successive run")
+	assert.Assert(t, CheckPreconditions(ask, preemptionDelay), "preconditions failed")
+	assert.Assert(t, !CheckPreconditions(ask, preemptionDelay), "preconditions succeeded on successive run")
 }
 
 func TestCheckPreemptionQueueGuarantees(t *testing.T) {


### PR DESCRIPTION
### Description
`tryPreemption` built a `Preemptor` and then called `CheckPreconditions` on it. The checks read
only the ask and the preemption delay, so the preemptor was being allocated even for asks that were
about to be rejected.

This turns `CheckPreconditions` into a package level function taking the ask and the delay, and moves
`NewPreemptor` below the check. Asks that fail the checks no longer allocate a preemptor to find that
out.

Generated by Claude Code (Claude Opus 5).

Two notes:

- `NewPreemptor` is a plain struct literal with no side effects, so moving it after the check does not
  change behaviour. All six checks read `ask` and `preemptionDelay` only, which is what makes the
  extraction possible in the first place.
- `CheckPreconditions` changes from a method on `*Preemptor` to a package level function. It stays
  exported so the identifier is still reachable, but it is only used inside this package and its
  tests, so I am happy to make it unexported if you would rather narrow the surface.

On effect: the allocation avoided is one 112 byte `Preemptor` per call that fails the checks. That
path is not rare, because `preemptAttemptFrequency` gates a given ask to one real attempt every 15
seconds, so repeated scheduling cycles over a pending unschedulable ask return at the frequency check.
I did not run a macro benchmark for this. `BenchmarkScheduling` drives asks that get allocated, so it
does not walk the preemption path, and I would rather report nothing than report a number that does
not measure this change.

### Type of change

- [x] Improvement
- [x] Refactoring

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3331

- [ ] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
- [x] The PR includes the phrase "Generated by Claude Code (Claude Opus 5)", where Claude Code is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [x] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

No new tests. `TestCheckPreconditions` already covered every branch of these checks, and it now calls
the function directly instead of through a preemptor, which is the point of the change.

`make test_all` on Linux, all green:

    running shellcheck
    checking license headers:
      all OK
    running golangci-lint
    0 issues.
    running unit tests
    ok  github.com/apache/yunikorn-core/pkg/scheduler          23.283s  coverage: 75.6% of statements
    ok  github.com/apache/yunikorn-core/pkg/scheduler/objects  11.851s  coverage: 89.6% of statements
    ok  github.com/apache/yunikorn-core/pkg/scheduler/tests    52.107s
    (every other package ok, output trimmed)

Also run locally, not part of CI:

    go test ./pkg/scheduler/objects/ -race -run 'TestCheckPreconditions|Preempt' -count=50
    ok  github.com/apache/yunikorn-core/pkg/scheduler/objects  389.748s

`gofmt -l pkg/` is clean and `go vet` passes.

### Questions:
- The change does not need documentation.
- There are no breaking changes.
- The license files do not need to be updated.
