### PR TITLE
[YUNIKORN-3353] Keep only pending asks in sortedRequests

### DIFF
--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -538,6 +538,10 @@ func (a *Allocation) HasTriggeredPreemption() bool {
 }
 
 // LessThan compares two allocations by priority and then creation time.
+// NOTE: deliberately not a strict ordering - a (priority, createTime) tie reports true in BOTH
+// directions. sortedRequests.reinsert (sorted_asks.go) relies on exactly that to land a returning
+// ask at the head of its tie-group; tightening the tie handling here would silently flip that
+// placement to the tail. TestReinsertHeadOfTieGroup pins the dependency.
 func (a *Allocation) LessThan(other *Allocation) bool {
 	if a.priority == other.priority {
 		return a.createTime.After(other.createTime) || a.createTime.Equal(other.createTime)

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -1175,12 +1175,26 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption
 	// because the len check above guarantees at least one iteration would occur.
 	backoffThreshold := sa.queue.GetMaxAppUnschedAskBackoff()
 	// get all the requests from the app sorted in order
-	// LOAD-BEARING INVARIANT: sa.sortedRequests now holds only pending asks (item 2) and
-	// allocateAsk/deallocateAsk mutate it in place. This range is only safe to mutate mid-loop
-	// because every successful-allocation path below returns immediately instead of continuing the
-	// loop. Do NOT add a "continue" after a successful allocateAsk call in this loop - restructure
-	// to a snapshot copy (see tryPlaceholderAllocate) if that is ever needed.
-	for _, request := range sa.sortedRequests {
+	// LOAD-BEARING INVARIANT: sa.sortedRequests now holds only pending asks and
+	// allocateAsk/deallocateAsk mutate it in place. An index based loop is used deliberately: it
+	// re-reads len() and re-indexes the current slice on every iteration, so a mid-loop remove can
+	// never make it read the nil'd tail slot, and it stays correct if an insert reallocates the
+	// backing array. A "range" loop captures the slice header once and would panic in that case.
+	// On top of that the length is asserted below: every successful-allocation path returns
+	// immediately today, so a length change mid-loop means a future edit mutated and continued.
+	// Worst case without the assert is skipping a single ask for this cycle (self-correcting on the
+	// next cycle) rather than a crash. If a mutate-then-continue is ever really needed, restructure
+	// to a snapshot copy (see tryPlaceholderAllocate).
+	startLen := len(sa.sortedRequests)
+	for i := 0; i < len(sa.sortedRequests); i++ {
+		if len(sa.sortedRequests) != startLen {
+			log.Log(log.SchedApplication).DPanic("sortedRequests mutated during tryAllocate iteration",
+				zap.String("application ID", sa.ApplicationID),
+				zap.Int("length at loop start", startLen),
+				zap.Int("current length", len(sa.sortedRequests)))
+			return nil
+		}
+		request := sa.sortedRequests[i]
 		if backoffThreshold > 0 && unschedulable >= backoffThreshold {
 			log.Log(log.SchedApplication).Info("too many unschedulable asks in the application, waiting",
 				zap.String("application ID", sa.ApplicationID),
@@ -1190,7 +1204,17 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption
 			return nil
 		}
 		if request.IsAllocated() {
-			continue
+			// sortedRequests holds pending asks only, so reaching an allocated one means the
+			// remove-on-allocate pairing has been broken and this entry is a ghost that nothing
+			// else will clean up: every other removal path skips allocated asks precisely because
+			// they cannot be in the slice. Scream, then repair - drop the ghost and end the cycle,
+			// so a broken pairing is a hard failure in tests and a single logged self-heal in
+			// production, rather than the same entry being re-detected every cycle forever.
+			log.Log(log.SchedApplication).DPanic("allocated ask found in pending-only sortedRequests",
+				zap.String("appID", sa.ApplicationID),
+				zap.String("allocationKey", request.GetAllocationKey()))
+			sa.sortedRequests.remove(request)
+			return nil
 		}
 		// check if there is a replacement possible
 		if sa.canReplace(request) {
@@ -1379,7 +1403,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 	// NOTE: iterate over a snapshot, not sa.sortedRequests directly. The revert path below calls
 	// sa.deallocateAsk(request), which re-inserts the ask into sa.sortedRequests mid-range - mutating
 	// the live slice while ranging over it would skip/revisit entries. allocateAsk/deallocateAsk keep
-	// only pending asks in sortedRequests (item 2).
+	// only pending asks in sortedRequests.
 	for _, request := range slices.Clone(sa.sortedRequests) {
 		// skip placeholders they follow standard allocation
 		// this should also be part of a task group just make sure it is

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -928,9 +928,9 @@ func (sa *Application) allocateAsk(ask *Allocation) (*resources.Resource, error)
 	// the ask just left the pending set
 	sa.removeFromPriorities(ask.GetPriority())
 	// keep sortedRequests limited to pending asks only: remove on allocate, re-insert on
-	// deallocate. This is safe here because every caller that ranges over sa.sortedRequests while
-	// calling allocateAsk either returns immediately on success (tryAllocate) or ranges over a
-	// snapshot (tryPlaceholderAllocate) - see the comments at those call sites.
+	// deallocate. This is safe here because every caller that iterates sa.sortedRequests while
+	// calling allocateAsk either uses an index loop that tolerates the removal (tryAllocate) or
+	// ranges over a snapshot (tryPlaceholderAllocate) - see the comments at those call sites.
 	sa.sortedRequests.remove(ask)
 
 	delta := ask.GetAllocatedResource()
@@ -948,16 +948,14 @@ func (sa *Application) deallocateAsk(ask *Allocation) (*resources.Resource, erro
 	}
 
 	// The ask returns to the pending set, but only if it still IS this application's ask: an ask that
-	// has already been dropped from sa.requests must not be resurrected. That is reachable today:
-	// removeAsksInternal("") wipes sa.requests while leaving sa.allocations intact until the shim
-	// confirms the releases, and a release arriving in that window reaches RollbackAllocation, which
-	// finds the entry in sa.allocations and deallocates it. The identity comparison (not just a
-	// presence check) also covers a stale ask object that has since been replaced by a new ask under
-	// the same key.
+	// has already been dropped from sa.requests must not be resurrected as a ghost that tryAllocate
+	// would then try to schedule. Since YUNIKORN-3360 no production caller can present one -
+	// RollbackAllocation rejects an untracked ask before it reaches here, the public DeallocateAsk
+	// resolves its ask out of sa.requests, and the tryPlaceholderAllocate reverts pass back the ask
+	// they just allocated - so this is defence-in-depth.
 	// This matches the converged behaviour of the full rescan this change replaced:
 	// updateAskMaxPriority derived the max by scanning sa.requests, so an ask absent from sa.requests
-	// never influenced it. Without the guard the pre-existing accounting drift above would be
-	// upgraded into a ghost entry in sortedRequests that tryAllocate would try to schedule.
+	// never influenced it.
 	delta := ask.GetAllocatedResource()
 	if sa.requests[ask.GetAllocationKey()] == ask {
 		sa.addToPriorities(ask.GetPriority())
@@ -965,14 +963,9 @@ func (sa *Application) deallocateAsk(ask *Allocation) (*resources.Resource, erro
 		// tie-group so the next cycle retries it before the peers it was already tried ahead of
 		sa.sortedRequests.reinsert(ask)
 		// The pending resource follows the same rule as the histogram and sortedRequests: it only
-		// counts asks the application still tracks. For an untracked ask this add would be a
-		// permanent leak - removeAsksInternal already zeroed sa.pending when it dropped the ask,
-		// and every later removeAsksInternal("") short-circuits on the empty sa.requests, so
-		// nothing would ever subtract it again. The leak is not cosmetic: it keeps
-		// resources.IsZero(sa.pending) false forever, which blocks the Completing transition in
-		// RemoveAllAllocations/removeAsksInternal, and inflates queue pending until app removal.
-		// Guarding it here (rather than in the caller) keeps all four pending-set structures -
-		// histogram, sortedRequests, sa.pending, queue pending - behind one decision.
+		// counts asks the application still tracks. Guarding it here (rather than in the caller)
+		// keeps all four pending-side structures - histogram, sortedRequests, sa.pending, queue
+		// pending - behind one decision instead of three guarded and one not.
 		sa.pending = resources.Add(sa.pending, delta)
 		// update the pending of the queue with the same delta
 		sa.queue.incPendingResource(delta)
@@ -1187,25 +1180,13 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption
 	// because the len check above guarantees at least one iteration would occur.
 	backoffThreshold := sa.queue.GetMaxAppUnschedAskBackoff()
 	// get all the requests from the app sorted in order
-	// LOAD-BEARING INVARIANT: sa.sortedRequests now holds only pending asks and
-	// allocateAsk/deallocateAsk mutate it in place. An index based loop is used deliberately: it
-	// re-reads len() and re-indexes the current slice on every iteration, so a mid-loop remove can
-	// never make it read the nil'd tail slot, and it stays correct if an insert reallocates the
-	// backing array. A "range" loop captures the slice header once and would panic in that case.
-	// On top of that the length is asserted below: every successful-allocation path returns
-	// immediately today, so a length change mid-loop means a future edit mutated and continued.
-	// Worst case without the assert is skipping a single ask for this cycle (self-correcting on the
-	// next cycle) rather than a crash. If a mutate-then-continue is ever really needed, restructure
-	// to a snapshot copy (see tryPlaceholderAllocate).
-	startLen := len(sa.sortedRequests)
+	// allocateAsk drops the ask from sa.sortedRequests and every path that allocates returns, so the
+	// only removal this loop ever observes is the ghost repair below. The index based loop re-reads
+	// len() and re-indexes the current slice on every iteration, which is what makes that
+	// remove-and-continue safe. Iterating a slices.Clone snapshot instead (as tryPlaceholderAllocate
+	// has to) measured -11% pods/s and 2x bytes/op on BenchmarkScheduling: it is O(pending) per call
+	// for a loop that normally exits at index 0.
 	for i := 0; i < len(sa.sortedRequests); i++ {
-		if len(sa.sortedRequests) != startLen {
-			log.Log(log.SchedApplication).DPanic("sortedRequests mutated during tryAllocate iteration",
-				zap.String("application ID", sa.ApplicationID),
-				zap.Int("length at loop start", startLen),
-				zap.Int("current length", len(sa.sortedRequests)))
-			return nil
-		}
 		request := sa.sortedRequests[i]
 		if backoffThreshold > 0 && unschedulable >= backoffThreshold {
 			log.Log(log.SchedApplication).Info("too many unschedulable asks in the application, waiting",
@@ -1219,14 +1200,18 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption
 			// sortedRequests holds pending asks only, so reaching an allocated one means the
 			// remove-on-allocate pairing has been broken and this entry is a ghost that nothing
 			// else will clean up: every other removal path skips allocated asks precisely because
-			// they cannot be in the slice. Scream, then repair - drop the ghost and end the cycle,
-			// so a broken pairing is a hard failure in tests and a single logged self-heal in
-			// production, rather than the same entry being re-detected every cycle forever.
+			// they cannot be in the slice. Scream, then repair - drop the ghost and carry on with
+			// the next ask, so a broken pairing is a hard failure in tests and a single logged
+			// self-heal in production, rather than the same entry being re-detected every cycle
+			// forever.
 			log.Log(log.SchedApplication).DPanic("allocated ask found in pending-only sortedRequests",
 				zap.String("appID", sa.ApplicationID),
 				zap.String("allocationKey", request.GetAllocationKey()))
 			sa.sortedRequests.remove(request)
-			return nil
+			// the remove shifted the tail down one slot: step back so the next iteration lands on
+			// the ask that took this index
+			i--
+			continue
 		}
 		// check if there is a replacement possible
 		if sa.canReplace(request) {

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -92,7 +93,7 @@ type Application struct {
 	pending           *resources.Resource     // pending resources from asks for the app
 	reservations      map[string]*reservation // a map of reservations
 	requests          map[string]*Allocation  // a map of allocations, pending or satisfied
-	sortedRequests    sortedRequests          // list of requests pre-sorted
+	sortedRequests    sortedRequests          // pending asks only, sorted by priority then age
 	user              security.UserGroup      // owner of the application
 	allocatedResource *resources.Resource     // total allocated resources
 	submissionTime    time.Time               // time application was submitted (based on the first ask)
@@ -615,11 +616,13 @@ func (sa *Application) removeAsksInternal(allocKey string, detail si.EventRecord
 				deltaPendingResource = ask.GetAllocatedResource()
 				sa.pending = resources.Sub(sa.pending, deltaPendingResource)
 				sa.pending.Prune()
-				// the removed ask was pending: drop it from the priority histogram
+				// the removed ask was pending: drop it from the priority histogram and from
+				// sortedRequests. An allocated ask needs neither: it left the slice at allocateAsk
+				// time, so scanning for it here would only ever be a guaranteed full-slice miss.
 				sa.removeFromPriorities(ask.GetPriority())
+				sa.sortedRequests.remove(ask)
 			}
 			delete(sa.requests, allocKey)
-			sa.sortedRequests.remove(ask)
 			sa.appEvents.SendRemoveAskEvent(sa.ApplicationID, ask.allocationKey, ask.GetAllocatedResource(), detail)
 		}
 	}
@@ -666,9 +669,11 @@ func (sa *Application) AddAllocationAsk(ask *Allocation) error {
 	var oldAskResource *resources.Resource = nil
 	if oldAsk := sa.requests[ask.GetAllocationKey()]; oldAsk != nil && !oldAsk.IsAllocated() {
 		oldAskResource = oldAsk.GetAllocatedResource().Clone()
-		// the old ask was pending and is being replaced: drop it from the priority histogram so the
-		// new ask's addAllocationAskInternal (via addToPriorities) nets correctly.
+		// the old ask was pending and is being replaced: remove it from the pending histogram so the
+		// new ask's addAllocationAskInternal (via addToPriorities) nets correctly, and drop it from
+		// sortedRequests so the unconditional insert below cannot leave two entries for one key.
 		sa.removeFromPriorities(oldAsk.GetPriority())
+		sa.sortedRequests.remove(oldAsk)
 	}
 
 	// Check if we need to change state based on the ask added, there are two cases:
@@ -922,6 +927,11 @@ func (sa *Application) allocateAsk(ask *Allocation) (*resources.Resource, error)
 
 	// the ask just left the pending set
 	sa.removeFromPriorities(ask.GetPriority())
+	// keep sortedRequests limited to pending asks only: remove on allocate, re-insert on
+	// deallocate. This is safe here because every caller that ranges over sa.sortedRequests while
+	// calling allocateAsk either returns immediately on success (tryAllocate) or ranges over a
+	// snapshot (tryPlaceholderAllocate) - see the comments at those call sites.
+	sa.sortedRequests.remove(ask)
 
 	delta := ask.GetAllocatedResource()
 	sa.pending = resources.Sub(sa.pending, delta)
@@ -938,7 +948,7 @@ func (sa *Application) deallocateAsk(ask *Allocation) (*resources.Resource, erro
 	}
 
 	// The ask returns to the pending set, but only if it still IS this application's ask: an ask that
-	// has already been dropped from sa.requests must not be counted again. That is reachable today:
+	// has already been dropped from sa.requests must not be resurrected. That is reachable today:
 	// removeAsksInternal("") wipes sa.requests while leaving sa.allocations intact until the shim
 	// confirms the releases, and a release arriving in that window reaches RollbackAllocation, which
 	// finds the entry in sa.allocations and deallocates it. The identity comparison (not just a
@@ -946,10 +956,13 @@ func (sa *Application) deallocateAsk(ask *Allocation) (*resources.Resource, erro
 	// the same key.
 	// This matches the converged behaviour of the full rescan this change replaced:
 	// updateAskMaxPriority derived the max by scanning sa.requests, so an ask absent from sa.requests
-	// never influenced it. Without the guard that pre-existing accounting drift would turn into a
-	// permanent leak in the incremental histogram instead.
+	// never influenced it. Without the guard the pre-existing accounting drift above would be
+	// upgraded into a ghost entry in sortedRequests that tryAllocate would try to schedule.
 	if sa.requests[ask.GetAllocationKey()] == ask {
 		sa.addToPriorities(ask.GetPriority())
+		// the ask is pending again: re-insert it at the head of its (priority, createTime)
+		// tie-group so the next cycle retries it before the peers it was already tried ahead of
+		sa.sortedRequests.reinsert(ask)
 	}
 
 	delta := ask.GetAllocatedResource()
@@ -1162,6 +1175,11 @@ func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption
 	// because the len check above guarantees at least one iteration would occur.
 	backoffThreshold := sa.queue.GetMaxAppUnschedAskBackoff()
 	// get all the requests from the app sorted in order
+	// LOAD-BEARING INVARIANT: sa.sortedRequests now holds only pending asks (item 2) and
+	// allocateAsk/deallocateAsk mutate it in place. This range is only safe to mutate mid-loop
+	// because every successful-allocation path below returns immediately instead of continuing the
+	// loop. Do NOT add a "continue" after a successful allocateAsk call in this loop - restructure
+	// to a snapshot copy (see tryPlaceholderAllocate) if that is ever needed.
 	for _, request := range sa.sortedRequests {
 		if backoffThreshold > 0 && unschedulable >= backoffThreshold {
 			log.Log(log.SchedApplication).Info("too many unschedulable asks in the application, waiting",
@@ -1358,7 +1376,11 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 	var phFit *Allocation
 	var reqFit *Allocation
 	// get all the requests from the app sorted in order
-	for _, request := range sa.sortedRequests {
+	// NOTE: iterate over a snapshot, not sa.sortedRequests directly. The revert path below calls
+	// sa.deallocateAsk(request), which re-inserts the ask into sa.sortedRequests mid-range - mutating
+	// the live slice while ranging over it would skip/revisit entries. allocateAsk/deallocateAsk keep
+	// only pending asks in sortedRequests (item 2).
+	for _, request := range slices.Clone(sa.sortedRequests) {
 		// skip placeholders they follow standard allocation
 		// this should also be part of a task group just make sure it is
 		if request.IsPlaceholder() || request.GetTaskGroup() == "" || request.IsAllocated() {

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -958,18 +958,30 @@ func (sa *Application) deallocateAsk(ask *Allocation) (*resources.Resource, erro
 	// updateAskMaxPriority derived the max by scanning sa.requests, so an ask absent from sa.requests
 	// never influenced it. Without the guard the pre-existing accounting drift above would be
 	// upgraded into a ghost entry in sortedRequests that tryAllocate would try to schedule.
+	delta := ask.GetAllocatedResource()
 	if sa.requests[ask.GetAllocationKey()] == ask {
 		sa.addToPriorities(ask.GetPriority())
 		// the ask is pending again: re-insert it at the head of its (priority, createTime)
 		// tie-group so the next cycle retries it before the peers it was already tried ahead of
 		sa.sortedRequests.reinsert(ask)
+		// The pending resource follows the same rule as the histogram and sortedRequests: it only
+		// counts asks the application still tracks. For an untracked ask this add would be a
+		// permanent leak - removeAsksInternal already zeroed sa.pending when it dropped the ask,
+		// and every later removeAsksInternal("") short-circuits on the empty sa.requests, so
+		// nothing would ever subtract it again. The leak is not cosmetic: it keeps
+		// resources.IsZero(sa.pending) false forever, which blocks the Completing transition in
+		// RemoveAllAllocations/removeAsksInternal, and inflates queue pending until app removal.
+		// Guarding it here (rather than in the caller) keeps all four pending-set structures -
+		// histogram, sortedRequests, sa.pending, queue pending - behind one decision.
+		sa.pending = resources.Add(sa.pending, delta)
+		// update the pending of the queue with the same delta
+		sa.queue.incPendingResource(delta)
 	}
 
-	delta := ask.GetAllocatedResource()
-	sa.pending = resources.Add(sa.pending, delta)
-	// update the pending of the queue with the same delta
-	sa.queue.incPendingResource(delta)
-
+	// The returned delta stays the ask's resource even when the guard above rejects the ask: the
+	// allocation being rolled back genuinely occupied its node and its queue's ALLOCATED tracking,
+	// and callers (partition rollbackAllocation, tryPlaceholderAllocate's revert) use the return to
+	// unwind that side. Only the PENDING re-add is conditional on the ask still being tracked.
 	return delta, nil
 }
 

--- a/pkg/scheduler/objects/application_property_test.go
+++ b/pkg/scheduler/objects/application_property_test.go
@@ -38,8 +38,8 @@ import (
 // of the real ask-management entry points (AddAllocationAsk, AllocateAsk, DeallocateAsk,
 // RemoveAllocationAsk, RecoverAllocationAsk, AddAllocation, RollbackAllocation and FSM-to-Failed
 // cleanup) and after every single step verifies that the incrementally maintained
-// askMaxPriority/pendingPriorities bookkeeping matches a reference model rebuilt from a simple set
-// of maps tracked alongside the application.
+// askMaxPriority/pendingPriorities/sortedRequests bookkeeping matches a reference model rebuilt
+// from a simple set of maps tracked alongside the application.
 //
 // The point is coverage of state combinations rather than of entry points: TestMaxAskPriority pins
 // the handful of transitions that are easy to reason about by hand, while this test reaches the
@@ -113,9 +113,9 @@ func runPropertyFuzz(t *testing.T, seed int64) int { //nolint:funlen
 	// or RecoverAllocationAsk); priority is immutable per ask for the lifetime of the key so this
 	// map is only ever added to (or wiped wholesale on clear-all/cleanup), never mutated in place.
 	keyPriority := make(map[string]int32)
-	// pendingKeys is the reference model of what the pending histogram should contain: keys that are
-	// currently pending (added or deallocated back to pending, and NOT yet allocated, removed, or
-	// recovered-as-allocated).
+	// pendingKeys is the reference model of what sa.sortedRequests / the pending histogram should
+	// contain: keys that are currently pending (added or deallocated back to pending, and NOT yet
+	// allocated, removed, or recovered-as-allocated).
 	pendingKeys := make(map[string]bool)
 	// allocatedKeys is the reference model of keys that are currently allocated (via AllocateAsk or
 	// RecoverAllocationAsk) and not yet deallocated or removed.
@@ -213,8 +213,8 @@ func runPropertyFuzz(t *testing.T, seed int64) int { //nolint:funlen
 			app.RecoverAllocationAsk(alloc)
 			// a recovered ask is already allocated (NodeID set => allocated=true in
 			// NewAllocationFromSI) so addAllocationAskInternal must NOT add it to the pending
-			// histogram: record it only as allocated, never as pending. This is the exact invariant
-			// this fuzz operation is probing.
+			// histogram/sortedRequests: record it only as allocated, never as pending. This is the
+			// exact invariant this fuzz operation is probing.
 			keyPriority[key] = priority
 			allocatedKeys[key] = true
 
@@ -275,10 +275,10 @@ func runPropertyFuzz(t *testing.T, seed int64) int { //nolint:funlen
 			// one RecoverAllocationAsk just added (~line 1263-1264) - so the fuzzer does the same and
 			// passes app.GetAllocationAsk(key) rather than building a second Allocation for the same
 			// key. That matters here: RollbackAllocation deallocates the object it found in
-			// sa.allocations, and deallocateAsk only counts an ask as pending again when it still IS
-			// the object sa.requests holds for that key - so a second Allocation built for the same
-			// key would fail that identity check for a reason the product itself cannot produce,
-			// making the assertions test fiction.
+			// sa.allocations, and if that were a different object the resulting
+			// sortedRequests.insert would put an Allocation into sortedRequests that sa.requests
+			// never contained - a state the product itself cannot produce, so asserting on it would
+			// be testing fiction.
 			if key, ok := pickRandomFilteredKey(rng, allocatedKeys, func(k string) bool {
 				if confirmedKeys[k] {
 					// already in sa.allocations: confirming the same key twice would add its
@@ -308,8 +308,9 @@ func runPropertyFuzz(t *testing.T, seed int64) int { //nolint:funlen
 
 		case 7: // RollbackAllocation - revert a confirmed allocation back to a pending ask
 			// This is the new C1 caller under test: RollbackAllocation runs deallocateAsk
-			// (application.go ~line 875), which is the function that does addToPriorities, so a
-			// still-tracked ask has to reappear in the pending histogram at its original priority.
+			// (application.go ~line 875), which is the function that does addToPriorities plus
+			// sortedRequests.insert, so a still-tracked ask has to reappear in the pending histogram
+			// and in sortedRequests at its original priority.
 			// Candidates deliberately also include confirmed keys whose ask is no longer in
 			// sa.requests at all. That "ghost" state IS reachable in production: sa.allocations is
 			// only cleaned up once the shim confirms the release, so every path that drops asks while
@@ -321,7 +322,9 @@ func runPropertyFuzz(t *testing.T, seed int64) int { //nolint:funlen
 			// and remains rollback-eligible. Since YUNIKORN-3360, RollbackAllocation rejects such a
 			// ghost before touching anything (application.go ~line 885: the ask has to be in
 			// sa.requests), so the fuzzer asserts that rejection below, and the reference model
-			// leaves the step as the no-op it now is.
+			// leaves the step as the no-op it now is. sortedRequests follows the same rule: a ghost
+			// must never be resurrected into it, where tryAllocate would then try to schedule
+			// something the application does not track any more.
 			// The only combination excluded is a confirmed key that is still tracked but already
 			// pending (deallocated without being removed): ask.deallocate() rejects that outright, so
 			// picking it would only ever burn a step.
@@ -359,9 +362,10 @@ func runPropertyFuzz(t *testing.T, seed int64) int { //nolint:funlen
 		case 8: // AddAllocationAsk re-using an existing key - the replace-existing-ask branch
 			// AddAllocationAsk (application.go ~line 668) handles a key that is already in
 			// sa.requests and still pending separately: it has to unwind the old ask from the
-			// pending histogram before addAllocationAskInternal counts the replacement, or the key
-			// is counted twice and its old priority never drops out again. Case 0 only ever mints
-			// fresh keys, so without this operation that branch is never executed here at all.
+			// pending histogram AND from sortedRequests before the unconditional insert at the end
+			// of the function, or a single allocation key ends up with two sortedRequests entries.
+			// Case 0 only ever mints fresh keys, so without this operation that branch is never
+			// executed here at all.
 			if len(pendingKeys) > 0 {
 				key := pickRandomKey(rng, pendingKeys)
 				existing := app.GetAllocationAsk(key)
@@ -406,7 +410,7 @@ func runPropertyFuzz(t *testing.T, seed int64) int { //nolint:funlen
 	// allocations) would silently turn case 7 into a no-op and stop covering deallocateAsk's new
 	// caller entirely, while every assertion above kept passing.
 	assert.Assert(t, successfulRollbacks > 0, "seed=%d: fuzz run never completed a RollbackAllocation", seed)
-	// The replace-existing-ask branch (case 8) must not double count the key in the histogram. It is
+	// The replace-existing-ask branch (case 8) must not leave a duplicate in sortedRequests. It is
 	// only reached while pendingKeys is non-empty, so assert it really happened rather than trusting
 	// that condition to keep holding. The ghost-rollback-attempt count is returned instead of asserted
 	// here: whether a run reaches that state at all depends on the interleaving it happens to produce,
@@ -490,10 +494,10 @@ func pickRandomExistingKey(rng *rand.Rand, keyPriority map[string]int32) (string
 	return list[rng.Intn(len(list))], true
 }
 
-// assertFuzzInvariants rebuilds the expected pending-ask histogram and max from the reference model
-// (keyPriority + pendingKeys) and compares it against the application's incrementally maintained
-// state. On any mismatch it fails with the seed and step number embedded in the message so the
-// failure is reproducible via `go test -run .../seed-<seed>`.
+// assertFuzzInvariants rebuilds the expected pending-ask histogram/max/sortedRequests membership
+// from the reference model (keyPriority + pendingKeys) and compares it against the application's
+// incrementally maintained state. On any mismatch it fails with the seed and step number embedded
+// in the message so the failure is reproducible via `go test -run .../seed-<seed>`.
 // It returns the number of distinct pending priorities observed this step, so the caller can track
 // coverage high-water marks without a second pass over pendingKeys.
 func assertFuzzInvariants(t *testing.T, app *Application, keyPriority map[string]int32, pendingKeys map[string]bool, seed int64, step int) int {
@@ -515,12 +519,29 @@ func assertFuzzInvariants(t *testing.T, app *Application, keyPriority map[string
 	for p, c := range app.pendingPriorities {
 		gotHistogram[p] = c
 	}
+	gotSorted := make([]*Allocation, len(app.sortedRequests))
+	copy(gotSorted, app.sortedRequests)
 	app.RUnlock()
 
 	assert.Equal(t, gotMax, wantMax, "seed=%d step=%d: askMaxPriority mismatch", seed, step)
 	assert.Equal(t, len(gotHistogram), len(wantHistogram), "seed=%d step=%d: pendingPriorities histogram size mismatch, got=%v want=%v", seed, step, gotHistogram, wantHistogram)
 	for p, wantCount := range wantHistogram {
 		assert.Equal(t, gotHistogram[p], wantCount, "seed=%d step=%d: pendingPriorities[%d] mismatch, got histogram=%v want histogram=%v", seed, step, p, gotHistogram, wantHistogram)
+	}
+
+	assert.Equal(t, len(gotSorted), len(pendingKeys), "seed=%d step=%d: len(sortedRequests) mismatch with pending key set", seed, step)
+	gotKeys := make(map[string]bool, len(gotSorted))
+	for i, entry := range gotSorted {
+		assert.Assert(t, !entry.IsAllocated(), "seed=%d step=%d: sortedRequests[%d] (key=%s) is allocated", seed, step, i, entry.GetAllocationKey())
+		gotKeys[entry.GetAllocationKey()] = true
+		if i > 0 {
+			// comparator-validity only (order-independent bonus check); no assertion is made about
+			// tie-break order among equal-priority/equal-createTime asks.
+			assert.Assert(t, gotSorted[i].LessThan(gotSorted[i-1]), "seed=%d step=%d: sortedRequests not descending at index %d", seed, step, i)
+		}
+	}
+	for k := range pendingKeys {
+		assert.Assert(t, gotKeys[k], "seed=%d step=%d: expected pending key %s missing from sortedRequests", seed, step, k)
 	}
 
 	return len(wantHistogram)

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -2329,6 +2329,47 @@ func TestTryAllocateFit(t *testing.T) {
 	assert.Equal(t, "node1", result.NodeID, "wrong node")
 }
 
+// TestTryAllocateAllocatedAskInSortedRequests pins the scream-then-repair guard that backs the
+// pending-only invariant of sortedRequests: an allocated ask can only still be in the slice if the
+// remove-on-allocate pairing has been broken. The guard uses DPanic, which panics under the
+// development logger the tests run with, so a broken pairing fails hard here while production only
+// logs and self-heals.
+func TestTryAllocateAllocatedAskInSortedRequests(t *testing.T) {
+	setupUGM()
+	node := newNode(nodeID1, map[string]resources.Quantity{"first": 5})
+	nodeMap := map[string]*Node{nodeID1: node}
+	iterator := getNodeIteratorFn(node)
+	getNode := func(nodeID string) *Node {
+		return nodeMap[nodeID]
+	}
+
+	queue, err := createRootQueue(map[string]string{"first": "5"})
+	assert.NilError(t, err, "queue create failed")
+	app := newApplication(appID1, "default", "root")
+	app.queue = queue
+	ask := newAllocationAsk(aKey, appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5}))
+	err = app.AddAllocationAsk(ask)
+	assert.NilError(t, err, "ask should have been added to app")
+
+	// build the ghost white-box: allocateAsk marks the ask allocated and drops it from the
+	// pending-only slice, putting it straight back is exactly the broken pairing under test
+	_, err = app.allocateAsk(ask)
+	assert.NilError(t, err, "ask should have been allocated")
+	app.sortedRequests.insert(ask)
+	assert.Assert(t, ask.IsAllocated(), "ask should be allocated")
+	assert.Equal(t, len(app.sortedRequests), 1, "ghost ask should be in sortedRequests")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("tryAllocate should have panicked on an allocated ask in sortedRequests")
+		}
+		assert.Assert(t, strings.Contains(fmt.Sprint(r), "allocated ask found in pending-only sortedRequests"), "unexpected panic: %v", r)
+	}()
+	preemptionAttemptsRemaining := 0
+	app.tryAllocate(node.GetAvailableResource(), true, 30*time.Second, &preemptionAttemptsRemaining, iterator, iterator, getNode)
+}
+
 func TestTryAllocatePreemptQueue(t *testing.T) {
 	node := newNode("node1", map[string]resources.Quantity{"first": 20})
 	nodeMap := map[string]*Node{"node1": node}

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -2656,17 +2656,33 @@ func assertMaxPriorityConsistent(t *testing.T, app *Application) {
 	defer app.RUnlock()
 	wantMax := configs.MinPriority
 	wantHistogram := make(map[int32]int)
+	wantSorted := make(map[string]bool)
 	for _, req := range app.requests {
 		if req.IsAllocated() {
 			continue
 		}
 		wantMax = max(wantMax, req.GetPriority())
 		wantHistogram[req.GetPriority()]++
+		wantSorted[req.GetAllocationKey()] = true
 	}
 	assert.Equal(t, app.askMaxPriority, wantMax, "askMaxPriority inconsistent with full scan over requests")
 	assert.Equal(t, len(app.pendingPriorities), len(wantHistogram), "pendingPriorities histogram size mismatch")
 	for p, count := range wantHistogram {
 		assert.Equal(t, app.pendingPriorities[p], count, "pendingPriorities count mismatch for priority %d", p)
+	}
+	// every non-allocated ask in app.requests must appear exactly once in app.sortedRequests: no extras, no duplicates.
+	assert.Equal(t, len(app.sortedRequests), len(wantSorted), "sortedRequests size mismatch against non-allocated requests")
+	seen := make(map[string]bool)
+	for i, req := range app.sortedRequests {
+		key := req.GetAllocationKey()
+		assert.Assert(t, !seen[key], "duplicate allocationKey %s found in sortedRequests", key)
+		seen[key] = true
+		assert.Assert(t, wantSorted[key], "sortedRequests contains allocationKey %s not present in non-allocated requests", key)
+		if i > 0 {
+			// comparator-validity only: adjacent entries must be tie-or-after, no assertion on
+			// tie-break order (mirrors the check in assertFuzzInvariants)
+			assert.Assert(t, app.sortedRequests[i].LessThan(app.sortedRequests[i-1]), "sortedRequests out of order at index %d", i)
+		}
 	}
 }
 
@@ -2753,10 +2769,12 @@ func TestMaxAskPriority(t *testing.T) {
 
 // TestAddAllocationAskReplaceExistingPendingAsk covers the replace-existing-ask branch of
 // AddAllocationAsk: re-submitting an ask under a key that is already tracked and still pending.
-// The displaced ask has to leave the pending histogram before addAllocationAskInternal counts the
-// replacement, or a single allocation key is counted twice and the priority it was originally
-// submitted at never drops out again. The full rescan this replaced could not get that wrong: it
-// derived the maximum from sa.requests, which only ever holds one ask per key.
+// That branch has to drop the old ask from BOTH the pending histogram and sortedRequests before the
+// new ask is inserted at the end of the function. Dropping it from the histogram only leaves two
+// sortedRequests entries for one allocation key while sa.requests holds just the replacement, which
+// breaks the pending-only invariant in a way that outlives the add: nothing ever removes the
+// replaced twin again, so it stays in the pending-only list forever as an ask the application does
+// not track.
 func TestAddAllocationAskReplaceExistingPendingAsk(t *testing.T) {
 	app := newApplication(appID1, "default", "root.default")
 	queue, err := createRootQueue(nil)
@@ -2774,18 +2792,20 @@ func TestAddAllocationAskReplaceExistingPendingAsk(t *testing.T) {
 	assert.NilError(t, err, "ask should have been updated on app")
 
 	app.RLock()
+	assert.Equal(t, len(app.sortedRequests), 1, "replacing a pending ask must leave exactly one sortedRequests entry")
+	assert.Assert(t, app.sortedRequests[0] == replacement, "sortedRequests must hold the replacement ask, not the replaced one")
 	assert.Equal(t, len(app.pendingPriorities), 1, "pending histogram must only hold the replacement's priority")
 	assert.Equal(t, app.pendingPriorities[3], 1, "wrong pending count for the replacement priority")
 	app.RUnlock()
 	assert.Equal(t, app.GetAskMaxPriority(), int32(3), "wrong priority after replacing p=5 with p=3")
 	assertMaxPriorityConsistent(t, app)
 
-	// allocating the only ask must empty the histogram: a double counted key would leave the
-	// replaced ask's priority behind.
+	// allocating the only ask must empty the pending-only list: with a duplicate present the replaced
+	// twin would still be sitting there afterwards.
 	_, err = app.AllocateAsk(aKey)
 	assert.NilError(t, err, "ask should have been allocated")
 	app.RLock()
-	assert.Equal(t, len(app.pendingPriorities), 0, "allocating the only ask must empty the pending histogram")
+	assert.Equal(t, len(app.sortedRequests), 0, "allocating the only ask must empty sortedRequests")
 	app.RUnlock()
 	assert.Equal(t, app.GetAskMaxPriority(), configs.MinPriority, "wrong priority after allocating the only ask")
 	assertMaxPriorityConsistent(t, app)
@@ -2793,12 +2813,12 @@ func TestAddAllocationAskReplaceExistingPendingAsk(t *testing.T) {
 
 // TestRollbackAllocationAskNotTracked covers RollbackAllocation being handed a "ghost": an ask that
 // sa.requests no longer holds while sa.allocations still does. That state is reachable in
-// production: removeAsksInternal("") wipes sa.requests and the pending histogram but deliberately
-// leaves sa.allocations alone until the shim confirms the releases, so a SCHEDULING_FAILED_ON_RM
-// release arriving in that window reaches RollbackAllocation. Since YUNIKORN-3360 the rollback is
-// rejected outright when the ask is not in sa.requests, and this test pins that guard: the call must
-// return an error and leave the allocation, the allocated resource and the pending histogram
-// untouched.
+// production: removeAsksInternal("") wipes sa.requests, sortedRequests and the pending histogram but
+// deliberately leaves sa.allocations alone until the shim confirms the releases, so a
+// SCHEDULING_FAILED_ON_RM release arriving in that window reaches RollbackAllocation. Since
+// YUNIKORN-3360 the rollback is rejected outright when the ask is not in sa.requests, and this test
+// pins that guard: the call must return an error and leave the allocation, the allocated resource,
+// sortedRequests and the pending histogram untouched.
 func TestRollbackAllocationAskNotTracked(t *testing.T) {
 	setupUGM()
 	defer setupUGM()
@@ -2826,6 +2846,7 @@ func TestRollbackAllocationAskNotTracked(t *testing.T) {
 
 	app.RLock()
 	assert.Assert(t, app.allocations[aKey] == ask, "rejected rollback must leave the confirmed allocation in place")
+	assert.Equal(t, len(app.sortedRequests), 0, "rejected rollback must not insert into sortedRequests")
 	assert.Equal(t, len(app.pendingPriorities), 0, "rejected rollback must not change the pending histogram")
 	app.RUnlock()
 	assert.Assert(t, resources.Equals(app.GetAllocatedResource(), res), "rejected rollback must not change the allocated resource")
@@ -3407,6 +3428,46 @@ func TestGetOutstandingRequests_AskReplaceable(t *testing.T) {
 	assert.Assert(t, resources.Equals(resTotal, expectedTotal), "expected resource %v, but got %v", expectedTotal, resTotal)
 	assert.Equal(t, 1, len(total))
 	assert.Equal(t, "alloc-3", total[0].allocationKey)
+}
+
+// TestGetOutstandingRequests_PartialHeadroom pins that selection follows the sortedRequests order,
+// front to back. getOutstandingRequests consumes the headrooms as it walks the slice, so as soon as
+// the headroom admits only part of the pending asks the slice order alone decides which asks are
+// selected. That set is not cosmetic: it is reported back to the shim as unschedulable and is what
+// drives cluster autoscaling, so the asks at the front, the ones that arrived first, must be the
+// ones that trigger the scale up.
+// The asks tie on priority and createTime, the normal case for a submitted burst, which leaves the
+// arrival order of sortedRequests as the only thing separating them.
+func TestGetOutstandingRequests_PartialHeadroom(t *testing.T) {
+	res := resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 1})
+
+	allocationAsk1 := newFuzzAsk("alloc-1", "app-1", "", res, false, 0, "", 100)
+	allocationAsk2 := newFuzzAsk("alloc-2", "app-1", "", res, false, 0, "", 100)
+	allocationAsk3 := newFuzzAsk("alloc-3", "app-1", "", res, false, 0, "", 100)
+	allocationAsk1.SetSchedulingAttempted(true)
+	allocationAsk2.SetSchedulingAttempted(true)
+	allocationAsk3.SetSchedulingAttempted(true)
+
+	app := &Application{
+		ApplicationID: "app-1",
+		queuePath:     "default",
+	}
+	sr := sortedRequests{}
+	sr.insert(allocationAsk1)
+	sr.insert(allocationAsk2)
+	sr.insert(allocationAsk3)
+	app.sortedRequests = sr
+
+	// headroom for two of the three asks: the third one runs into an exhausted headroom
+	var total []*Allocation
+	headroom := resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 2})
+	userHeadroom := resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 2})
+	resTotal := app.getOutstandingRequests(headroom, userHeadroom, &total)
+	expectedTotal := resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 2})
+	assert.Assert(t, resources.Equals(resTotal, expectedTotal), "expected resource %v, but got %v", expectedTotal, resTotal)
+	assert.Equal(t, 2, len(total))
+	assert.Equal(t, "alloc-1", total[0].allocationKey, "the first ask in the slice must be selected first")
+	assert.Equal(t, "alloc-2", total[1].allocationKey, "the second ask in the slice must be selected second")
 }
 
 func TestGetRateLimitedAppLog(t *testing.T) {

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -2818,7 +2818,7 @@ func TestAddAllocationAskReplaceExistingPendingAsk(t *testing.T) {
 // SCHEDULING_FAILED_ON_RM release arriving in that window reaches RollbackAllocation. Since
 // YUNIKORN-3360 the rollback is rejected outright when the ask is not in sa.requests, and this test
 // pins that guard: the call must return an error and leave the allocation, the allocated resource,
-// sortedRequests and the pending histogram untouched.
+// sortedRequests, the pending histogram and the app/queue pending resource untouched.
 func TestRollbackAllocationAskNotTracked(t *testing.T) {
 	setupUGM()
 	defer setupUGM()
@@ -2851,6 +2851,8 @@ func TestRollbackAllocationAskNotTracked(t *testing.T) {
 	app.RUnlock()
 	assert.Assert(t, resources.Equals(app.GetAllocatedResource(), res), "rejected rollback must not change the allocated resource")
 	assert.Equal(t, app.GetAskMaxPriority(), configs.MinPriority, "rejected rollback must not change askMaxPriority")
+	assert.Assert(t, resources.IsZero(app.GetPendingResource()), "rejected rollback must not re-add pending resource, got %v", app.GetPendingResource())
+	assert.Assert(t, resources.IsZero(queue.GetPendingResource()), "rejected rollback must not re-add queue pending resource, got %v", queue.GetPendingResource())
 	assertMaxPriorityConsistent(t, app)
 }
 

--- a/pkg/scheduler/objects/sorted_asks.go
+++ b/pkg/scheduler/objects/sorted_asks.go
@@ -35,7 +35,17 @@ func (s *sortedRequests) insert(ask *Allocation) {
 		return
 	}
 
-	idx := sort.Search(size, func(i int) bool {
+	// the slow path is exactly reinsert's placement; share it so the two cannot diverge
+	s.reinsert(ask)
+}
+
+// reinsert puts an ask that is returning to the pending set (deallocated after a reverted or
+// failed allocation) back into the slice. Unlike insert it never takes the append fast path: with
+// LessThan reporting a (priority, createTime) tie as true in both directions, the binary search
+// stops at the FIRST tie-peer, so the returning ask lands at the head of its tie-group and is
+// retried before the peers it had already been tried ahead of.
+func (s *sortedRequests) reinsert(ask *Allocation) {
+	idx := sort.Search(len(*s), func(i int) bool {
 		return (*s)[i].LessThan(ask)
 	})
 	s.insertAt(idx, ask)
@@ -49,9 +59,13 @@ func (s *sortedRequests) insertAt(index int, ask *Allocation) {
 	(*s)[index] = ask
 }
 
+// remove drops the entry that IS the passed ask, matching on pointer identity and not on
+// allocationKey. The slice tracks the pending asks the application holds in sa.requests, and every
+// caller passes the tracked object. Matching on key would remove the first entry that shares the
+// key, which is a different ask than the caller asked to remove as soon as two ever coexist.
 func (s *sortedRequests) remove(ask *Allocation) {
 	for i, a := range *s {
-		if a.allocationKey == ask.allocationKey {
+		if a == ask {
 			s.removeAt(i)
 			return
 		}

--- a/pkg/scheduler/objects/sorted_asks.go
+++ b/pkg/scheduler/objects/sorted_asks.go
@@ -59,10 +59,9 @@ func (s *sortedRequests) insertAt(index int, ask *Allocation) {
 	(*s)[index] = ask
 }
 
-// remove drops the entry that IS the passed ask, matching on pointer identity and not on
-// allocationKey. The slice tracks the pending asks the application holds in sa.requests, and every
-// caller passes the tracked object. Matching on key would remove the first entry that shares the
-// key, which is a different ask than the caller asked to remove as soon as two ever coexist.
+// remove drops the entry that IS the passed ask, matching on pointer identity: that is cheaper than
+// comparing allocationKeys, and every caller passes the object it resolved from sa.requests or read
+// out of the slice itself.
 func (s *sortedRequests) remove(ask *Allocation) {
 	for i, a := range *s {
 		if a == ask {

--- a/pkg/scheduler/objects/sorted_asks_test.go
+++ b/pkg/scheduler/objects/sorted_asks_test.go
@@ -157,6 +157,72 @@ func TestRemoveWithSamePriorityAndTime(t *testing.T) {
 	assert.Assert(t, !askPresent(alloc3, sorted), "alloc3 should be removed")
 }
 
+// TestReinsertHeadOfTieGroup pins the placement contract of reinsert: an ask returning to the
+// pending set (allocate followed by deallocate) is placed at the HEAD of its
+// (priority, createTime) tie-group, so the next scheduling cycle retries it before the peers it
+// had already been tried ahead of. insert makes no such promise for ties between newly arriving
+// asks: the append fast path lands behind the tie-group while the binary search lands in front of
+// it, and nothing in the scheduler depends on which of the two a new tied ask gets.
+func TestReinsertHeadOfTieGroup(t *testing.T) {
+	baseTime := time.Now()
+	alloc1 := &Allocation{
+		createTime:    baseTime,
+		priority:      10,
+		allocationKey: "alloc-1",
+	}
+	alloc2 := &Allocation{
+		createTime:    baseTime,
+		priority:      10,
+		allocationKey: "alloc-2",
+	}
+	alloc3 := &Allocation{
+		createTime:    baseTime,
+		priority:      10,
+		allocationKey: "alloc-3",
+	}
+	lower := &Allocation{
+		createTime:    baseTime,
+		priority:      1,
+		allocationKey: "alloc-low",
+	}
+
+	sorted := sortedRequests{}
+	// an in-order burst of tied asks hits the append fast path: arrival order front to back
+	sorted.insert(alloc1)
+	sorted.insert(alloc2)
+	sorted.insert(alloc3)
+	assert.Equal(t, 3, len(sorted))
+	assert.Equal(t, "alloc-1", sorted[0].allocationKey, "expected arrival order front to back")
+	assert.Equal(t, "alloc-2", sorted[1].allocationKey, "expected arrival order front to back")
+	assert.Equal(t, "alloc-3", sorted[2].allocationKey, "expected arrival order front to back")
+
+	// allocate/deallocate cycle for the middle ask: it must come back at the head of the group
+	sorted.remove(alloc2)
+	assert.Equal(t, 2, len(sorted))
+	sorted.reinsert(alloc2)
+	assert.Equal(t, 3, len(sorted))
+	assert.Equal(t, "alloc-2", sorted[0].allocationKey, "a returning ask must head its tie-group")
+	assert.Equal(t, "alloc-1", sorted[1].allocationKey)
+	assert.Equal(t, "alloc-3", sorted[2].allocationKey)
+
+	// same with a lower-priority ask sitting behind the tie-group
+	sorted.insert(lower)
+	assert.Equal(t, "alloc-low", sorted[3].allocationKey, "lower priority sorts after the group")
+	sorted.remove(alloc3)
+	sorted.reinsert(alloc3)
+	assert.Equal(t, 4, len(sorted))
+	assert.Equal(t, "alloc-3", sorted[0].allocationKey, "a returning ask must head its tie-group")
+	assert.Equal(t, "alloc-2", sorted[1].allocationKey)
+	assert.Equal(t, "alloc-1", sorted[2].allocationKey)
+	assert.Equal(t, "alloc-low", sorted[3].allocationKey, "lower priority must stay behind the group")
+
+	// a returning ask with nothing sorting after it goes to the very end, not the front
+	sorted.remove(lower)
+	sorted.reinsert(lower)
+	assert.Equal(t, 4, len(sorted))
+	assert.Equal(t, "alloc-low", sorted[3].allocationKey, "sole member of the last tie-group returns to the end")
+}
+
 func askPresent(ask *Allocation, asks []*Allocation) bool {
 	for _, a := range asks {
 		if a.allocationKey == ask.allocationKey {


### PR DESCRIPTION
Part of YUNIKORN-3350, which splits one change into three independent levers. This is the third and
last lever, the one held back from the earlier submissions because it carries the contested
decisions: pending-only membership, where a returning ask lands, and identity-based `remove`.

## What

`sortedRequests` is ordered by priority, then age. Whether an ask is allocated plays no part in that
ordering, so allocated and pending asks sit side by side in the list. `tryAllocate` walks it from the
front, skipping the allocated ones with `if request.IsAllocated() { continue }` — a read lock each. The
more asks an application has already had satisfied, the more there are to skip, so each scheduling
cycle costs more than the last. In a CPU profile of master that skip is 18% of
`Application.tryAllocate`.

Keep the slice pending-only instead: `allocateAsk` removes the ask, `deallocateAsk` puts it back. The
container, its comparator and its insert behaviour are unchanged — only membership changes, plus one
placement rule for the way back in (below). (`insert`'s slow path is shared with the new `reinsert`
since the two are byte-identical, so they cannot diverge.)

## Measured effect

`BenchmarkScheduling`, allocate phase, 10000 pods, alternating A/B, 3 samples, medians. Linux 6.8
aarch64, 6 CPUs, GOMAXPROCS=6. Cumulative is the whole stack against master; "this PR" is the ratio
against the previous PR in the stack.

| nodes | master (c/s) | this PR (c/s) | cumulative | this PR |
|---|---:|---:|---:|---:|
| 500  | 5,481 | 44,421 | 8.10x | 2.64x |
| 1000 | 5,517 | 42,452 | 7.70x | 2.60x |
| 2000 | 5,396 | 43,086 | 7.99x | 2.62x |
| 5000 | 5,353 | 40,577 | 7.58x | 2.48x |

Spread up to 7%. After the change both hot symbols are absent from the profile entirely and node
iteration becomes the dominant term, which is the correct shape.

Scope: mock resource manager, no real bind, so this is core scheduling headroom rather than a
real-cluster pods/second figure — on a real cluster the ceiling remains the Kubernetes API bind rate.
The workload is 2 applications x 5,000 asks, which is favourable to a per-application quadratic fix.

Reproduce with:

```
go test ./pkg/scheduler/tests/ -run '^$' -bench 'BenchmarkScheduling' -benchtime=1x -v
```

## What else reads `sortedRequests`

Pending-only membership changes what every reader sees, so all were checked. `sortedRequests` is
unexported, has no accessor, and appears in no DAO, REST handler, metric or proto conversion. Inside
`pkg/scheduler/objects` there are exactly three readers:

| reader | effect |
|---|---|
| `tryAllocate` | the target of this change |
| `tryPlaceholderAllocate` | already skips on `IsAllocated()`, so sees the same set |
| `getOutstandingRequests` | unchanged here, already skips on `IsAllocated()`, so sees the same set |

No caller uses `len(sortedRequests)` as a count of an application's asks, so its changed meaning is
not observed anywhere.

Insertion of new asks is untouched, so for a workload that only adds asks all three readers see the
slice exactly as master builds it. The one order change is the re-insert path (next section), and it
is visible to all three readers, including `getOutstandingRequests` — which consumes headroom as it
walks, so which asks land in the outstanding set can differ when headroom runs out inside a tie
group. That set feeds `UpdateContainerSchedulingState`, i.e. the pods reported to the resource
manager as unschedulable for cluster autoscaling.

## Where a returning ask lands

Nothing on master re-inserts into `sortedRequests`: an ask that becomes pending again (preemption
revert, placeholder-replacement revert, rollback after a failed bind) has been sitting in its
original position all along. Pending-only membership creates the question of where it goes back in,
and the existing machinery cannot answer it: `createTime` is whole-second resolution end to end — the
shim sends `pod.CreationTimestamp.Unix()`, the core does `time.Unix(secs, 0)`, and Kubernetes
`creationTimestamp` is second-resolution at source — so every pod of a burst ties on
`(priority, createTime)`, and `LessThan` reports both directions as less-than for a tie. Plain
`insert` would place a returning ask by slice contents: behind its tie-peers when the group sits at
the tail (the append fast path), in front of them otherwise.

So the placement is made a stated rule instead of a side effect: **a returning ask goes to the head
of its `(priority, createTime)` tie-group** — `sortedRequests.reinsert`, which is `insert` minus the
append fast path. The scheduler was already trying that ask ahead of its tie-peers when it allocated
it; putting it back at the head means it is retried before the others rather than sent to the back
of a group it had already cleared. The comparator is untouched, no tiebreaker is added, and ties
between newly *arriving* asks keep the existing position-dependent placement — no canonical order is
imposed where nothing needs one.

The trade-off is deliberate: an ask that keeps failing (say, a repeated bind failure) is re-attempted
first each cycle. That costs the group one attempt per cycle, not the cycle: when an attempt fails
`tryAllocate` walks on to the next pending ask, and the application-level unschedulable-ask backoff
bounds the walk as it always has. If retry-first proves wrong for that path specifically, sending the
returning ask to the back of its group instead is the same binary search with the opposite tie
handling — a scheduling-policy decision that can be made in its own change without touching this
structure.

## Three guards

The full rescan tolerated states that incremental membership does not:

- `AddAllocationAsk`'s replace branch drops the displaced ask from `sortedRequests`. The unconditional
  insert that follows would otherwise leave two entries for one key. The duplicate exists on master,
  masked because nothing depended on the slice holding each key once.
- `sortedRequests.remove` matches on **pointer identity** rather than `allocationKey`. On master
  `remove` has a single cold call site; this PR puts it on the allocation path, so "first entry with
  this key" is no longer good enough. Every direct call site passes a map- or slice-resolved object,
  so no outcome changes today. This is correctness by construction rather than a fix for a live
  hazard: the one path that could present a stale object — `AddAllocationAsk` replacing an ask that
  holds a reservation, whose captured `reserve.alloc` `tryReservedAllocate`'s second loop uses
  without re-resolving — is unreachable, because that function's only caller adds an ask solely when
  `GetAllocationAsk` returned nil, and both run on the single allocation-event goroutine. Identity
  matching means the invariant does not depend on that remaining true.
- `deallocateAsk` returns an ask to the pending structures — histogram, `sortedRequests`, `sa.pending`
  and queue pending — only when it is still the tracked object for its key, so all four sit behind one
  decision. Since YUNIKORN-3360 no production caller can present an untracked ask (`RollbackAllocation`
  rejects it first, `DeallocateAsk` resolves the ask from `sa.requests`, the placeholder reverts pass the
  ask they just allocated), so this is defence-in-depth rather than a fix. The returned delta is
  unchanged either way: callers use it to unwind node/queue *allocated* tracking. Pinned by
  `TestRollbackAllocationAskNotTracked`.

### Why not a different structure

- **Leave allocated asks in and keep skipping them.** That is master, and it is the cost being removed.
- **Tombstone and compact periodically.** Keeps positions stable, but adds a compaction policy and
  leaves the loop walking tombstones in between.
- **A second list, or an order-maintenance structure.** Position-preserving, so no re-insert rule
  would be needed — but it trades one ordering invariant for two structures that must agree, and
  gives up the binary-search insert the slice already provides. This is the alternative worth
  revisiting if the re-insert placement proves contentious.

### `remove` is O(n) — has the quadratic just moved?

No, and this was measured. `remove` → `removeAt` → `memmove` is **~30ms** of the post-change profile,
against the **~0.31s** of allocated-ask skipping this PR removes on the same workload. (That 0.31s is
the share of `IsAllocated` attributed to `tryAllocate`; the rest belongs to the rescan the previous PR
removes and is not claimed here.) Two reasons: `tryAllocate` allocates the first ask that fits, so
`remove`'s linear search almost always terminates at or near index 0; and moving pointers is far
cheaper per element than the scan it replaces, where each element cost a read lock. The cost also
falls across a run as the pending list shrinks, whereas the scan it replaces grew.

The one place a miss-scan was guaranteed is also closed: `removeAsksInternal` now skips the slice
removal for allocated asks, which left `sortedRequests` at `allocateAsk` time — without the skip,
every release of a satisfied allocation would scan the whole pending list to find nothing.

### Why the histogram is kept

Once the slice is pending-only it is ordered highest priority first, so `sortedRequests[0]` is the
pending maximum and the previous PR's histogram becomes derivable — the equivalence holds across the
whole property fuzzer. It is kept anyway, because deriving it would make queue-priority accounting
silently contingent on the ask sort policy, and on the pending-only invariant this PR introduces. The
two values answer different questions.

## Hardening

`tryAllocate` ranged over `sortedRequests` while paths inside call `allocateAsk`, which now removes from
that same slice. Every allocating path returns, so a range loop would still be correct, but it is
correct by convention only. It becomes an index loop that re-reads `len()` each iteration, so a
remove-and-continue is safe — which the one remaining guard uses: the `IsAllocated()` skip is dead
under the pending-only invariant, so it is upgraded to scream-then-repair. It `DPanic`s (hard failure
under core's development logger, i.e. unit tests; a logged line in a Kubernetes deployment, which
presets `Development: false`), drops the ghost entry and carries on with the next ask. An allocated
entry in the slice means the remove-on-allocate pairing broke and nothing else would clean it up.
It cannot fire against the current code; `TestTryAllocateAllocatedAskInSortedRequests` pins it.

A `slices.Clone` snapshot (as `tryPlaceholderAllocate` uses, where the revert path re-inserts
mid-loop) was measured instead of assumed: on `BenchmarkScheduling/1000Nodes/10000Pods`, 3 alternating
samples, medians, the index loop gives 38,604 pods/s at 203 MB/op and the clone 34,461 pods/s at
407 MB/op — an 11% cost, because the clone is O(pending) per call for a loop that normally exits at
index 0. `tryPlaceholderAllocate` keeps its clone: it needs one, and it is cold.

## Behaviour and testing

For workloads that never revert an allocation — the overwhelming majority of scheduling activity —
ordering is byte-for-byte what master produces, because the comparator and `insert` are untouched.
The behaviour change is confined to the revert paths, and the tests carry it:

- `TestReinsertHeadOfTieGroup` (sorted_asks_test.go) pins the `reinsert` contract: a returning ask
  heads its tie-group, whether the group sits at the tail or has lower-priority asks behind it, and
  an ask with nothing sorting after it returns to the end, not the front.
- `TestGetOutstandingRequests_PartialHeadroom` pins that outstanding-ask selection follows slice
  order; it holds before and after. The pre-existing cases at all three levels size headroom so that
  either all or none are selected, so they pass under any ordering.
- The previous PR's property fuzzer is extended to assert `sortedRequests` membership (pending keys
  exactly, no duplicates, nothing allocated) and comparator-validity of the order against its
  independent reference model, across every entry point including rollback and replace.
- `TestAddAllocationAskReplaceExistingPendingAsk` and `TestRollbackAllocationAskNotTracked` pin the
  two guards above at the application level.
- Full `pkg/scheduler/...` green, including under `-race`.

Concurrency: no new lock acquisition and no new ordering. All slice mutation happens under the
application write lock, where the previous PR's histogram maintenance already lives.

## Scope and rollback

No configuration, REST, scheduler-interface or metrics changes. No new public API. No persisted or
serialized state — nothing crosses a process or version boundary, so there is nothing to migrate and
no mixed-version concern during a rolling upgrade. Rollback is a single revert.

Release note: an ask whose allocation is reverted (preemption, placeholder replacement, failed-bind
rollback) is now retried before other pending asks of equal priority and creation time, instead of
holding its original arrival slot.

Generated by Author with assistance from Claude Code.

