### PR TITLE
[YUNIKORN-3358] Remove the unreachable replace-existing-ask branch

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -647,8 +647,9 @@ func (sa *Application) removeAsksInternal(allocKey string, detail si.EventRecord
 	return toRelease
 }
 
-// Add an allocation ask to this application
-// If the ask already exist update the existing info
+// Add an allocation ask to this application.
+// An ask under a key the application already holds is rejected: see addAllocationAskInternal for
+// the single adder invariant that requires it.
 func (sa *Application) AddAllocationAsk(ask *Allocation) error {
 	sa.Lock()
 	defer sa.Unlock()
@@ -658,18 +659,13 @@ func (sa *Application) AddAllocationAsk(ask *Allocation) error {
 	if ask.IsAllocated() || resources.IsZero(ask.GetAllocatedResource()) {
 		return fmt.Errorf("invalid ask added to app %s: %v", sa.ApplicationID, ask)
 	}
+	if _, tracked := sa.requests[ask.GetAllocationKey()]; tracked {
+		return fmt.Errorf("ask %s is already tracked on app %s", ask.GetAllocationKey(), sa.ApplicationID)
+	}
 	if ask.createTime.Before(sa.submissionTime) {
 		sa.submissionTime = ask.createTime
 	}
 	delta := ask.GetAllocatedResource().Clone()
-
-	var oldAskResource *resources.Resource = nil
-	if oldAsk := sa.requests[ask.GetAllocationKey()]; oldAsk != nil && !oldAsk.IsAllocated() {
-		oldAskResource = oldAsk.GetAllocatedResource().Clone()
-		// the old ask was pending and is being replaced: drop it from the priority histogram so the
-		// new ask's addAllocationAskInternal (via addToPriorities) nets correctly.
-		sa.removeFromPriorities(oldAsk.GetPriority())
-	}
 
 	// Check if we need to change state based on the ask added, there are two cases:
 	// 1) first ask added on a new app: state is New
@@ -685,7 +681,6 @@ func (sa *Application) AddAllocationAsk(ask *Allocation) error {
 	sa.addAllocationAskInternal(ask)
 
 	// Update total pending resource
-	delta.SubFrom(oldAskResource)
 	sa.pending = resources.Add(sa.pending, delta)
 	sa.pending.Prune()
 	sa.queue.incPendingResource(delta)
@@ -839,6 +834,18 @@ func (sa *Application) setAskMaxPriority(v int32) {
 	sa.queue.UpdateApplicationPriority(sa.ApplicationID, v)
 }
 
+// addAllocationAskInternal is the only place an ask enters sa.requests. Call with sa.Lock() held.
+//
+// Single adder invariant: the key must not be tracked yet. Every write around the map write below
+// is applied blind - the priority histogram and the placeholder count here, sa.pending and the
+// sortedRequests insert in AddAllocationAsk - so a second add for a live key would count it twice
+// in each of them and strand the ask it displaced in sortedRequests, which only ever drops the
+// first entry matching a key. Both entry points (AddAllocationAsk and RecoverAllocationAsk) are
+// reached from PartitionContext.UpdateAllocation only after it has found GetAllocationAsk nil for
+// the key, and those calls all run on the single goroutine draining pendingAllocEvents
+// (Scheduler.handleAllocEvent), so nothing can insert the key between that check and this call.
+// AddAllocationAsk rejects a tracked key rather than resting on that argument; RecoverAllocationAsk
+// returns nothing and so has no way to refuse.
 func (sa *Application) addAllocationAskInternal(ask *Allocation) {
 	sa.requests[ask.GetAllocationKey()] = ask
 

--- a/pkg/scheduler/objects/application_property_test.go
+++ b/pkg/scheduler/objects/application_property_test.go
@@ -43,10 +43,12 @@ import (
 //
 // The point is coverage of state combinations rather than of entry points: TestMaxAskPriority pins
 // the handful of transitions that are easy to reason about by hand, while this test reaches the
-// interleavings that are not - a replaced ask whose priority differs from the one it displaces, an
-// attempted rollback of an allocation whose ask has already been dropped, an allocate that empties
-// the top priority bucket while lower buckets still hold pending asks. Those are precisely the cases
-// where incremental bookkeeping and a full rescan can disagree.
+// interleavings that are not - an attempted rollback of an allocation whose ask has already been
+// dropped, a deallocate that puts a key back at a priority no other pending ask holds, an allocate
+// that empties the top priority bucket while lower buckets still hold pending asks. Those are
+// precisely the cases where incremental bookkeeping and a full rescan can disagree. It also holds
+// AddAllocationAsk to the single adder rule the bookkeeping rests on, by feeding it keys the
+// application already tracks and requiring every one of them to be refused.
 func TestApplicationPropertyFuzzHistogram(t *testing.T) {
 	// A "ghost" rollback attempt (case 7 picking a confirmed allocation whose ask sa.requests no
 	// longer holds) first needs a specific remove-then-release interleaving, but once one exists the
@@ -138,12 +140,13 @@ func runPropertyFuzz(t *testing.T, seed int64) int { //nolint:funlen
 	// ghostRollbackAttempts counts the case 7 calls that targeted an ask sa.requests no longer holds;
 	// those never succeed (the YUNIKORN-3360 guard rejects them) so attempts, not successes, are what
 	// there is to count - each one is individually asserted rejected in case 7, which is what makes
-	// the count proof that the guard was exercised. replacedAsks counts the AddAllocationAsk calls
-	// that took the replace-existing-ask branch (case 8). Both are narrow branches that a small change
-	// to the candidate filters could stop reaching entirely, so both are asserted - replacedAsks per
-	// run at the end of this function, ghostRollbackAttempts over the whole seed set by the caller.
+	// the count proof that the guard was exercised. rejectedDuplicateAdds counts the case 8 adds that
+	// AddAllocationAsk turned away under the single adder rule. Both are narrow branches that a small
+	// change to the candidate filters could stop reaching entirely, so both are asserted -
+	// rejectedDuplicateAdds per run at the end of this function, ghostRollbackAttempts over the whole
+	// seed set by the caller.
 	ghostRollbackAttempts := 0
-	replacedAsks := 0
+	rejectedDuplicateAdds := 0
 
 	const steps = 5000
 	for i := 0; i < steps; i++ {
@@ -162,8 +165,10 @@ func runPropertyFuzz(t *testing.T, seed int64) int { //nolint:funlen
 			}
 			addErr := app.AddAllocationAsk(ask)
 			if addErr == nil {
-				// unique keys every time, so this operation always takes the "brand new ask" path
-				// through AddAllocationAsk; the replace-existing-ask branch is driven by case 8.
+				// A fresh key every time, which is the only shape production can produce:
+				// PartitionContext.UpdateAllocation only reaches AddAllocationAsk once
+				// GetAllocationAsk has come back nil for the key. Case 8 covers the other side of
+				// that rule, an add under a key the application already holds.
 				keyPriority[key] = priority
 				pendingKeys[key] = true
 			}
@@ -356,27 +361,31 @@ func runPropertyFuzz(t *testing.T, seed int64) int { //nolint:funlen
 				}
 			}
 
-		case 8: // AddAllocationAsk re-using an existing key - the replace-existing-ask branch
-			// AddAllocationAsk (application.go ~line 668) handles a key that is already in
-			// sa.requests and still pending separately: it has to unwind the old ask from the
-			// pending histogram before addAllocationAskInternal counts the replacement, or the key
-			// is counted twice and its old priority never drops out again. Case 0 only ever mints
-			// fresh keys, so without this operation that branch is never executed here at all.
-			if len(pendingKeys) > 0 {
-				key := pickRandomKey(rng, pendingKeys)
+		case 8: // AddAllocationAsk under a key the application already holds
+			// The single adder invariant addAllocationAskInternal documents is what lets every write
+			// around the insert be applied blind, so the add has to be turned away and the rejection
+			// has to be a true no-op. Candidates come from keyPriority rather than pendingKeys so
+			// allocated and recovered keys are covered too - the rule is about the key being tracked
+			// at all, not about it being pending - and the duplicate keeps the placeholder shape of
+			// the ask it collides with, because addPlaceholderData is one of the blind writes.
+			if key, ok := pickRandomExistingKey(rng, keyPriority); ok {
 				existing := app.GetAllocationAsk(key)
-				assert.Assert(t, existing != nil, "seed=%d step=%d: pending key %s missing from sa.requests", seed, i, key)
+				assert.Assert(t, existing != nil, "seed=%d step=%d: tracked key %s missing from sa.requests", seed, i, key)
+				taskGroup := existing.GetTaskGroup()
 				priority := int32(rng.Intn(11) - 5) //nolint:gosec // bounded to -5..5, no overflow
 				nextCreationTime++
-				// keep the placeholder/task-group shape of the ask being replaced: production
-				// re-sends the same pod's ask, it never turns a placeholder into a regular ask.
-				replacement := newFuzzAsk(key, appID, existing.GetTaskGroup(), res, existing.IsPlaceholder(), priority, "", nextCreationTime)
-				if replaceErr := app.AddAllocationAsk(replacement); replaceErr == nil {
-					// the replacement carries its OWN priority: the key stays pending but the model
-					// must account for it at the new priority from here on.
-					keyPriority[key] = priority
-					replacedAsks++
-				}
+				duplicate := newFuzzAsk(key, appID, taskGroup, res, existing.IsPlaceholder(), priority, "", nextCreationTime)
+
+				pendingBefore, sortedBefore, phBefore := snapshotAddState(app, taskGroup)
+				addErr := app.AddAllocationAsk(duplicate)
+				assert.Assert(t, addErr != nil, "seed=%d step=%d: duplicate add of %s was not rejected", seed, i, key)
+				pendingAfter, sortedAfter, phAfter := snapshotAddState(app, taskGroup)
+
+				assert.Assert(t, app.GetAllocationAsk(key) == existing, "seed=%d step=%d: rejected duplicate add of %s replaced the tracked ask", seed, i, key)
+				assert.Assert(t, resources.Equals(pendingAfter, pendingBefore), "seed=%d step=%d: rejected duplicate add of %s changed pending from %s to %s", seed, i, key, pendingBefore, pendingAfter)
+				assert.Equal(t, sortedAfter, sortedBefore, "seed=%d step=%d: rejected duplicate add of %s changed len(sortedRequests)", seed, i, key)
+				assert.Equal(t, phAfter, phBefore, "seed=%d step=%d: rejected duplicate add of %s changed the placeholder count for %s", seed, i, key, taskGroup)
+				rejectedDuplicateAdds++
 			}
 		}
 
@@ -397,7 +406,7 @@ func runPropertyFuzz(t *testing.T, seed int64) int { //nolint:funlen
 	// operation to be rejected/no-op'd): confirm it actually drove the application through
 	// non-trivial pending/allocated/multi-priority states, so a real regression in the product's
 	// bookkeeping (e.g. removeFromPriorities) has states to be caught in.
-	t.Logf("seed=%d coverage: maxPending=%d maxAllocated=%d maxDistinctPendingPriorities=%d successfulRollbacks=%d ghostRollbackAttempts=%d replacedAsks=%d", seed, maxPending, maxAllocated, maxDistinctPendingPriorities, successfulRollbacks, ghostRollbackAttempts, replacedAsks)
+	t.Logf("seed=%d coverage: maxPending=%d maxAllocated=%d maxDistinctPendingPriorities=%d successfulRollbacks=%d ghostRollbackAttempts=%d rejectedDuplicateAdds=%d", seed, maxPending, maxAllocated, maxDistinctPendingPriorities, successfulRollbacks, ghostRollbackAttempts, rejectedDuplicateAdds)
 	assert.Assert(t, maxPending > 0, "seed=%d: fuzz run never observed any pending asks", seed)
 	assert.Assert(t, maxAllocated > 0, "seed=%d: fuzz run never observed any allocated asks", seed)
 	assert.Assert(t, maxDistinctPendingPriorities > 1, "seed=%d: fuzz run never observed a multi-priority pending histogram", seed)
@@ -406,13 +415,12 @@ func runPropertyFuzz(t *testing.T, seed int64) int { //nolint:funlen
 	// allocations) would silently turn case 7 into a no-op and stop covering deallocateAsk's new
 	// caller entirely, while every assertion above kept passing.
 	assert.Assert(t, successfulRollbacks > 0, "seed=%d: fuzz run never completed a RollbackAllocation", seed)
-	// The replace-existing-ask branch (case 8) must not double count the key in the histogram. It is
-	// only reached while pendingKeys is non-empty, so assert it really happened rather than trusting
-	// that condition to keep holding. The ghost-rollback-attempt count is returned instead of asserted
-	// here: whether a run reaches that state at all depends on the interleaving it happens to produce,
-	// so the coverage floor for it is asserted over the whole seed set by
+	// Case 8 only fires while the application still tracks a key, so assert it really happened rather
+	// than trusting that condition to keep holding. The ghost-rollback-attempt count is returned
+	// instead of asserted here: whether a run reaches that state at all depends on the interleaving
+	// it happens to produce, so the coverage floor for it is asserted over the whole seed set by
 	// TestApplicationPropertyFuzzHistogram.
-	assert.Assert(t, replacedAsks > 0, "seed=%d: fuzz run never took the replace-existing-ask branch", seed)
+	assert.Assert(t, rejectedDuplicateAdds > 0, "seed=%d: fuzz run never attempted a duplicate add", seed)
 
 	return ghostRollbackAttempts
 }
@@ -488,6 +496,20 @@ func pickRandomExistingKey(rng *rand.Rand, keyPriority map[string]int32) (string
 	// - this was the residual nondeterminism source alongside pickRandomKey above.
 	sort.Strings(list)
 	return list[rng.Intn(len(list))], true
+}
+
+// snapshotAddState returns the three things AddAllocationAsk writes that the fuzzer's reference
+// model does not carry - the pending resource, the length of sortedRequests and taskGroup's
+// placeholder count - so that a rejected add can be held to being the no-op it has to be.
+// assertFuzzInvariants covers the histogram and askMaxPriority.
+func snapshotAddState(app *Application, taskGroup string) (*resources.Resource, int, int64) {
+	app.RLock()
+	defer app.RUnlock()
+	var placeholders int64
+	if pd := app.placeholderData[taskGroup]; pd != nil {
+		placeholders = pd.Count
+	}
+	return app.pending.Clone(), len(app.sortedRequests), placeholders
 }
 
 // assertFuzzInvariants rebuilds the expected pending-ask histogram and max from the reference model

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -462,7 +462,7 @@ func TestAddAllocAsk(t *testing.T) {
 	res = resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})
 	ask = newAllocationAsk(aKey, appID1, res)
 	err = app.AddAllocationAsk(ask)
-	assert.NilError(t, err, "ask should have been updated on app")
+	assert.NilError(t, err, "ask should have been added to app")
 	assert.Assert(t, app.IsAccepted(), "Application should be in accepted state")
 	pending := app.GetPendingResource()
 	if !resources.Equals(res, pending) {
@@ -489,10 +489,10 @@ func TestAddAllocAsk(t *testing.T) {
 	assert.Equal(t, si.EventRecord_APP_REQUEST, record.EventChangeDetail, "incorrect change detail, expected app request")
 	eventSystem.Stop()
 
-	// change resource
-	ask = newAllocationAsk(aKey, appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10}))
+	// a second ask adds to the pending total
+	ask = newAllocationAsk(aKey2, appID1, res)
 	err = app.AddAllocationAsk(ask)
-	assert.NilError(t, err, "ask should have been updated on app")
+	assert.NilError(t, err, "ask should have been added to app")
 	pending = app.GetPendingResource()
 	if !resources.Equals(resources.Multiply(res, 2), app.GetPendingResource()) {
 		t.Errorf("pending resource not updated correctly, expected %v but was: %v", resources.Multiply(res, 2), pending)
@@ -502,9 +502,9 @@ func TestAddAllocAsk(t *testing.T) {
 	assert.Assert(t, app.IsAccepted(), "Application should have stayed in accepted state")
 
 	// test PlaceholderData
-	ask = newAllocationAskTG(aKey, appID1, tg1, res)
+	ask = newAllocationAskTG(aKey3, appID1, tg1, res)
 	err = app.AddAllocationAsk(ask)
-	assert.NilError(t, err, "ask should have been updated on app")
+	assert.NilError(t, err, "ask should have been added to app")
 	app.SetTimedOutPlaceholder(tg1, 1)
 	app.SetTimedOutPlaceholder(tg2, 2)
 	clonePlaceholderData := app.GetAllPlaceholderData()
@@ -513,15 +513,15 @@ func TestAddAllocAsk(t *testing.T) {
 	assert.Equal(t, clonePlaceholderData[0], app.placeholderData[tg1])
 	assertPlaceholderData(t, app, tg1, 1, 1, 0, res)
 
-	ask = newAllocationAskTG(aKey, appID1, tg1, res)
+	ask = newAllocationAskTG(aKey4, appID1, tg1, res)
 	err = app.AddAllocationAsk(ask)
-	assert.NilError(t, err, "ask should have been updated on app")
+	assert.NilError(t, err, "ask should have been added to app")
 	assert.Equal(t, len(app.placeholderData), 1)
 	assertPlaceholderData(t, app, tg1, 2, 1, 0, res)
 
-	ask = newAllocationAskTG(aKey, appID1, tg2, res)
+	ask = newAllocationAskTG(aKey5, appID1, tg2, res)
 	err = app.AddAllocationAsk(ask)
-	assert.NilError(t, err, "ask should have been updated on app")
+	assert.NilError(t, err, "ask should have been added to app")
 
 	assert.Equal(t, len(app.placeholderData), 2)
 	assertPlaceholderData(t, app, tg2, 1, 0, 0, res)
@@ -2751,43 +2751,44 @@ func TestMaxAskPriority(t *testing.T) {
 	assertMaxPriorityConsistent(t, app)
 }
 
-// TestAddAllocationAskReplaceExistingPendingAsk covers the replace-existing-ask branch of
-// AddAllocationAsk: re-submitting an ask under a key that is already tracked and still pending.
-// The displaced ask has to leave the pending histogram before addAllocationAskInternal counts the
-// replacement, or a single allocation key is counted twice and the priority it was originally
-// submitted at never drops out again. The full rescan this replaced could not get that wrong: it
-// derived the maximum from sa.requests, which only ever holds one ask per key.
-func TestAddAllocationAskReplaceExistingPendingAsk(t *testing.T) {
+// TestAddAllocationAskDuplicateKeyRejected pins the rejection that backs the single adder invariant
+// documented on addAllocationAskInternal: an ask under a tracked key is refused and nothing moves.
+// Both shapes are covered, a key that is still pending and one that has since been allocated.
+func TestAddAllocationAskDuplicateKeyRejected(t *testing.T) {
 	app := newApplication(appID1, "default", "root.default")
 	queue, err := createRootQueue(nil)
 	assert.NilError(t, err, "queue create failed")
 	app.queue = queue
 
 	res := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 5})
-	err = app.AddAllocationAsk(newAllocationAskPriority(aKey, appID1, res, 5))
+	ask := newAllocationAskPriority(aKey, appID1, res, 5)
+	err = app.AddAllocationAsk(ask)
 	assert.NilError(t, err, "ask should have been added to app")
-	assertMaxPriorityConsistent(t, app)
 
-	// same key, still pending, different priority: the replace branch
-	replacement := newAllocationAskPriority(aKey, appID1, res, 3)
-	err = app.AddAllocationAsk(replacement)
-	assert.NilError(t, err, "ask should have been updated on app")
-
+	err = app.AddAllocationAsk(newAllocationAskPriority(aKey, appID1, res, 3))
+	assert.ErrorContains(t, err, "already tracked", "duplicate add of a pending ask should have been rejected")
+	assert.Assert(t, app.GetAllocationAsk(aKey) == ask, "rejected add must leave the tracked ask in place")
+	assert.Assert(t, resources.Equals(app.GetPendingResource(), res), "rejected add must not change the pending resource")
 	app.RLock()
-	assert.Equal(t, len(app.pendingPriorities), 1, "pending histogram must only hold the replacement's priority")
-	assert.Equal(t, app.pendingPriorities[3], 1, "wrong pending count for the replacement priority")
+	assert.Equal(t, len(app.pendingPriorities), 1, "rejected add must not change the pending histogram")
+	assert.Equal(t, app.pendingPriorities[5], 1, "rejected add must not change the pending histogram")
+	assert.Equal(t, len(app.sortedRequests), 1, "rejected add must not insert into sortedRequests")
 	app.RUnlock()
-	assert.Equal(t, app.GetAskMaxPriority(), int32(3), "wrong priority after replacing p=5 with p=3")
+	assert.Equal(t, app.GetAskMaxPriority(), int32(5), "rejected add must not change askMaxPriority")
 	assertMaxPriorityConsistent(t, app)
 
-	// allocating the only ask must empty the histogram: a double counted key would leave the
-	// replaced ask's priority behind.
+	// same key once it is no longer pending: still tracked, so still refused
 	_, err = app.AllocateAsk(aKey)
 	assert.NilError(t, err, "ask should have been allocated")
+	err = app.AddAllocationAsk(newAllocationAskPriority(aKey, appID1, res, 3))
+	assert.ErrorContains(t, err, "already tracked", "duplicate add of an allocated ask should have been rejected")
+	assert.Assert(t, app.GetAllocationAsk(aKey) == ask, "rejected add must leave the tracked ask in place")
+	assert.Assert(t, resources.IsZero(app.GetPendingResource()), "rejected add must not change the pending resource")
 	app.RLock()
-	assert.Equal(t, len(app.pendingPriorities), 0, "allocating the only ask must empty the pending histogram")
+	assert.Equal(t, len(app.pendingPriorities), 0, "rejected add must not change the pending histogram")
+	assert.Equal(t, len(app.sortedRequests), 1, "rejected add must not insert into sortedRequests")
 	app.RUnlock()
-	assert.Equal(t, app.GetAskMaxPriority(), configs.MinPriority, "wrong priority after allocating the only ask")
+	assert.Equal(t, app.GetAskMaxPriority(), configs.MinPriority, "rejected add must not change askMaxPriority")
 	assertMaxPriorityConsistent(t, app)
 }
 
@@ -3584,11 +3585,11 @@ func TestPredicateFailedEvents(t *testing.T) {
 		allocKey             string
 		expectedFailedEvents int
 	}{
-		{"prefilter pass", mockCommon.NewPredicatePlugin(false, false, nil), "alloc-1", 0},
-		{"prefilter passes but none of the node from iterator is available in feasible nodes", mockCommon.NewPredicatePlugin(false, false, wrongNodes), "alloc-2", 0},
-		{"prefilter fails", mockCommon.NewPredicatePlugin(true, false, nil), "alloc-2", 1},
-		{"prefilter pass with expected feasible nodes, filter fails", mockCommon.NewPredicatePlugin(false, true, rightNodes), "alloc-3", 1},
-		{"both prefilter and filter passes with correct feasible nodes", mockCommon.NewPredicatePlugin(false, false, rightNodes), "alloc-3", 0},
+		{"prefilter pass", mockCommon.NewPredicatePlugin(false, false, nil), aKey, 0},
+		{"prefilter passes but none of the node from iterator is available in feasible nodes", mockCommon.NewPredicatePlugin(false, false, wrongNodes), aKey2, 0},
+		{"prefilter fails", mockCommon.NewPredicatePlugin(true, false, nil), aKey3, 1},
+		{"prefilter pass with expected feasible nodes, filter fails", mockCommon.NewPredicatePlugin(false, true, rightNodes), aKey4, 1},
+		{"both prefilter and filter passes with correct feasible nodes", mockCommon.NewPredicatePlugin(false, false, rightNodes), aKey5, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -1678,7 +1678,7 @@ func TestOutStandingRequestMultipleChildrenWithMax(t *testing.T) {
 	ask1Leaf2.SetSchedulingAttempted(true)
 	err = leaf2App.AddAllocationAsk(ask1Leaf2)
 	assert.NilError(t, err, "could not add ask")
-	ask2Leaf2 := newAllocationAsk("ask1-leaf2", "app-leaf2", askRes)
+	ask2Leaf2 := newAllocationAsk("ask2-leaf2", "app-leaf2", askRes)
 	ask2Leaf2.SetSchedulingAttempted(true)
 	err = leaf2App.AddAllocationAsk(ask2Leaf2)
 	assert.NilError(t, err, "could not add ask")

--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -45,6 +45,8 @@ const (
 	aKey          = "alloc-1"
 	aKey2         = "alloc-2"
 	aKey3         = "alloc-3"
+	aKey4         = "alloc-4"
+	aKey5         = "alloc-5"
 	nodeID1       = "node-1"
 	nodeID2       = "node-2"
 	nodeID3       = "node-3"

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -596,7 +596,7 @@ func TestPlaceholderDataWithNodeRemoval(t *testing.T) {
 
 	for i := 1; i <= 6; i++ {
 		// add an ask for a placeholder and allocate
-		ask := newAllocationAskTG(phID+strconv.Itoa(i+1), appID2, taskGroup, res, true)
+		ask := newAllocationAskTG(phID+strconv.Itoa(i), appID2, taskGroup, res, true)
 		err = gangApp.AddAllocationAsk(ask)
 		assert.NilError(t, err, "failed to add placeholder ask ph-1 to app1")
 		// try to allocate a placeholder via normal allocate
@@ -685,7 +685,7 @@ func TestPlaceholderDataWithRemoval(t *testing.T) {
 	var lastPhAllocationKey string
 	for i := 1; i <= 6; i++ {
 		// add an ask for a placeholder and allocate
-		ask := newAllocationAskTG(phID+strconv.Itoa(i+1), appID2, taskGroup, res, true)
+		ask := newAllocationAskTG(phID+strconv.Itoa(i), appID2, taskGroup, res, true)
 		err = gangApp.AddAllocationAsk(ask)
 		assert.NilError(t, err, "failed to add placeholder ask ph-1 to app1")
 		// try to allocate a placeholder via normal allocate


### PR DESCRIPTION
## Summary

`AddAllocationAsk` compensated for re-adding an allocation key the application already tracks and still has pending. That state cannot occur:

* `PartitionContext.UpdateAllocation` is the only caller, and it only calls in after `GetAllocationAsk` has returned nil for the key.
* All of those calls are processed by the single goroutine draining `pendingAllocEvents`.

The compensation was incomplete anyway. It rolled back `sa.pending` and the priority histogram but left the displaced ask in `sortedRequests`, which only removes one entry for a given key.

## Change

* The unreachable replacement branch is removed.
* `AddAllocationAsk` now rejects a tracked key with an error, ahead of any state mutation.

Removing the branch on its own would turn an impossible-but-protected state into a silently corrupting one, since a duplicate add would then double count `sa.pending` and the priority histogram and append another `sortedRequests` entry. `UpdateAllocation` never presents a tracked key, so the normal scheduler path is unchanged. `RecoverAllocationAsk` sits behind the same check but returns nothing and so cannot refuse, leaving it covered by the documented invariant alone.

## Tests

* `TestAddAllocationAskReplaceExistingPendingAsk` is replaced by `TestAddAllocationAskDuplicateKeyRejected`.
* The property fuzzer's case 8 now re-adds tracked keys and requires the add to be refused with nothing moved: tracked ask, `sa.pending`, `sortedRequests` and the task group's placeholder count all unchanged.
* Three fixtures that silently reused allocation keys are corrected with their assertions intact: the two placeholder tests, `TestOutStandingRequestMultipleChildrenWithMax` and `TestPredicateFailedEvents`.

Each new fuzz assertion was checked against a deliberately misplaced guard, so the case cannot pass vacuously. The existing invariant checks continue to cover the priority histogram and `askMaxPriority`.

## Relationship to #1127

#1127 repairs the same branch by adding the missing `sortedRequests.remove(oldAsk)`; this PR removes it instead. The two differ in implementation rather than intent, and whichever lands second should only need a small rebase.

### Type of change

- [x] Refactoring

### Jira issue

Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3358

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling

Generated by Claude Code (Opus 5)

- [x] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

### How has this been tested?

- [x] New unit tests were added to cover new or changed code paths.
- [x] `make test_all` was run, and no failures reported.

### Questions:

- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
