### PR TITLE
[YUNIKORN-3360] Check allocation is present in requests map before ro…

### DIFF
--- a/pkg/events/event_publisher_test.go
+++ b/pkg/events/event_publisher_test.go
@@ -41,7 +41,7 @@ func TestCreateShimPublisher(t *testing.T) {
 // StartService() and stop() functions should not cause panic
 func TestServiceStartStopInternal(t *testing.T) {
 	countPublisherGoroutines := func() int {
-		buf := make([]byte, 2*1024)
+		buf := make([]byte, 64*1024)
 		n := runtime.Stack(buf, true)
 		return strings.Count(string(buf[:n]), "(*eventPublisher).start.func1")
 	}

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -824,6 +824,10 @@ func (sa *Application) RollbackAllocation(allocKey string) (*resources.Resource,
 		return nil, fmt.Errorf("cannot rollback allocation %s: application %s is in state %s", allocKey, sa.ApplicationID, sa.CurrentState())
 	}
 
+	if sa.requests[allocKey] == nil {
+		return nil, fmt.Errorf("failed to locate ask with key %s for rollback", allocKey)
+	}
+
 	ask := sa.allocations[allocKey]
 	if ask == nil {
 		return nil, fmt.Errorf("failed to locate allocation with key %s for rollback", allocKey)


### PR DESCRIPTION
…llback

### Description
- fixed broken UT
- Before rolling back checking for allocation in `requests`


### Type of change
Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3360

- [ ] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] `make test_all` was run, and no failures reported.

