### PR TITLE
[YUNIKORN-3420] Remove self-deadlock trap from String() methods

### DIFF
--- a/pkg/common/resources/tracked_resources.go
+++ b/pkg/common/resources/tracked_resources.go
@@ -57,8 +57,6 @@ func (tr *TrackedResource) String() string {
 	if tr == nil {
 		return "TrackedResource{}"
 	}
-	tr.RLock()
-	defer tr.RUnlock()
 
 	var resourceUsage []string
 	for instanceType, resourceTypeMap := range tr.TrackedResourceMap {

--- a/pkg/common/resources/tracked_resources_test.go
+++ b/pkg/common/resources/tracked_resources_test.go
@@ -311,3 +311,10 @@ func TestTrackedResourceString(t *testing.T) {
 	str := tr.String()
 	assert.Equal(t, str, "TrackedResource{}")
 }
+
+func TestTrackedResourceStringSelfLocked(t *testing.T) {
+	tr := NewTrackedResource()
+	tr.Lock()
+	defer tr.Unlock()
+	assert.Equal(t, tr.String(), "TrackedResource{}")
+}

--- a/pkg/locking/locking_test.go
+++ b/pkg/locking/locking_test.go
@@ -195,8 +195,11 @@ func BenchmarkTrackedNoOrderRWMutexWrite(b *testing.B) {
 func TestMutex(t *testing.T) {
 	var mutex Mutex
 	var result atomic.Int32
+	var wg sync.WaitGroup
 	mutex.Lock()
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		mutex.Lock()
 		result.Store(2)
 		mutex.Unlock()
@@ -204,20 +207,24 @@ func TestMutex(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	result.Store(1)
 	mutex.Unlock()
-	time.Sleep(100 * time.Millisecond)
+	wg.Wait()
 	assert.Equal(t, int32(2), result.Load())
 }
 
 func TestRWMutex(t *testing.T) {
 	var mutex RWMutex
 	var count atomic.Int32
+	var wg sync.WaitGroup
 	mutex.RLock()
+	wg.Add(2)
 	go func() {
+		defer wg.Done()
 		mutex.Lock()
 		count.Add(1)
 		mutex.Unlock()
 	}()
 	go func() {
+		defer wg.Done()
 		mutex.Lock()
 		count.Add(1)
 		mutex.Unlock()
@@ -225,7 +232,7 @@ func TestRWMutex(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	before := count.Load()
 	mutex.RUnlock()
-	time.Sleep(500 * time.Millisecond)
+	wg.Wait()
 	after := count.Load()
 	assert.Equal(t, before, int32(0))
 	assert.Equal(t, after, int32(2))

--- a/pkg/scheduler/objects/allocation.go
+++ b/pkg/scheduler/objects/allocation.go
@@ -179,7 +179,7 @@ func (a *Allocation) String() string {
 	if a == nil {
 		return "nil allocation"
 	}
-	return fmt.Sprintf("allocationKey %s, applicationID %s, Resource %s, Allocated %t", a.allocationKey, a.applicationID, a.GetAllocatedResource(), a.IsAllocated())
+	return fmt.Sprintf("allocationKey %s, applicationID %s", a.allocationKey, a.applicationID)
 }
 
 // GetAllocationKey returns the allocation key for this allocation.

--- a/pkg/scheduler/objects/allocation_test.go
+++ b/pkg/scheduler/objects/allocation_test.go
@@ -49,8 +49,21 @@ func TestNewAsk(t *testing.T) {
 		t.Fatal("NewAllocationAskFromSI create failed while it should not")
 	}
 	askStr := ask.String()
-	expected := "allocationKey ask-1, applicationID app-1, Resource map[first:10], Allocated false"
+	expected := "allocationKey ask-1, applicationID app-1"
 	assert.Equal(t, askStr, expected, "Strings should have been equal")
+}
+
+func TestAllocationStringSelfLocked(t *testing.T) {
+	res := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
+	siAsk := &si.Allocation{
+		AllocationKey:    "ask-1",
+		ApplicationID:    "app-1",
+		ResourcePerAlloc: res.ToProto(),
+	}
+	ask := NewAllocationFromSI(siAsk)
+	ask.Lock()
+	defer ask.Unlock()
+	assert.Equal(t, ask.String(), "allocationKey ask-1, applicationID app-1")
 }
 
 func TestAskAllocateDeallocate(t *testing.T) {
@@ -257,7 +270,7 @@ func TestNewAlloc(t *testing.T) {
 	alloc.SetInstanceType(instType1)
 	assert.Equal(t, alloc.GetInstanceType(), instType1, "Instance type not set as expected")
 	allocStr := alloc.String()
-	expected := "allocationKey ask-1, applicationID app-1, Resource map[first:1], Allocated false"
+	expected := "allocationKey ask-1, applicationID app-1"
 	assert.Equal(t, allocStr, expected, "Strings should have been equal")
 	assert.Assert(t, !alloc.IsPlaceholderUsed(), fmt.Sprintf("Alloc should not be placeholder replacement by default: got %t, expected %t", alloc.IsPlaceholderUsed(), false))
 }

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -183,8 +183,8 @@ func (sa *Application) String() string {
 	if sa == nil {
 		return "application is nil"
 	}
-	return fmt.Sprintf("applicationID: %s, Partition: %s, SubmissionTime: %x, State: %s",
-		sa.ApplicationID, sa.Partition, sa.GetSubmissionTime(), sa.stateMachine.Current())
+	return fmt.Sprintf("applicationID: %s, Partition: %s, State: %s",
+		sa.ApplicationID, sa.Partition, sa.stateMachine.Current())
 }
 
 func (sa *Application) SetState(state string) {

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -59,6 +59,14 @@ func setupUGM() {
 	userManager.ClearGroupTrackers()
 }
 
+func TestApplicationStringSelfLocked(t *testing.T) {
+	app := newApplication("app-00001", "default", "root.a")
+	app.Lock()
+	defer app.Unlock()
+	s := app.String()
+	assert.Equal(t, s, "applicationID: app-00001, Partition: default, State: New")
+}
+
 // basic app creating with timeout checks
 func TestNewApplication(t *testing.T) {
 	user := security.UserGroup{

--- a/pkg/scheduler/objects/predicates_test.go
+++ b/pkg/scheduler/objects/predicates_test.go
@@ -97,7 +97,7 @@ func TestPredicateCheckResult_String(t *testing.T) {
 					newAllocationAll("alloc-key-1", "app-1", "node-1", "", nil, false, 0),
 				},
 			},
-			want: "node: node-1, alloc: alloc-1, success: true, index: 1, victims: [allocationKey alloc-key-1, applicationID app-1, Resource map[], Allocated true]",
+			want: "node: node-1, alloc: alloc-1, success: true, index: 1, victims: [allocationKey alloc-key-1, applicationID app-1]",
 		},
 		{
 			name: "result with multiple victims",
@@ -111,7 +111,7 @@ func TestPredicateCheckResult_String(t *testing.T) {
 					newAllocationAll("alloc-key-2", "app-2", "node-2", "", nil, false, 0),
 				},
 			},
-			want: "node: node-1, alloc: alloc-1, success: true, index: 2, victims: [allocationKey alloc-key-1, applicationID app-1, Resource map[], Allocated true, allocationKey alloc-key-2, applicationID app-2, Resource map[], Allocated true]",
+			want: "node: node-1, alloc: alloc-1, success: true, index: 2, victims: [allocationKey alloc-key-1, applicationID app-1, allocationKey alloc-key-2, applicationID app-2]",
 		},
 	}
 

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -2021,10 +2021,10 @@ func (sq *Queue) removeMetrics() {
 }
 
 func (sq *Queue) String() string {
-	sq.RLock()
-	defer sq.RUnlock()
-	return fmt.Sprintf("{QueuePath: %s, State: %s, StateTime: %x, MaxResource: %s}",
-		sq.QueuePath, sq.stateMachine.Current(), sq.stateTime, sq.maxResource)
+	if sq == nil {
+		return "queue is nil"
+	}
+	return fmt.Sprintf("{QueuePath: %s, State: %s}", sq.QueuePath, sq.stateMachine.Current())
 }
 
 // incRunningApps increments the number of running applications for this queue (recursively).

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -45,6 +45,15 @@ import (
 )
 
 // base test for creating a managed queue
+func TestQueueStringSelfLocked(t *testing.T) {
+	root, err := createRootQueue(nil)
+	assert.NilError(t, err, "failed to create root queue")
+	root.Lock()
+	defer root.Unlock()
+	s := root.String()
+	assert.Equal(t, s, "{QueuePath: root, State: Active}")
+}
+
 func TestMergeParentPropertiesNilParent(t *testing.T) {
 	// root queue has no parent
 	root, err := createRootQueue(nil)


### PR DESCRIPTION
### Description
Four `String()` methods (`TrackedResource.String`, `Allocation.String`, `Application.String`, and `Queue.String`) transitively acquired read locks (`RLock`) on the object being formatted. Because `fmt` and `zap` evaluate a `Stringer` when building log lines, logging an object while holding its write lock (`Lock()`) would cause the calling goroutine to self-deadlock on `locking.RWMutex`.

This PR remove the self-deadlock trap:
- `TrackedResource.String`: Removed internal `tr.RLock()`.
- `Allocation.String`: Removed calls to `GetAllocatedResource()`/`IsAllocated()`.
- `Application.String`: Only prints immutable fields (`ApplicationID`, `Partition`) and `State` (`sa.stateMachine.Current()`), dropping lock-protected `submissionTime`.
- `Queue.String`: Only prints immutable `QueuePath` and `State`, removing `sq.RLock()` and dynamic resource formatting.

- `pkg/locking/locking_test.go`: Fixed flaky `time.Sleep` with `sync.WaitGroup` in `TestMutex` and `TestRWMutex`.

### Type of change
Please delete options that are not relevant.

- [ ] Bug Fix
- [x] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3420

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [x] `make test_all` was run, and no failures reported.
- [x] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
