### PR TITLE
[YUNIKORN-3440] Use https instead of http in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,18 @@ shim layer and adopt to different ResourceManager implementation including Apach
 
 ## Get Started
 
-See how to get started with running YuniKorn on Kubernetes, please read the documentation on [yunikorn.apache.org](http://yunikorn.apache.org/docs/).
+See how to get started with running YuniKorn on Kubernetes, please read the documentation on [yunikorn.apache.org](https://yunikorn.apache.org/docs/).
 
 Want to know more about the value of the YuniKorn project, and what YuniKorn can do? Here are some
 [session recordings and demos](https://yunikorn.apache.org/community/events#past-conference--meetup-recordings).
 
 ## Get Involved
 
-Please read [get involved](http://yunikorn.apache.org/community/get_involved) document if you want to discuss issues,
+Please read [get involved](https://yunikorn.apache.org/community/get_involved) document if you want to discuss issues,
 contribute your ideas, explore use cases, or participate the development.
 
-If you want to contribute code to this repo, please read the [developer doc](http://yunikorn.apache.org/docs/next/developer_guide/build).
-All the design docs are available [here](http://yunikorn.apache.org/docs/next/design/architecture).
+If you want to contribute code to this repo, please read the [developer doc](https://yunikorn.apache.org/docs/next/developer_guide/build).
+All the design docs are available [here](https://yunikorn.apache.org/docs/next/design/architecture).
 
 ## Code Structure
 
@@ -55,7 +55,7 @@ Apache YuniKorn project has the following git repositories:
 - [yunikorn-scheduler-interface](https://github.com/apache/yunikorn-scheduler-interface) : the common scheduling interface
 - [yunikorn-web](https://github.com/apache/yunikorn-web) : the web UI
 - [yunikorn-release](https://github.com/apache/yunikorn-release/): the repo manages yunikorn releases, including the helm charts
-- [yunikorn-site](https://github.com/apache/yunikorn-site/): the source code for [yunikorn website](http://yunikorn.apache.org/)
+- [yunikorn-site](https://github.com/apache/yunikorn-site/): the source code for [yunikorn website](https://yunikorn.apache.org/)
 
 The `yunikorn-core` is the brain of the scheduler, which makes placement decisions (allocate container X on node Y) according
 to the builtin rich scheduling policies. Scheduler core implementation is agnostic to the underneath resource manager system.


### PR DESCRIPTION
### Description
Update the links in the README to use https instead of http.

Generated by Claude ( commit message and PR description wording; the file changes were made and verified by me)


### Type of change
- [x] Improvement

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3440

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [ ] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

Documentation-only change; no code paths affected. All updated links were verified to resolve over https.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A