### PR TITLE
[YUNIKORN-3345] Turn on nonamedreturns linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,6 +72,7 @@ linters:
     - gosec
     - dogsled
     - whitespace
+    - nonamedreturns
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/pkg/common/configs/configvalidator.go
+++ b/pkg/common/configs/configvalidator.go
@@ -827,8 +827,11 @@ func getLongestPlacementPaths(rules []PlacementRule) ([]placementStaticPath, err
 	return paths, nil
 }
 
-func getLongestStaticPath(rule PlacementRule) (staticPath, ruleChain string, foundDynamicRule bool, err error) {
+func getLongestStaticPath(rule PlacementRule) (string, string, bool, error) {
 	rules := getRuleChain(rule)
+	var staticPath string
+	var ruleChain string
+	var foundDynamicRule bool
 
 	for _, r := range rules {
 		if ruleChain == "" {
@@ -853,7 +856,7 @@ func getLongestStaticPath(rule PlacementRule) (staticPath, ruleChain string, fou
 		if qualified {
 			if staticPath != "" {
 				// error, only the first fixed rule can be fully qualified
-				err = fmt.Errorf("illegal fully qualified 'fixed' rule with value %s", queueName)
+				err := fmt.Errorf("illegal fully qualified 'fixed' rule with value %s", queueName)
 				return staticPath, ruleChain, foundDynamicRule, err
 			}
 			staticPath = queueName

--- a/pkg/locking/locking.go
+++ b/pkg/locking/locking.go
@@ -53,7 +53,7 @@ type errorBuf struct {
 	sync.Mutex
 }
 
-func (b *errorBuf) Write(p []byte) (n int, err error) {
+func (b *errorBuf) Write(p []byte) (int, error) {
 	if b == nil {
 		return len(p), nil
 	}

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -1252,8 +1252,9 @@ func (sa *Application) unreserveForApp(res *reservation) int {
 
 // cancelMatchingReservations cancels reservations that match the predicate.
 // Returns the number of reservations released and the number remaining.
-func (sa *Application) cancelMatchingReservations(reservations []*reservation, shouldCancel func(*reservation) bool) (released, remaining int) {
-	remaining = len(reservations)
+func (sa *Application) cancelMatchingReservations(reservations []*reservation, shouldCancel func(*reservation) bool) (int, int) {
+	released := 0
+	remaining := len(reservations)
 	for _, res := range reservations {
 		if !shouldCancel(res) {
 			continue
@@ -1262,7 +1263,7 @@ func (sa *Application) cancelMatchingReservations(reservations []*reservation, s
 		released += num
 		remaining -= num
 	}
-	return
+	return released, remaining
 }
 
 // cancelReservations will cancel all non required node reservations for a node. The list of reservations passed in is

--- a/pkg/scheduler/objects/preemption_queue_test.go
+++ b/pkg/scheduler/objects/preemption_queue_test.go
@@ -374,21 +374,20 @@ func TestGetRemainingGuaranteedResource(t *testing.T) {
 	}
 }
 
-func setup(t *testing.T) (rootQ, parentQ, childQ1, childQ2, childQ3 *Queue) {
+func setup(t *testing.T) (*Queue, *Queue, *Queue, *Queue, *Queue) {
 	rootQ, err := createRootQueue(map[string]string{})
 	assert.NilError(t, err)
-	var parent1Q *Queue
-	parentQ, err = createManagedQueue(rootQ, "parent", true, map[string]string{})
+	parentQ, err := createManagedQueue(rootQ, "parent", true, map[string]string{})
 	assert.NilError(t, err)
-	parent1Q, err = createManagedQueue(rootQ, "parent1", true, map[string]string{})
+	parent1Q, err := createManagedQueue(rootQ, "parent1", true, map[string]string{})
 	assert.NilError(t, err)
-	childQ1, err = createManagedQueue(parentQ, "child1", false, map[string]string{})
+	childQ1, err := createManagedQueue(parentQ, "child1", false, map[string]string{})
 	assert.NilError(t, err)
-	childQ2, err = createManagedQueue(parentQ, "child2", false, map[string]string{})
+	childQ2, err := createManagedQueue(parentQ, "child2", false, map[string]string{})
 	assert.NilError(t, err)
-	childQ3, err = createManagedQueue(parent1Q, "child3", false, map[string]string{})
+	childQ3, err := createManagedQueue(parent1Q, "child3", false, map[string]string{})
 	assert.NilError(t, err)
-	return
+	return rootQ, parentQ, childQ1, childQ2, childQ3
 }
 
 func assertRemaining(t *testing.T, rootQ *Queue, parentQ *Queue, childQ2 *Queue, childQ1 *Queue, askQueue *Queue, res1 res) {

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1166,10 +1166,10 @@ func (pc *PartitionContext) GetNodes() []*objects.Node {
 // UpdateAllocation adds or updates an Allocation. If the Allocation has no NodeID specified, it is considered a
 // pending allocation and processed appropriate. This call is idempotent, and can be called multiple times with the
 // same allocation (such as on change updates from the shim)
-// Upon successfully processing, two flags are returned: requestCreated (if a new request was added) and allocCreated (if an allocation was satisifed).
+// Upon successfully processing, two flags are returned: requestCreated (if a new request was added) and allocCreated (if an allocation was satisfied).
 // This can be used by callers that need this information to take further action.
 // NOTE: this is a lock free call. It must NOT be called holding the PartitionContext lock.
-func (pc *PartitionContext) UpdateAllocation(alloc *objects.Allocation) (requestCreated bool, allocCreated bool, err error) { //nolint:funlen
+func (pc *PartitionContext) UpdateAllocation(alloc *objects.Allocation) (bool, bool, error) { //nolint:funlen
 	// cannot do anything with a nil alloc, should only happen if the shim broke things badly
 	if alloc == nil {
 		return false, false, nil
@@ -1350,7 +1350,7 @@ func (pc *PartitionContext) UpdateAllocation(alloc *objects.Allocation) (request
 	return false, false, nil
 }
 
-func (pc *PartitionContext) handleForeignAllocation(allocationKey, applicationID, nodeID string, node *objects.Node, alloc *objects.Allocation) (requestCreated bool, allocCreated bool, err error) {
+func (pc *PartitionContext) handleForeignAllocation(allocationKey, applicationID, nodeID string, node *objects.Node, alloc *objects.Allocation) (bool, bool, error) {
 	allocated := alloc.IsAllocated()
 	if !allocated {
 		return false, false, fmt.Errorf("trying to add a foreign request (non-allocation) %s", allocationKey)

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -2607,7 +2607,7 @@ func assertYunikornError(t *testing.T, output, errMsg string) {
 	assert.Equal(t, errMsg, ykErr.Message)
 }
 
-func addEvents(t *testing.T) (appEvent, nodeEvent, queueEvent *si.EventRecord) {
+func addEvents(t *testing.T) (*si.EventRecord, *si.EventRecord, *si.EventRecord) {
 	t.Helper()
 	events.Init()
 	ev := events.GetEventSystem().(*events.EventSystemImpl) //nolint:errcheck
@@ -2616,7 +2616,7 @@ func addEvents(t *testing.T) (appEvent, nodeEvent, queueEvent *si.EventRecord) {
 		"cpu": 1,
 	}).ToProto()
 
-	appEvent = &si.EventRecord{
+	appEvent := &si.EventRecord{
 		Type:              si.EventRecord_APP,
 		TimestampNano:     100,
 		Message:           "app event",
@@ -2627,7 +2627,7 @@ func addEvents(t *testing.T) (appEvent, nodeEvent, queueEvent *si.EventRecord) {
 		Resource:          protoRes,
 	}
 	ev.AddEvent(appEvent)
-	nodeEvent = &si.EventRecord{
+	nodeEvent := &si.EventRecord{
 		Type:              si.EventRecord_NODE,
 		TimestampNano:     101,
 		Message:           "node event",
@@ -2638,7 +2638,7 @@ func addEvents(t *testing.T) (appEvent, nodeEvent, queueEvent *si.EventRecord) {
 		Resource:          protoRes,
 	}
 	ev.AddEvent(nodeEvent)
-	queueEvent = &si.EventRecord{
+	queueEvent := &si.EventRecord{
 		Type:              si.EventRecord_QUEUE,
 		TimestampNano:     102,
 		Message:           "queue event",


### PR DESCRIPTION
### Description
This PR turns on the nonamedreturns linter in .golangci.yml and refactors existing functions. 


### Type of change
Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] Improvement
- [ ] Feature
- [X] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3345

- [ ] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A