### PR TITLE
[YUNIKORN-2251] Add node instanceType to the node added event message

### DIFF
--- a/pkg/scheduler/objects/events/node_events.go
+++ b/pkg/scheduler/objects/events/node_events.go
@@ -29,11 +29,11 @@ type NodeEvents struct {
 	eventSystem events.EventSystem
 }
 
-func (n *NodeEvents) SendNodeAddedEvent(nodeID string, capacity *resources.Resource) {
+func (n *NodeEvents) SendNodeAddedEvent(nodeID string, capacity *resources.Resource, instanceType string) {
 	if !n.eventSystem.IsEventTrackingEnabled() {
 		return
 	}
-	event := events.CreateNodeEventRecord(nodeID, "Node added to the scheduler", common.Empty, si.EventRecord_ADD,
+	event := events.CreateNodeEventRecord(nodeID, "Node added to the scheduler, instanceType: "+instanceType, common.Empty, si.EventRecord_ADD,
 		si.EventRecord_DETAILS_NONE, capacity)
 	n.eventSystem.AddEvent(event)
 }

--- a/pkg/scheduler/objects/events/node_events_test.go
+++ b/pkg/scheduler/objects/events/node_events_test.go
@@ -30,22 +30,23 @@ import (
 )
 
 const nodeID1 = "node-1"
+const instanceType1 = "instance-type-1"
 
 func TestSendNodeAddedEvent(t *testing.T) {
 	resource := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1})
 	eventSystem := mock.NewEventSystemDisabled()
 	ne := NewNodeEvents(eventSystem)
-	ne.SendNodeAddedEvent(nodeID1, resource)
+	ne.SendNodeAddedEvent(nodeID1, resource, instanceType1)
 	assert.Equal(t, 0, len(eventSystem.Events), "unexpected event")
 
 	eventSystem = mock.NewEventSystem()
 	ne = NewNodeEvents(eventSystem)
-	ne.SendNodeAddedEvent(nodeID1, resource)
+	ne.SendNodeAddedEvent(nodeID1, resource, instanceType1)
 	assert.Equal(t, 1, len(eventSystem.Events), "event was not generated")
 	event := eventSystem.Events[0]
 	assert.Equal(t, nodeID1, event.ObjectID)
 	assert.Equal(t, common.Empty, event.ReferenceID)
-	assert.Equal(t, "Node added to the scheduler", event.Message)
+	assert.Equal(t, "Node added to the scheduler, instanceType: "+instanceType1, event.Message)
 	assert.Equal(t, si.EventRecord_ADD, event.EventChangeType)
 	assert.Equal(t, si.EventRecord_DETAILS_NONE, event.EventChangeDetail)
 	assert.Equal(t, 1, len(event.Resource.Resources))

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -706,7 +706,7 @@ func (sn *Node) getListeners() []NodeListener {
 func (sn *Node) SendNodeAddedEvent() {
 	sn.RLock()
 	defer sn.RUnlock()
-	sn.nodeEvents.SendNodeAddedEvent(sn.NodeID, sn.totalResource.Clone())
+	sn.nodeEvents.SendNodeAddedEvent(sn.NodeID, sn.totalResource.Clone(), sn.GetInstanceType())
 }
 
 func (sn *Node) SendNodeRemovedEvent() {

--- a/pkg/scheduler/tests/application_tracking_test.go
+++ b/pkg/scheduler/tests/application_tracking_test.go
@@ -31,6 +31,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/apache/yunikorn-core/pkg/common"
+	"github.com/apache/yunikorn-core/pkg/scheduler/objects"
 	"github.com/apache/yunikorn-core/pkg/webservice/dao"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
@@ -282,7 +283,7 @@ func verifyNodeAddedAndQueueMaxSetEvents(t *testing.T, events []*si.EventRecord)
 	assert.Equal(t, si.EventRecord_QUEUE_MAX, events[1].EventChangeDetail)
 
 	assert.Equal(t, "node-1:1234", events[2].ObjectID)
-	assert.Equal(t, "Node added to the scheduler", events[2].Message)
+	assert.Equal(t, "Node added to the scheduler, instanceType: "+objects.UnknownInstanceType, events[2].Message)
 	assert.Equal(t, "", events[2].ReferenceID)
 	assert.Equal(t, si.EventRecord_NODE, events[2].Type)
 	assert.Equal(t, si.EventRecord_ADD, events[2].EventChangeType)


### PR DESCRIPTION
### Description
The node added event carried the fixed message "Node added to the scheduler", so anyone reading
the event stream had to look the node up separately to find out what kind of node had joined.

This adds the instance type to that message, using the same key and value style the file already
uses for the schedulable changed event:

    Node added to the scheduler, instanceType: <type>

Nodes without the `si/instance-type` attribute report `UNKNOWN`, which is what
`Node.GetInstanceType()` already returns in that case. The value is always present rather than
omitted when unknown, so the message keeps one shape and a missing attribute stays visible to
whoever reads the event.

Generated by Claude Code (Claude Opus 5).

Two notes on scope:

- This keeps the value in the existing `Message` string rather than adding a field to
  `EventRecord`, which is what the Jira title asks for and avoids a scheduler-interface change.
  Happy to move it to a structured field instead if you would rather have it typed.
- `Node.GetInstanceType()` is documented as a lock free call because attributes are read only, so
  calling it from `SendNodeAddedEvent` under the existing read lock does not change the locking.

### Type of change

- [x] Improvement

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-2251

- [ ] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
- [x] The PR includes the phrase "Generated by Claude Code (Claude Opus 5)", where Claude Code is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [x] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

No new tests. The two existing assertions on this message were updated instead:
`TestSendNodeAddedEvent` covers the explicit value, and `TestApplicationHistoryTracking` covers the
`UNKNOWN` case through the real scheduler path, since the node in that test has no instance type
attribute.

They are not vacuous. Passing an empty string instead of `sn.GetInstanceType()` in `node.go` fails
the integration test:

    --- FAIL: TestApplicationHistoryTracking (0.54s)

`make test_all` on Linux, all green:

    running shellcheck
    checking license headers:
      all OK
    running golangci-lint
    0 issues.
    running unit tests
    ok  github.com/apache/yunikorn-core/pkg/scheduler                 26.951s  coverage: 75.6% of statements
    ok  github.com/apache/yunikorn-core/pkg/scheduler/objects         11.257s  coverage: 89.6% of statements
    ok  github.com/apache/yunikorn-core/pkg/scheduler/objects/events   1.246s  coverage: 100.0% of statements
    ok  github.com/apache/yunikorn-core/pkg/scheduler/tests           54.513s
    (every other package ok, output trimmed)

`gofmt -l pkg/` is clean and `go vet` passes.

### Questions:
- The site docs quote this message in a few places, so they will need a follow up. I can open a
  Jira against apache/yunikorn-site for that if you want it tracked.
- There are no breaking changes.
- The license files do not need to be updated.
