### PR TITLE
[YUNIKORN-3361] Improve performance tests in yunikorn-core

### DIFF
--- a/pkg/scheduler/tests/mock_rm_callback_test.go
+++ b/pkg/scheduler/tests/mock_rm_callback_test.go
@@ -19,6 +19,7 @@
 package tests
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -86,11 +87,17 @@ type mockRMCallback struct {
 	// of decisions is ever in flight. Used by golden_trace_test.go for the golden-trace test.
 	trace []traceEntry
 
+	// allocCond is broadcast whenever new allocations are recorded, so waiters can be woken the moment
+	// the target count is reached instead of polling. It is backed by the write side of the embedded
+	// RWMutex so the predicate (len(Allocations)) is evaluated under the same lock that guards Wait,
+	// which is what prevents a missed signal between the check and the wait.
+	allocCond *sync.Cond
+
 	locking.RWMutex
 }
 
 func newMockRMCallbackHandler() *mockRMCallback {
-	return &mockRMCallback{
+	m := &mockRMCallback{
 		acceptedApplications: make(map[string]bool),
 		rejectedApplications: make(map[string]bool),
 		acceptedNodes:        make(map[string]bool),
@@ -100,6 +107,8 @@ func newMockRMCallbackHandler() *mockRMCallback {
 		releasedPhs:          make(map[string]*si.AllocationRelease),
 		appStates:            make(map[string]string),
 	}
+	m.allocCond = sync.NewCond(&m.RWMutex)
+	return m
 }
 
 func (m *mockRMCallback) UpdateApplication(response *si.ApplicationResponse) error {
@@ -123,6 +132,9 @@ func (m *mockRMCallback) UpdateApplication(response *si.ApplicationResponse) err
 func (m *mockRMCallback) UpdateAllocation(response *si.AllocationResponse) error {
 	m.Lock()
 	defer m.Unlock()
+	if len(response.New) > 0 {
+		defer m.allocCond.Broadcast()
+	}
 	for _, alloc := range response.New {
 		m.Allocations[alloc.AllocationKey] = alloc
 		if val, ok := m.nodeAllocations[alloc.NodeID]; ok {
@@ -296,15 +308,23 @@ func (m *mockRMCallback) waitForAllocations(t *testing.T, nAlloc int, timeoutMs 
 }
 
 func (m *mockRMCallback) waitForMinAllocations(tb testing.TB, nAlloc int, timeoutMs int) {
-	var allocLen int
-	err := common.WaitForCondition(10*time.Millisecond, time.Duration(timeoutMs)*time.Millisecond, func() bool {
-		m.RLock()
-		defer m.RUnlock()
-		allocLen = len(m.Allocations)
-		return allocLen >= nAlloc
+	deadline := time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
+	// sync.Cond has no timeout, so wake the waiter once at the deadline to re-check and bail out.
+	timer := time.AfterFunc(time.Duration(timeoutMs)*time.Millisecond, func() {
+		m.Lock()
+		defer m.Unlock()
+		m.allocCond.Broadcast()
 	})
-	if err != nil {
-		tb.Fatalf("Failed to wait for min allocations expected %d, actual %d, called from: %s", nAlloc, allocLen, caller())
+	defer timer.Stop()
+
+	m.Lock()
+	defer m.Unlock()
+	for len(m.Allocations) < nAlloc {
+		if time.Now().After(deadline) {
+			tb.Fatalf("Failed to wait for min allocations expected %d, actual %d, called from: %s", nAlloc, len(m.Allocations), caller())
+			return
+		}
+		m.allocCond.Wait()
 	}
 }
 

--- a/pkg/scheduler/tests/performance_test.go
+++ b/pkg/scheduler/tests/performance_test.go
@@ -122,9 +122,8 @@ partitions:
 	// Wait for all nodes to be accepted
 	startTime := time.Now()
 	mockRM.waitForMinAcceptedNodes(b, numNodes, 5000)
-	duration := time.Since(startTime)
-	b.Logf("Total time to add %d node in %s, %f per second", numNodes, duration, float64(numNodes)/duration.Seconds())
-
+	duration1 := time.Since(startTime)
+	b.Logf("Total time to add %d nodes in %s, %f nodes per second", numNodes, duration1, float64(numNodes)/duration1.Seconds())
 	// Request pods
 	app1NumPods := numPods / 2
 	app1Asks := make([]*si.Allocation, app1NumPods)
@@ -139,13 +138,6 @@ partitions:
 			},
 			ApplicationID: appID1,
 		}
-	}
-	err = proxy.UpdateAllocation(&si.AllocationRequest{
-		Allocations: app1Asks,
-		RmID:        "rm:123",
-	})
-	if err != nil {
-		b.Error(err.Error())
 	}
 
 	app2NumPods := numPods - app1NumPods
@@ -162,6 +154,16 @@ partitions:
 			ApplicationID: appID2,
 		}
 	}
+
+	b.ResetTimer()
+	startTime = time.Now()
+	err = proxy.UpdateAllocation(&si.AllocationRequest{
+		Allocations: app1Asks,
+		RmID:        "rm:123",
+	})
+	if err != nil {
+		b.Error(err.Error())
+	}
 	err = proxy.UpdateAllocation(&si.AllocationRequest{
 		Allocations: app2Asks,
 		RmID:        "rm:123",
@@ -169,21 +171,16 @@ partitions:
 	if err != nil {
 		b.Error(err.Error())
 	}
-
-	// Reset  timer for this benchmark
-	duration = time.Since(startTime)
-	b.Logf("Total time to add %d pods in %s, %f per second", numPods, duration, float64(numPods)/duration.Seconds())
-	startTime = time.Now()
-	b.ResetTimer()
-
 	// Wait for all pods to be allocated
 	mockRM.waitForMinAllocations(b, numPods, 300000)
-
 	// Stop timer and calculate duration
 	b.StopTimer()
-	duration = time.Since(startTime)
-
-	b.Logf("Total time to allocate %d containers in %s, %f per second", numPods, duration, float64(numPods)/duration.Seconds())
+	duration2 := time.Since(startTime)
+	b.Logf("Total time to add %d pods in %s, %f pods per second", numPods, duration2, float64(numPods)/duration2.Seconds())
+	b.ReportAllocs()
+	// ReportMetric must run after ResetTimer; ResetTimer clears any custom metrics reported before it.
+	b.ReportMetric(float64(numNodes)/duration1.Seconds(), "nodes/s")
+	b.ReportMetric(float64(numPods)/duration2.Seconds(), "pods/s")
 }
 
 func BenchmarkScheduling(b *testing.B) {
@@ -196,6 +193,9 @@ func BenchmarkScheduling(b *testing.B) {
 	for _, test := range tests {
 		name := fmt.Sprintf("%vNodes/%vPods", test.numNodes, test.numPods)
 		b.Run(name, func(b *testing.B) {
+			if b.N > 1 {
+				b.Skip("Single-run benchmark")
+			}
 			benchmarkScheduling(b, test.numNodes, test.numPods)
 		})
 	}


### PR DESCRIPTION
### Description
- Fixed timers to report accurate metrics of scheduling 
- Added Allocation metrics as well
- Using broadcast conditions instead of polling for increasing accuracy 


### Type of change
Please delete options that are not relevant.

- [ ] Bug Fix
- [x] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3361

- [ ] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [ ] `make test_all` was run, and no failures reported.

### Questions:
NA

### Screenshots or other details

New benchamark results - 
```
goos: darwin
goarch: arm64
pkg: github.com/apache/yunikorn-core/pkg/scheduler/tests
cpu: Apple M4 Pro
BenchmarkScheduling
BenchmarkScheduling/500Nodes/10000Pods
    /Users/amaheshwari/Documents/Github/outside-projects/forked/yunikorn-combined/yunikorn-core/pkg/scheduler/tests/performance_test.go:126: Total time to add 500 nodes in 11.043292ms, 45276.354189 nodes per second
    /Users/amaheshwari/Documents/Github/outside-projects/forked/yunikorn-combined/yunikorn-core/pkg/scheduler/tests/performance_test.go:179: Total time to add 10000 pods in 1.106214583s, 9039.837436 pods per second
BenchmarkScheduling/500Nodes/10000Pods-14         	       1	1106170292 ns/op	     45276 nodes/s	      9040 pods/s	198466560 B/op	 1905394 allocs/op
BenchmarkScheduling/1000Nodes/10000Pods
2026-08-14T17:57:42.031+0530	INFO	core.events	events/event_publisher.go:62	Event publisher exiting
    /Users/amaheshwari/Documents/Github/outside-projects/forked/yunikorn-combined/yunikorn-core/pkg/scheduler/tests/performance_test.go:126: Total time to add 1000 nodes in 10.423334ms, 95938.593160 nodes per second
    /Users/amaheshwari/Documents/Github/outside-projects/forked/yunikorn-combined/yunikorn-core/pkg/scheduler/tests/performance_test.go:179: Total time to add 10000 pods in 1.118996625s, 8936.577445 pods per second
BenchmarkScheduling/1000Nodes/10000Pods-14        	       1	1118922791 ns/op	     95939 nodes/s	      8937 pods/s	203923480 B/op	 1991527 allocs/op
2026-08-14T17:57:43.223+0530	INFO	core.events	events/event_publisher.go:62	Event publisher exiting
BenchmarkScheduling/2000Nodes/10000Pods
    /Users/amaheshwari/Documents/Github/outside-projects/forked/yunikorn-combined/yunikorn-core/pkg/scheduler/tests/performance_test.go:126: Total time to add 2000 nodes in 10.090084ms, 198214.405351 nodes per second
    /Users/amaheshwari/Documents/Github/outside-projects/forked/yunikorn-combined/yunikorn-core/pkg/scheduler/tests/performance_test.go:179: Total time to add 10000 pods in 1.103445375s, 9062.523825 pods per second
BenchmarkScheduling/2000Nodes/10000Pods-14        	       1	1103405125 ns/op	    198214 nodes/s	      9063 pods/s	207324192 B/op	 1999844 allocs/op
2026-08-14T17:57:44.401+0530	INFO	core.events	events/event_publisher.go:62	Event publisher exiting
BenchmarkScheduling/5000Nodes/10000Pods
    /Users/amaheshwari/Documents/Github/outside-projects/forked/yunikorn-combined/yunikorn-core/pkg/scheduler/tests/performance_test.go:126: Total time to add 5000 nodes in 21.025333ms, 237808.361941 nodes per second
    /Users/amaheshwari/Documents/Github/outside-projects/forked/yunikorn-combined/yunikorn-core/pkg/scheduler/tests/performance_test.go:179: Total time to add 10000 pods in 1.101094375s, 9081.873659 pods per second
BenchmarkScheduling/5000Nodes/10000Pods-14        	2026-08-14T17:57:45.600+0530	INFO	core.events	events/event_publisher.go:62	Event publisher exiting
       1	1101054375 ns/op	    237808 nodes/s	      9082 pods/s	211988880 B/op	 2026164 allocs/op
PASS
ok  	github.com/apache/yunikorn-core/pkg/scheduler/tests	6.476s

```
