### PR TITLE
[YUNIKORN-3380] Fix user/group tracker quota leak on RemoveAllAllocations with pending asks

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -2237,8 +2237,8 @@ func (sa *Application) RemoveAllAllocations() []*Allocation {
 
 	// if an app doesn't have any allocations and the user doesn't have other applications,
 	// the user tracker is nonexistent. We don't want to decrease resource usage in this case.
-	if ugm.GetUserManager().GetUserTracker(sa.user.User) != nil && resources.IsZero(sa.pending) {
-		sa.decUserResourceUsage(resources.Add(sa.allocatedResource, sa.allocatedPlaceholder), true)
+	if ugm.GetUserManager().GetUserTracker(sa.user.User) != nil {
+		sa.decUserResourceUsage(resources.Add(sa.allocatedResource, sa.allocatedPlaceholder), resources.IsZero(sa.pending))
 	}
 	// cleanup allocated resource for app (placeholders and normal)
 	sa.allocatedResource = resources.NewResource()

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -955,6 +955,46 @@ func TestAllocations(t *testing.T) {
 	assertUserGroupResource(t, getTestUserGroup(), nil)
 }
 
+func TestRemoveAllAllocationsWithPendingAsks(t *testing.T) {
+	setupUGM()
+	app := newApplication(appID1, "default", "root.a")
+	queue, err := createRootQueue(nil)
+	assert.NilError(t, err, "queue create failed")
+	app.queue = queue
+
+	resMap := map[string]string{"memory": "100", "vcores": "10"}
+	res, err := resources.NewResourceFromConf(resMap)
+	assert.NilError(t, err, "failed to create resource with error")
+
+	// 1. Add an allocation: UGM tracks 100m/10v
+	alloc := newAllocation(appID1, nodeID1, res)
+	app.AddAllocation(alloc)
+	assertUserGroupResource(t, getTestUserGroup(), res)
+
+	// 2. Add a pending ask so that app.pending is non-zero
+	ask := newAllocationAsk("ask-1", appID1, res)
+	err = app.AddAllocationAsk(ask)
+	assert.NilError(t, err)
+	assert.Assert(t, !resources.IsZero(app.GetPendingResource()), "app should have pending resources")
+
+	// 3. Remove all allocations while pending ask is still present
+	allocs := app.RemoveAllAllocations()
+	assert.Equal(t, len(allocs), 1)
+	assert.Assert(t, resources.IsZero(app.GetAllocatedResource()), "app allocated resources should be zero")
+
+	// 4. Invariant check: UGM usage must have decremented the released allocation!
+	// In the unpatched code, this assertion will fail because decUserResourceUsage was skipped!
+	assertUserGroupResource(t, getTestUserGroup(), nil)
+
+	// 5. App should still have its pending ask and remain in Accepted state (not Completing)
+	assert.Assert(t, resources.Equals(app.GetPendingResource(), res), "pending resources should remain intact")
+	assert.Equal(t, app.CurrentState(), Accepted.String(), "app should remain in Accepted state while asks are pending")
+
+	// 6. Now remove the pending ask and verify pending resources are cleared
+	app.RemoveAllocationAsk(ask.GetAllocationKey())
+	assert.Assert(t, resources.IsZero(app.GetPendingResource()), "pending resources should be zero after ask removal")
+}
+
 func TestGangAllocChange(t *testing.T) {
 	resMap := map[string]string{"first": "4"}
 	totalPH, err := resources.NewResourceFromConf(resMap)


### PR DESCRIPTION
### Description
Fixes YUNIKORN-3380: RemoveAllAllocations leaks user/group tracked usage when a release-all arrives with pending asks.

In `Application.RemoveAllAllocations()`, decrements to the user/group resource tracker (`sa.decUserResourceUsage`) were guarded by `resources.IsZero(sa.pending)`. When an application received a release-all while pending asks were still present, the decrement was skipped, while `sa.allocatedResource` and `sa.allocatedPlaceholder` were wiped unconditionally right after. Because the application totals were zeroed out, the leaked allocation resources could never be decremented in the future, permanently corrupting the user's tracked quota until scheduler restart.

This PR:
1. Removes the `resources.IsZero(sa.pending)` condition guarding `decUserResourceUsage` in `Application.RemoveAllAllocations()`, ensuring that released allocated resources are always returned to the user tracker.
2. Passes `resources.IsZero(sa.pending)` as the `removeApp` flag to `decUserResourceUsage`, keeping the application tracked while pending asks remain, and untracking it only when no pending asks remain.
3. Adds `TestRemoveAllAllocationsWithPendingAsks` in `application_test.go` reproducing the defect and asserting that tracked user resource usage is cleanly cleared even with active pending asks.

### Type of change
- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3380

- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by Antigravity", where Antigravity is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit test added: `TestRemoveAllAllocationsWithPendingAsks` in `pkg/scheduler/objects/application_test.go`.
- [x] Defect reproduction verified: the new test failed on unpatched code with `userResource.IsEmpty() == false`, and passes cleanly after the fix.
- [x] Concurrency stress test: `go test -race -count=5 ./pkg/scheduler/objects/...` passed 100% with zero data races.
- [x] Full repository regression suite: `go test ./...` across all packages in `yunikorn-core` passed with zero regressions.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
*Generated by hedger9487 with assistance from Antigravity.*