### PR TITLE
[YUNIKORN-3137] Fails to preempt more than 2 victims for a larger ask

### DIFF
--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -636,11 +636,7 @@ func (p *Preemptor) TryPreemption() (*AllocationResult, bool) {
 	// Holds total victims resources
 	victimsTotalResource := resources.NewResource()
 
-	fitIn := false
-	nodeCurrentAvailable := p.nodeAvailableMap
-	if nodeCurrentAvailable[nodeID].FitIn(p.ask.GetAllocatedResource()) {
-		fitIn = true
-	}
+	fitIn := p.nodeAvailableMap[nodeID].FitIn(p.ask.GetAllocatedResource())
 
 	// Since there could be more victims than the actual need, ensure only required victims are filtered finally
 	// to do: There is room for improvements especially when there are more victims. victims could be chosen based
@@ -653,15 +649,28 @@ func (p *Preemptor) TryPreemption() (*AllocationResult, bool) {
 		if !fitIn && victim.GetNodeID() != nodeID {
 			continue
 		}
-		// stop collecting the victims once ask resource requirement met
-		if p.ask.GetAllocatedResource().StrictlyGreaterThanOnlyExisting(victimsTotalResource) {
-			finalVictims = append(finalVictims, victim)
+		// check if victim contributes to any resource dimension that is still needed
+		allocRes := victim.GetAllocatedResource()
+		for k, needVal := range p.ask.GetAllocatedResource().Resources {
+			if victimsTotalResource.Resources[k] < needVal && allocRes.Resources[k] > 0 {
+				finalVictims = append(finalVictims, victim)
+				victimsTotalResource.AddTo(allocRes)
+				break
+			}
 		}
-		// add the victim resources to the total
-		victimsTotalResource.AddTo(victim.GetAllocatedResource())
 	}
 
-	if p.ask.GetAllocatedResource().StrictlyGreaterThanOnlyExisting(victimsTotalResource) {
+	hasShortfall := victimsTotalResource.IsEmpty()
+	if !hasShortfall {
+		for k, victimVal := range victimsTotalResource.Resources {
+			if needVal, ok := p.ask.GetAllocatedResource().Resources[k]; ok && victimVal < needVal {
+				hasShortfall = true
+				break
+			}
+		}
+	}
+
+	if hasShortfall {
 		// there is shortfall, so preemption doesn't help
 		p.ask.LogAllocationFailure(common.PreemptionShortfall, true)
 		return nil, false

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -721,7 +721,7 @@ func TestTryPreemption_VictimsAvailable_InsufficientResource(t *testing.T) {
 	alloc1, alloc2, err := creatApp1(childQ1, node1, node2, map[string]resources.Quantity{"first": 2, "pods": 1}, appQueueMapping)
 	assert.NilError(t, err)
 
-	app2, ask3, err := creatApp2(childQ2, map[string]resources.Quantity{"first": 5}, "alloc3", appQueueMapping)
+	app2, ask3, err := creatApp2(childQ2, map[string]resources.Quantity{"first": 5, "pods": 1}, "alloc3", appQueueMapping)
 	assert.NilError(t, err)
 
 	headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "pods": 3})
@@ -1459,88 +1459,106 @@ func createVictimApplications(childQ2 *Queue, appQueueMapping *AppQueueMapping) 
 //
 //nolint:funlen
 func TestTryPreemption_AskResTypesSame_GuaranteedSetOnPreemptorSide(t *testing.T) {
-	appQueueMapping := NewAppQueueMapping()
-	node := newNode(nodeID1, map[string]resources.Quantity{"vcores": 5, "gpu": 300, "mem": 200})
-	iterator := getNodeIteratorFn(node)
-	rootQ, err := createRootQueue(map[string]string{"vcores": "5", "gpu": "300", "mem": "200"})
-	assert.NilError(t, err)
-	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, nil, nil, appQueueMapping)
-	assert.NilError(t, err)
-	parentQ1, err := createManagedQueueGuaranteed(parentQ, "parent1", true, nil, nil, appQueueMapping)
-	assert.NilError(t, err)
-	parentQ2, err := createManagedQueueGuaranteed(parentQ, "parent2", true, nil, nil, appQueueMapping)
-	assert.NilError(t, err)
-
-	childQ1, err := createManagedQueueGuaranteed(parentQ1, "child1", false, nil, map[string]string{"vcores": "2"}, appQueueMapping)
-	assert.NilError(t, err)
-	childQ2, err := createManagedQueueGuaranteed(parentQ2, "child2", false, nil, nil, appQueueMapping)
-	assert.NilError(t, err)
-	_, err = createManagedQueueGuaranteed(parentQ2, "child3", false, nil, nil, appQueueMapping)
-	assert.NilError(t, err)
-	app1, app2, app3 := createVictimApplications(childQ2, appQueueMapping)
-	for i := 5; i < 8; i++ {
-		askN := newAllocationAsk(alloc+strconv.Itoa(i), appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"gpu": 100}))
-		askN.createTime = time.Now().Add(-2 * time.Minute)
-		assert.NilError(t, app1.AddAllocationAsk(askN))
-		allocN := newAllocationWithKey(askN.allocationKey, appID1, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"gpu": 100}))
-		allocN.createTime = askN.createTime
-		app1.AddAllocation(allocN)
-		assert.Check(t, node.TryAddAllocation(allocN), "node alloc1 failed")
+	tests := []struct {
+		name                  string
+		askCores              int64
+		expectAlloc1Preempted bool
+	}{
+		{"preempt 2 victims - alloc1 protected", 2, false},
+		{"preempt 3 victims with pods dimension", 3, true},
 	}
 
-	ask1 := newAllocationAsk("alloc1", appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
-	ask1.createTime = time.Now().Add(-1 * time.Minute)
-	assert.NilError(t, app1.AddAllocationAsk(ask1))
-	ask2 := newAllocationAsk("alloc2", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
-	ask2.createTime = time.Now()
-	assert.NilError(t, app1.AddAllocationAsk(ask2))
-	ask3 := newAllocationAsk("alloc3", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
-	ask3.createTime = time.Now()
-	assert.NilError(t, app1.AddAllocationAsk(ask3))
-	alloc1 := newAllocationWithKey("alloc1", appID1, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
-	alloc1.createTime = ask1.createTime
-	app1.AddAllocation(alloc1)
-	assert.Check(t, node.TryAddAllocation(alloc1), "node alloc1 failed")
-	alloc2 := newAllocationWithKey("alloc2", appID2, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
-	alloc2.createTime = ask2.createTime
-	app2.AddAllocation(alloc2)
-	assert.Check(t, node.TryAddAllocation(alloc2), "node alloc2 failed")
-	alloc3 := newAllocationWithKey("alloc3", appID2, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
-	alloc3.createTime = ask3.createTime
-	app3.AddAllocation(alloc3)
-	assert.Check(t, node.TryAddAllocation(alloc3), "node alloc3 failed")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appQueueMapping := NewAppQueueMapping()
+			node := newNode(nodeID1, map[string]resources.Quantity{"vcores": 6, "gpu": 300, "mem": 200, "pods": 10})
+			iterator := getNodeIteratorFn(node)
+			rootQ, err := createRootQueue(map[string]string{"vcores": "6", "gpu": "300", "mem": "200", "pods": "10"})
+			assert.NilError(t, err)
+			parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, nil, nil, appQueueMapping)
+			assert.NilError(t, err)
+			parentQ1, err := createManagedQueueGuaranteed(parentQ, "parent1", true, nil, nil, appQueueMapping)
+			assert.NilError(t, err)
+			parentQ2, err := createManagedQueueGuaranteed(parentQ, "parent2", true, nil, nil, appQueueMapping)
+			assert.NilError(t, err)
 
-	for i := 5; i < 8; i++ {
-		assert.NilError(t, childQ2.TryIncAllocatedResource(resources.NewResourceFromMap(map[string]resources.Quantity{"gpu": 100})))
+			childQ1, err := createManagedQueueGuaranteed(parentQ1, "child1", false, nil, map[string]string{"vcores": "3"}, appQueueMapping)
+			assert.NilError(t, err)
+			childQ2, err := createManagedQueueGuaranteed(parentQ2, "child2", false, nil, nil, appQueueMapping)
+			assert.NilError(t, err)
+			_, err = createManagedQueueGuaranteed(parentQ2, "child3", false, nil, nil, appQueueMapping)
+			assert.NilError(t, err)
+			app1, app2, app3 := createVictimApplications(childQ2, appQueueMapping)
+			for i := 5; i < 8; i++ {
+				askN := newAllocationAsk(alloc+strconv.Itoa(i), appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"gpu": 100}))
+				askN.createTime = time.Now().Add(-2 * time.Minute)
+				assert.NilError(t, app1.AddAllocationAsk(askN))
+				allocN := newAllocationWithKey(askN.allocationKey, appID1, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"gpu": 100}))
+				allocN.createTime = askN.createTime
+				app1.AddAllocation(allocN)
+				assert.Check(t, node.TryAddAllocation(allocN), "node alloc1 failed")
+			}
+
+			ask1 := newAllocationAsk("alloc1", appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "pods": 1}))
+			ask1.createTime = time.Now().Add(-1 * time.Minute)
+			assert.NilError(t, app1.AddAllocationAsk(ask1))
+			ask2 := newAllocationAsk("alloc2", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "pods": 1}))
+			ask2.createTime = time.Now()
+			assert.NilError(t, app1.AddAllocationAsk(ask2))
+			ask3 := newAllocationAsk("alloc3", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "pods": 1}))
+			ask3.createTime = time.Now()
+			assert.NilError(t, app1.AddAllocationAsk(ask3))
+			alloc1 := newAllocationWithKey("alloc1", appID1, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "pods": 1}))
+			alloc1.createTime = ask1.createTime
+			app1.AddAllocation(alloc1)
+			assert.Check(t, node.TryAddAllocation(alloc1), "node alloc1 failed")
+			alloc2 := newAllocationWithKey("alloc2", appID2, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "pods": 1}))
+			alloc2.createTime = ask2.createTime
+			app2.AddAllocation(alloc2)
+			assert.Check(t, node.TryAddAllocation(alloc2), "node alloc2 failed")
+			alloc3 := newAllocationWithKey("alloc3", appID2, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "pods": 1}))
+			alloc3.createTime = ask3.createTime
+			app3.AddAllocation(alloc3)
+			assert.Check(t, node.TryAddAllocation(alloc3), "node alloc3 failed")
+
+			for i := 5; i < 8; i++ {
+				assert.NilError(t, childQ2.TryIncAllocatedResource(resources.NewResourceFromMap(map[string]resources.Quantity{"gpu": 100})))
+			}
+			assert.NilError(t, childQ2.TryIncAllocatedResource(ask1.GetAllocatedResource()))
+			assert.NilError(t, childQ2.TryIncAllocatedResource(ask2.GetAllocatedResource()))
+			assert.NilError(t, childQ2.TryIncAllocatedResource(ask3.GetAllocatedResource()))
+
+			app4 := newApplication("app-4", "default", "root.parent.parent1.child1")
+			app4.SetQueue(childQ1)
+			ask4 := newAllocationAsk("alloc4", "app-4", resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": resources.Quantity(tt.askCores), "mem": 200, "pods": 1}))
+			assert.NilError(t, app4.AddAllocationAsk(ask4))
+			headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": resources.Quantity(tt.askCores), "pods": 1})
+			preemptor := NewPreemptor(app4, headRoom, 30*time.Second, ask4, iterator(), false)
+
+			// register predicate handler
+			plugin := mock.NewPreemptionPredicatePlugin(nil, nil, false, false)
+			plugins.RegisterSchedulerPlugin(plugin)
+			defer plugins.UnregisterSchedulerPlugins()
+
+			result, ok := preemptor.TryPreemption()
+			assert.Assert(t, result != nil, "no result")
+			assert.NilError(t, plugin.GetPredicateError())
+			assert.Assert(t, ok, "no victims found")
+			assert.Equal(t, "alloc4", result.Request.GetAllocationKey(), "wrong alloc")
+			assert.Equal(t, nodeID1, result.NodeID, "wrong node")
+			assert.Equal(t, nodeID1, alloc2.nodeID, "wrong node")
+			assert.Equal(t, nodeID1, alloc3.nodeID, "wrong node")
+			assert.Check(t, alloc2.IsPreempted(), "alloc2 not preempted")
+			assert.Check(t, alloc3.IsPreempted(), "alloc3 not preempted")
+			if tt.expectAlloc1Preempted {
+				assert.Equal(t, nodeID1, alloc1.nodeID, "wrong node")
+				assert.Check(t, alloc1.IsPreempted(), "alloc1 not preempted")
+			} else {
+				assert.Check(t, !alloc1.IsPreempted(), "alloc1 preempted")
+			}
+			assert.Equal(t, len(ask4.GetAllocationLog()), 0)
+		})
 	}
-	assert.NilError(t, childQ2.TryIncAllocatedResource(ask1.GetAllocatedResource()))
-	assert.NilError(t, childQ2.TryIncAllocatedResource(ask2.GetAllocatedResource()))
-	assert.NilError(t, childQ2.TryIncAllocatedResource(ask3.GetAllocatedResource()))
-
-	app4 := newApplication("app-4", "default", "root.parent.parent1.child1")
-	app4.SetQueue(childQ1)
-	ask4 := newAllocationAsk("alloc4", "app-4", resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 2, "mem": 200}))
-	assert.NilError(t, app4.AddAllocationAsk(ask4))
-	headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 2})
-	preemptor := NewPreemptor(app4, headRoom, 30*time.Second, ask4, iterator(), false)
-
-	// register predicate handler
-	plugin := mock.NewPreemptionPredicatePlugin(nil, nil, false, false)
-	plugins.RegisterSchedulerPlugin(plugin)
-	defer plugins.UnregisterSchedulerPlugins()
-
-	result, ok := preemptor.TryPreemption()
-	assert.Assert(t, result != nil, "no result")
-	assert.NilError(t, plugin.GetPredicateError())
-	assert.Assert(t, ok, "no victims found")
-	assert.Equal(t, "alloc4", result.Request.GetAllocationKey(), "wrong alloc")
-	assert.Equal(t, nodeID1, result.NodeID, "wrong node")
-	assert.Equal(t, nodeID1, alloc2.nodeID, "wrong node")
-	assert.Equal(t, nodeID1, alloc3.nodeID, "wrong node")
-	assert.Check(t, !alloc1.IsPreempted(), "alloc1 preempted")
-	assert.Check(t, alloc2.IsPreempted(), "alloc2 not preempted")
-	assert.Check(t, alloc3.IsPreempted(), "alloc3 not preempted")
-	assert.Equal(t, len(ask4.GetAllocationLog()), 0)
 }
 
 // TestTryPreemption_OnNode_AskResTypesSame_GuaranteedSetOnPreemptorSide Test try preemption with 2 level queue hierarchy. Since Node doesn't have enough resources to accomodate, preemption happens because of node resource constraint.


### PR DESCRIPTION
### Description

In `pkg/scheduler/objects/preemption.go:TryPreemption()`, the post-filtering loop that accumulates final preemption victims previously checked:
```go
if p.ask.GetAllocatedResource().StrictlyGreaterThanOnlyExisting(victimsTotalResource) {
    finalVictims = append(finalVictims, victim)
}
victimsTotalResource.AddTo(victim.GetAllocatedResource())
```

When allocations contain multi-dimensional resource vectors (such as `"pods": 1` in addition to `"vcores"` and `"mem"`), preempting multiple smaller victims causes `victimsTotalResource.Resources["pods"]` to accumulate and exceed `p.ask.GetAllocatedResource().Resources["pods"]` (which is typically `1` for a single ask).

Because `StrictlyGreaterThanOnlyExisting()` requires the ask's resources to be strictly greater across existing dimensions, this comparison evaluated to `false` once `pods` count exceeded `1`, stopping victim collection prematurely even if the ask's remaining deficit for `vcores` or `mem` was not yet satisfied. Furthermore, `victimsTotalResource.AddTo()` was called unconditionally on every candidate victim, causing unselected allocations to incorrectly inflate the accumulated resource total.

This PR:
1. **Dimension-wise Deficit Matching**: Iterates over each resource dimension in `p.ask` to check if a candidate victim contributes to any resource type that still has an unmet shortfall (`currentVal < needVal`).
2. **Conditional Resource Accumulation**: Moves `victimsTotalResource.AddTo(allocRes)` inside the conditional check so only actually selected victims contribute to the accumulated resource total.
3. **Explicit Shortfall Validation**: Validates whether `victimsTotalResource` satisfies all dimensions of `p.ask`, properly reporting `PreemptionShortfall` only when a true deficiency remains.
4. **Enhanced Existing Preemption Tests (per review feedback)**:
   - Converted `TestTryPreemption_AskResTypesSame_GuaranteedSetOnPreemptorSide` to table-driven subtests:
     - Subtest `preempt 2 victims - alloc1 protected`: verifies the original boundary condition where 2 victims suffice and `alloc1` remains protected.
     - Subtest `preempt 3 victims with pods dimension`: asserts that 3 victims with `pods: 1` dimension are properly preempted when a larger ask requires 3 vcores.
   - Updated `TestTryPreemption_VictimsAvailable_InsufficientResource` to include `"pods": 1` on candidate asks, verifying that multi-dimensional asks properly abort when victims cannot cover all required dimensions.

### Type of change
- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3137

- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by Antigravity", where Antigravity is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] **Defect reproduction & verification against unpatched `upstream/master`**: 
  - On unpatched code:
    - Subtest `preempt 3 victims with pods dimension` 🔴 **FAILS** (`alloc1 not preempted`).
    - `TestTryPreemption_VictimsAvailable_InsufficientResource` (with `"pods": 1`) 🔴 **FAILS** (premature preemption despite shortfall).
    - Subtest `preempt 2 victims - alloc1 protected` 🟢 **PASSES** (verifying original boundary preservation).
  - With this patch:
    - All subtests and tests 🟢 **PASS**.
- [x] **Full Regression Suite**: 
  - Ran `go test -race ./pkg/scheduler/objects/...` (100% green, 0 race conditions).
  - Ran `go vet ./...` (clean).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
*Generated by hedger9487 with assistance from Antigravity.*
