### PR TITLE
[YUNIKORN-3364] Fix event stream history replay blocking forever on disconnect

### DIFF
--- a/pkg/events/event_streaming.go
+++ b/pkg/events/event_streaming.go
@@ -106,7 +106,15 @@ func (e *EventStreaming) CreateEventStream(name string, count uint64) *EventStre
 		// map, so "local" will also contain the new event.
 		seen := make(map[*si.EventRecord]bool)
 		for _, event := range history {
-			consumer <- event
+			select {
+			case consumer <- event:
+			case <-e.stopCh:
+				close(consumer)
+				return
+			case <-stop:
+				close(consumer)
+				return
+			}
 			seen[event] = true
 		}
 		for {

--- a/pkg/events/event_streaming_test.go
+++ b/pkg/events/event_streaming_test.go
@@ -154,6 +154,21 @@ func TestGetEventStreams(t *testing.T) {
 	assert.Assert(t, names["test-1"])
 }
 
+func TestEventStreaming_HistoryReplay_SlowConsumer(t *testing.T) {
+	buffer := newEventRingBuffer(1500)
+	for i := 0; i < 1500; i++ {
+		buffer.Add(&si.EventRecord{TimestampNano: int64(i)})
+	}
+	streaming := NewEventStreaming(buffer)
+	defer streaming.Close()
+
+	// requesting more historical events than defaultChannelBufSize (1000) and disconnecting
+	es := streaming.CreateEventStream("test", 1500)
+	streaming.RemoveEventStream(es)
+
+	assert.Equal(t, 0, len(streaming.eventStreams))
+}
+
 func receive(t *testing.T, input <-chan *si.EventRecord) *si.EventRecord {
 	select {
 	case event := <-input:


### PR DESCRIPTION
### Description
Fixes a goroutine and resource leak in `EventStreaming.CreateEventStream` identified during the review of #1124. Previously, replaying historical events used a bare blocking send (`consumer <- event`) outside the forwarder's `select` loop. If a client requested non-zero history and disconnected early (or history exceeded the 1,000-element channel buffer), the send blocked indefinitely because neither `stop` nor `e.stopCh` could be reached.                                                                       
                                                                                                                                             
This PR makes the history-replay send selectable, allowing the forwarder goroutine to exit promptly upon stream removal or system shutdown.

### Type of change
Please delete options that are not relevant.

- [X] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3364

- [ ] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity CLI", where Antigravity CLI is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A