### PR TITLE
[YUNIKORN-3409] Fix concurrent map read and write on rejectedApplications

### DIFF
--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1111,9 +1111,7 @@ func (pc *PartitionContext) GetRejectedApplications() []*objects.Application {
 	return appList
 }
 
-func (pc *PartitionContext) getAppsState(appMap map[string]*objects.Application, state string) []string {
-	pc.RLock()
-	defer pc.RUnlock()
+func (pc *PartitionContext) getAppsStateInternal(appMap map[string]*objects.Application, state string) []string {
 	var apps []string
 	for appID, app := range appMap {
 		if app.CurrentState() == state {
@@ -1126,17 +1124,23 @@ func (pc *PartitionContext) getAppsState(appMap map[string]*objects.Application,
 // getAppsByState returns a slice of applicationIDs for the current applications filtered by state
 // Completed and Rejected applications are tracked in a separate map and will never be included.
 func (pc *PartitionContext) getAppsByState(state string) []string {
-	return pc.getAppsState(pc.applications, state)
+	pc.RLock()
+	defer pc.RUnlock()
+	return pc.getAppsStateInternal(pc.applications, state)
 }
 
 // getRejectedAppsByState returns a slice of applicationIDs for the rejected applications filtered by state.
 func (pc *PartitionContext) getRejectedAppsByState(state string) []string {
-	return pc.getAppsState(pc.rejectedApplications, state)
+	pc.RLock()
+	defer pc.RUnlock()
+	return pc.getAppsStateInternal(pc.rejectedApplications, state)
 }
 
 // getCompletedAppsByState returns a slice of applicationIDs for the completed applicationIDs filtered by state.
 func (pc *PartitionContext) getCompletedAppsByState(state string) []string {
-	return pc.getAppsState(pc.completedApplications, state)
+	pc.RLock()
+	defer pc.RUnlock()
+	return pc.getAppsStateInternal(pc.completedApplications, state)
 }
 
 // cleanupExpiredApps cleans up applications in the Expired state from the three tracking maps
@@ -1763,6 +1767,8 @@ func (pc *PartitionContext) AddRejectedApplication(rejectedApplication *objects.
 			zap.String("currentState", rejectedApplication.CurrentState()),
 			zap.Error(err))
 	}
+	pc.Lock()
+	defer pc.Unlock()
 	if pc.rejectedApplications == nil {
 		pc.rejectedApplications = make(map[string]*objects.Application)
 	}

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2922,6 +2923,123 @@ func TestCleanupRejectedApps(t *testing.T) {
 	assert.Equal(t, 0, len(partition.rejectedApplications), "the partition should not have app")
 	assert.Assert(t, partition.getRejectedApplication(rejectedApp.ApplicationID) == nil, "rejected application should have been deleted")
 	assert.Equal(t, 0, len(partition.getRejectedAppsByState(objects.Expired.String())), "the partition should have 0 expired app")
+}
+
+func TestAddRejectedApplicationConcurrent(t *testing.T) {
+	partition, err := newBasePartition()
+	assert.NilError(t, err, "partition create failed")
+	defer partition.userGroupCache.Stop()
+
+	var wg sync.WaitGroup
+	numGoroutines := 20
+	appsPerGoroutine := 10
+	start := make(chan struct{})
+
+	// Concurrent Writers
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			<-start
+			for j := 0; j < appsPerGoroutine; j++ {
+				appID := fmt.Sprintf("app-%d-%d", workerID, j)
+				app := newApplication(appID, "default", defQueue)
+				partition.AddRejectedApplication(app, "rejected reason")
+			}
+		}(i)
+	}
+
+	// Concurrent Readers
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			<-start
+			for j := 0; j < appsPerGoroutine; j++ {
+				_ = partition.GetRejectedApplications()
+				appID := fmt.Sprintf("app-%d-%d", workerID, j)
+				_ = partition.getRejectedApplication(appID)
+				_ = partition.getRejectedAppsByState(objects.Rejected.String())
+			}
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+	assert.Equal(t, numGoroutines*appsPerGoroutine, len(partition.GetRejectedApplications()), "all rejected applications should be tracked")
+}
+
+func TestAddRejectedApplicationConcurrentWithCleanup(t *testing.T) {
+	partition, err := newBasePartition()
+	assert.NilError(t, err, "partition create failed")
+	defer partition.userGroupCache.Stop()
+
+	var wg sync.WaitGroup
+	numGoroutines := 20
+	appsPerGoroutine := 10
+	start := make(chan struct{})
+
+	// Concurrent Writers
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			<-start
+			for j := 0; j < appsPerGoroutine; j++ {
+				appID := fmt.Sprintf("cleanup-app-%d-%d", workerID, j)
+				app := newApplication(appID, "default", defQueue)
+				partition.AddRejectedApplication(app, "rejected reason")
+				if j%2 == 0 {
+					app.SetState(objects.Expired.String())
+				}
+			}
+		}(i)
+	}
+
+	// Concurrent Cleaners and Readers
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < appsPerGoroutine; j++ {
+				partition.cleanupExpiredApps()
+				_ = partition.GetRejectedApplications()
+				_ = partition.getRejectedAppsByState(objects.Expired.String())
+				_ = partition.getRejectedAppsByState(objects.Rejected.String())
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	partition.cleanupExpiredApps()
+	assert.Equal(t, 0, len(partition.getRejectedAppsByState(objects.Expired.String())), "no expired apps should remain after cleanup")
+}
+
+func TestAddRejectedApplicationDuplicate(t *testing.T) {
+	partition, err := newBasePartition()
+	assert.NilError(t, err, "partition create failed")
+	defer partition.userGroupCache.Stop()
+
+	var wg sync.WaitGroup
+	numGoroutines := 20
+	appID := "duplicate-app"
+	start := make(chan struct{})
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			app := newApplication(appID, "default", defQueue)
+			partition.AddRejectedApplication(app, "duplicate rejected reason")
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	assert.Equal(t, 1, len(partition.GetRejectedApplications()), "duplicate rejected app should only have 1 entry")
 }
 
 func TestUpdateNode(t *testing.T) {


### PR DESCRIPTION
### Description
Fixes potential `fatal error: concurrent map read and map write` panics and data races on `PartitionContext.rejectedApplications`:
1. `AddRejectedApplication` previously created and mutated `pc.rejectedApplications` with no lock, causing concurrent map write races with REST readers and background cleanup loops.
2. `getRejectedAppsByState` previously read the `pc.rejectedApplications` map pointer outside `pc.RLock()`.

This PR:
- Acquires `pc.Lock()` / `pc.Unlock()` in `AddRejectedApplication` around map creation and insertion, keeping `rejectedApplication.RejectApplication()` outside the lock to prevent lock order inversion.
- Acquires `pc.RLock()` / `pc.RUnlock()` in `getRejectedAppsByState` before resolving the `pc.rejectedApplications` field.
- Adds comprehensive concurrent unit tests using a start gate barrier covering concurrent writes, concurrent reads, background cleanup deletes, and duplicate rejections.

### Type of change
- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3409

- [ ] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by Antigravity", where Antigravity is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths (`TestAddRejectedApplicationConcurrent`, `TestAddRejectedApplicationConcurrentWithCleanup`, `TestAddRejectedApplicationDuplicate`).
- [x] Full test suite run under `-race` and `-tags deadlock` (`go test ./... -p 1 -race -tags deadlock`), 100% passed.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
*Generated by hedger9487 with assistance from Antigravity.*