### PR TITLE
[YUNIKORN-3436] Fix event stream forwarder goroutine leak on slow-consumer eviction

### DIFF
--- a/pkg/events/event_streaming.go
+++ b/pkg/events/event_streaming.go
@@ -124,7 +124,15 @@ func (e *EventStreaming) CreateEventStream(name string, count uint64) *EventStre
 				// since events are processed in a single goroutine, doubling is no longer
 				// possible at this point
 				seen = make(map[*si.EventRecord]bool)
-				consumer <- event
+				select {
+				case consumer <- event:
+				case <-e.stopCh:
+					close(consumer)
+					return
+				case <-stop:
+					close(consumer)
+					return
+				}
 			}
 		}
 	}(consumer, local, stop)


### PR DESCRIPTION
### Description
Sibling of YUNIKORN-3364. The forwarder goroutine in `EventStreaming.CreateEventStream` had a bare blocking send (`consumer <- event`) in its live event loop. When a client falls behind and its `consumer` buffer becomes full (1000 events), the forwarder parks on this send and cannot reach the outer `select`. If the stream is evicted due to a full `local` buffer or the client disconnects, neither `stop` nor `e.stopCh` can be observed, causing the forwarder goroutine and its buffers to leak indefinitely.                                                    
                                                                                                                                                                                              
Wrap the in-loop `consumer <- event` in a `select` block with `stop` and `e.stopCh` cases to ensure the forwarder observes stop signals and exits cleanly.


### Type of change
Please delete options that are not relevant.

- [X] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3436

- [ ] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity CLI", where Antigravity CLI is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
NA