### PR TITLE
[YUNIKORN-3372] Clean up event streams in tests to prevent goroutine leaks

### DIFF
--- a/pkg/events/event_streaming_test.go
+++ b/pkg/events/event_streaming_test.go
@@ -97,6 +97,8 @@ func TestEventStreaming_WithHistoryCount(t *testing.T) {
 	assert.Equal(t, int64(6), received1.TimestampNano)
 	assert.Equal(t, int64(9), received2.TimestampNano)
 	assert.Equal(t, int64(10), received3.TimestampNano)
+	streaming.RemoveEventStream(es)
+	assert.Equal(t, 0, len(streaming.eventStreams))
 }
 
 func TestEventStreaming_TwoConsumers(t *testing.T) {
@@ -118,6 +120,9 @@ func TestEventStreaming_TwoConsumers(t *testing.T) {
 	assert.Equal(t, 0, len(streaming.eventStreams[es1].consumer))
 	assert.Equal(t, 0, len(streaming.eventStreams[es2].local))
 	assert.Equal(t, 0, len(streaming.eventStreams[es2].consumer))
+	streaming.RemoveEventStream(es1)
+	streaming.RemoveEventStream(es2)
+	assert.Equal(t, 0, len(streaming.eventStreams))
 }
 
 func TestEventStreaming_SlowConsumer(t *testing.T) {
@@ -139,12 +144,12 @@ func TestGetEventStreams(t *testing.T) {
 	streaming := NewEventStreaming(buffer)
 	defer streaming.Close()
 
-	streaming.CreateEventStream("test-1", 0)
+	es1 := streaming.CreateEventStream("test-1", 0)
 	streams := streaming.GetEventStreams()
 	assert.Equal(t, 1, len(streams))
 	assert.Equal(t, "test-1", streams[0].Name)
 
-	streaming.CreateEventStream("test-2", 0)
+	es2 := streaming.CreateEventStream("test-2", 0)
 	streams = streaming.GetEventStreams()
 	assert.Equal(t, 2, len(streams))
 	names := make(map[string]bool)
@@ -152,6 +157,9 @@ func TestGetEventStreams(t *testing.T) {
 	names[streams[1].Name] = true
 	assert.Assert(t, names["test-2"])
 	assert.Assert(t, names["test-1"])
+	streaming.RemoveEventStream(es1)
+	streaming.RemoveEventStream(es2)
+	assert.Equal(t, 0, len(streaming.eventStreams))
 }
 
 func receive(t *testing.T, input <-chan *si.EventRecord) *si.EventRecord {

--- a/pkg/events/event_system_test.go
+++ b/pkg/events/event_system_test.go
@@ -165,7 +165,8 @@ func TestEventStreaming(t *testing.T) {
 	eventSystem.StartService()
 	defer eventSystem.Stop()
 
-	eventSystem.CreateEventStream("test", 10)
+	stream := eventSystem.CreateEventStream("test", 10)
+	defer eventSystem.RemoveStream(stream)
 	streams := eventSystem.GetEventStreams()
 
 	assert.Equal(t, 1, len(streams))


### PR DESCRIPTION
### Description
Fixes goroutine and resource leaks in event-streaming unit tests identified during the review of #1124. Several tests created event streams via `CreateEventStream` without calling `RemoveStream`/`RemoveEventStream`, causing forwarder goroutines and channel resources to outlive the test binary.                                                                               
                                                                                                                                             
This PR adds the missing cleanup calls across unit tests in `pkg/events`.

### Type of change
Please delete options that are not relevant.

- [X] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3372

- [ ] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity CLI", where Antigravity CLI is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [ ] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A