### PR TITLE
[YUNIKORN-3410] Fix self-deadlock on ClusterContext lock during partition removal

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -313,18 +313,13 @@ func (cc *ClusterContext) processNodes(request *si.NodeRequest) {
 func (cc *ClusterContext) removePartitionsByRMID(event *rmevent.RMPartitionsRemoveEvent) {
 	cc.Lock()
 	defer cc.Unlock()
-	partitionToRemove := make(map[string]bool)
 
 	// Just remove corresponding partitions
-	for k, partition := range cc.partitions {
-		if partition.RmID == event.RmID {
-			partition.partitionManager.Stop()
-			partitionToRemove[k] = true
+	for _, part := range cc.partitions {
+		if part.RmID == event.RmID {
+			part.partitionManager.Stop()
+			delete(cc.partitions, part.Name)
 		}
-	}
-
-	for partitionName := range partitionToRemove {
-		delete(cc.partitions, partitionName)
 	}
 	// Done, notify channel
 	event.Channel <- &rmevent.Result{
@@ -399,6 +394,7 @@ func (cc *ClusterContext) updateSchedulerConfig(conf *configs.SchedulerConfig, r
 	for _, part := range cc.partitions {
 		if !visited[part.Name] {
 			part.partitionManager.Stop()
+			delete(cc.partitions, part.Name)
 			log.Log(log.SchedContext).Info("marked partition for removal",
 				zap.String("partitionName", part.Name))
 		}
@@ -583,14 +579,6 @@ func (cc *ClusterContext) NeedPreemption() bool {
 	defer cc.RUnlock()
 
 	return cc.needPreemption
-}
-
-// Callback from the partition manager to finalise the removal of the partition
-func (cc *ClusterContext) removePartition(partitionName string) {
-	cc.Lock()
-	defer cc.Unlock()
-
-	delete(cc.partitions, partitionName)
 }
 
 // addNode adds a new node to the cluster enforcing just one unlimited node in the cluster.

--- a/pkg/scheduler/context_test.go
+++ b/pkg/scheduler/context_test.go
@@ -445,3 +445,103 @@ outer:
 
 	assert.Assert(t, checked, "Failed to find metric")
 }
+
+func TestContext_RemovePartition(t *testing.T) {
+	context := &ClusterContext{
+		partitions:     map[string]*PartitionContext{},
+		rmEventHandler: newMockEventHandler(),
+	}
+	defer context.Stop()
+
+	// Initial config with two partitions: default and gpu
+	configTwoPartitions := `
+partitions:
+  - name: default
+    queues:
+      - name: root
+        submitacl: '*'
+        queues:
+          - name: default
+            submitacl: '*'
+  - name: gpu
+    queues:
+      - name: root
+        submitacl: '*'
+        queues:
+          - name: default
+            submitacl: '*'
+`
+	conf1, err := configs.LoadSchedulerConfigFromByteArray([]byte(configTwoPartitions))
+	assert.NilError(t, err)
+
+	context.Lock()
+	err = context.updateSchedulerConfig(conf1, "rm:123")
+	assert.NilError(t, err)
+	context.Unlock()
+
+	assert.Equal(t, 2, len(context.GetPartitionMapClone()))
+	gpuPart := context.GetPartition("[rm:123]gpu")
+	assert.Assert(t, gpuPart != nil)
+
+	// Add node to gpu partition
+	nodeInfo := &si.NodeInfo{
+		NodeID: "node-gpu-1",
+		Action: si.NodeInfo_CREATE,
+		Attributes: map[string]string{
+			siCommon.NodePartition: "[rm:123]gpu",
+		},
+		SchedulableResource: &si.Resource{Resources: map[string]*si.Quantity{"first": {Value: 10}}},
+	}
+	err = context.addNode(nodeInfo, true)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(gpuPart.GetNodes()))
+
+	// Add app to gpu partition
+	app := newApplication("app-gpu-1", "[rm:123]gpu", "root.default")
+	err = gpuPart.AddApplication(app)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(gpuPart.GetApplications()))
+
+	// 1. Remove partition via updateSchedulerConfig
+	t.Run("remove via updateSchedulerConfig", func(t *testing.T) {
+		configOnePartition := `
+partitions:
+  - name: default
+    queues:
+      - name: root
+        submitacl: '*'
+        queues:
+          - name: default
+            submitacl: '*'
+`
+		conf2, err := configs.LoadSchedulerConfigFromByteArray([]byte(configOnePartition))
+		assert.NilError(t, err)
+
+		context.Lock()
+		err = context.updateSchedulerConfig(conf2, "rm:123")
+		assert.NilError(t, err)
+		context.Unlock()
+
+		// Verify gpu partition is removed and app was failed
+		partitions := context.GetPartitionMapClone()
+		assert.Equal(t, 1, len(partitions))
+		_, ok := partitions["[rm:123]default"]
+		assert.Assert(t, ok, "default partition should still exist")
+		_, ok = partitions["[rm:123]gpu"]
+		assert.Assert(t, !ok, "gpu partition should have been removed")
+		assert.Assert(t, app.IsFailing() || app.IsFailed(), "app should be marked as failed/failing upon partition removal")
+	})
+
+	// 2. Remove remaining partition via removePartitionsByRMID
+	t.Run("remove via removePartitionsByRMID", func(t *testing.T) {
+		c := make(chan *rmevent.Result, 1)
+		context.removePartitionsByRMID(&rmevent.RMPartitionsRemoveEvent{
+			RmID:    "rm:123",
+			Channel: c,
+		})
+
+		result := <-c
+		assert.Assert(t, result.Succeeded)
+		assert.Equal(t, 0, len(context.GetPartitionMapClone()))
+	})
+}

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -300,7 +300,9 @@ func (pc *PartitionContext) isStopped() bool {
 func (pc *PartitionContext) handlePartitionEvent(event objects.ObjectEvent) error {
 	err := pc.stateMachine.Event(context.Background(), event.String(), pc.Name)
 	if err == nil {
+		pc.Lock()
 		pc.stateTime = time.Now()
+		pc.Unlock()
 		return nil
 	}
 	// handle the same state transition not nil error (limit of fsm).

--- a/pkg/scheduler/partition_manager.go
+++ b/pkg/scheduler/partition_manager.go
@@ -164,8 +164,6 @@ func (manager *partitionManager) remove() {
 	}
 	log.Log(log.SchedPartition).Info("removing partition",
 		zap.String("partitionName", manager.pc.Name))
-	// remove the scheduler object
-	manager.cc.removePartition(manager.pc.Name)
 }
 
 func (manager *partitionManager) cleanExpiredApps() {


### PR DESCRIPTION
### Description
Fixes a self-deadlock on the `ClusterContext` write lock during partition removal:
1. During a configuration reload that drops or renames a partition (`updateSchedulerConfig`), and during RM partition removal events (`removePartitionsByRMID`), the caller stops the partition manager while holding the `ClusterContext` write lock (`cc.Lock()`).
2. `partitionManager.Stop()` calls `manager.remove()` synchronously (since YUNIKORN-2233). In the previous code, `manager.remove()` ended with `manager.cc.removePartition(name)`, which attempted to acquire the non-reentrant `cc.Lock()` again, resulting in an immediate self-deadlock that hung the scheduling loop, REST endpoints, and RM callbacks.

This PR:
- Drops the `manager.cc.removePartition()` call from `partitionManager.remove()`, keeping `remove()` focused solely on cleaning up internal partition resources (queues, applications, nodes).
- Removes the unused private `removePartition()` callback from `ClusterContext`.
- In `updateSchedulerConfig()` and `removePartitionsByRMID()`, deletes removed partitions directly from `cc.partitions` during iteration under the already-held `cc.Lock()`, eliminating intermediate slice/map allocations (per maintainer feedback).
- Wraps the `pc.stateTime` write in `handlePartitionEvent()` with `pc.Lock()` / `pc.Unlock()` to eliminate potential unprotected concurrent writes.
- Adds `TestContext_RemovePartition` in `context_test.go` covering config reload partition removal, RM partition removal events, and active partition removal with running applications and nodes without duplicate fixtures.

### Type of change
- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3410

- [ ] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by Antigravity", where Antigravity is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] Deadlock reproduction and active application/node cleanup verified in `TestContext_RemovePartition`.
- [x] Full test suite run under `-race` (`go test -race ./pkg/scheduler/...`), 100% passed.
- [x] Local linter passed with 0 issues in modified files (`golangci-lint run pkg/scheduler/...`).
- [x] Full repository regression suite (`go test ./...`), 100% passed with zero regressions.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
*Generated by hedger9487 with assistance from Antigravity.*