### PR TITLE
[YUNIKORN-3379] Fix scheduler panic on PLACEHOLDER_REPLACED release without linked replacement

### DIFF
--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -1598,6 +1598,15 @@ func (pc *PartitionContext) removeAllocation(release *si.AllocationRelease) ([]*
 // real allocation.
 func (pc *PartitionContext) replacePlaceholderOnNode(alloc *objects.Allocation, node *objects.Node, total *resources.Resource) *objects.Allocation {
 	confirmed := alloc.GetRelease()
+	if confirmed == nil {
+		log.Log(log.SchedPartition).Warn("unexpected placeholder replacement without replacement allocation, removing placeholder from node",
+			zap.String("nodeID", alloc.GetNodeID()),
+			zap.String("allocationKey", alloc.GetAllocationKey()))
+		if node.RemoveAllocation(alloc.GetAllocationKey()) != nil {
+			total.AddTo(alloc.GetAllocatedResource())
+		}
+		return nil
+	}
 	// we need to check the resources equality
 	delta := resources.Sub(confirmed.GetAllocatedResource(), alloc.GetAllocatedResource())
 	// Any negative value in the delta means that at least one of the requested resource in the

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -5718,3 +5718,43 @@ func TestRemoveAppWithReservations(t *testing.T) {
 	partition.removeApplication(appID1)
 	assert.Equal(t, 0, partition.getReservationCount())
 }
+
+func TestRemoveAllocationPlaceholderReplacedWithoutReplacement(t *testing.T) {
+	setupUGM()
+	partition, err := newBasePartition()
+	assert.NilError(t, err, "partition create failed")
+	defer partition.userGroupCache.Stop()
+
+	// add a new app
+	app := newApplication(appID1, "default", defQueue)
+	err = partition.AddApplication(app)
+	assert.NilError(t, err, "add application to partition should not have failed")
+
+	// add a node with placeholder allocation
+	nodeRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
+	node1 := newNodeMaxResource(nodeID1, nodeRes)
+	appRes := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 1})
+	ph := newAllocationTG("placeholder", appID1, nodeID1, taskGroup, appRes, true)
+	err = partition.AddNode(node1)
+	assert.NilError(t, err)
+	_, allocCreated, err := partition.UpdateAllocation(ph)
+	assert.NilError(t, err)
+	assert.Check(t, allocCreated)
+	assert.Equal(t, 1, partition.GetTotalAllocationCount())
+	assert.Assert(t, resources.Equals(partition.GetQueue(defQueue).GetAllocatedResource(), appRes))
+
+	// Release with PLACEHOLDER_REPLACED when no replacement was ever linked (ph.GetRelease() == nil)
+	release := &si.AllocationRelease{
+		PartitionName:   partition.Name,
+		ApplicationID:   appID1,
+		AllocationKey:   "placeholder",
+		TerminationType: si.TerminationType_PLACEHOLDER_REPLACED,
+	}
+
+	released, confirmed := partition.removeAllocation(release)
+	assert.Assert(t, confirmed == nil, "confirmed allocation should be nil when no replacement exists")
+	assert.Equal(t, 1, len(released), "placeholder should be in released list")
+	assert.Equal(t, 0, partition.GetTotalAllocationCount(), "allocation count should be 0 after placeholder removed")
+	assert.Assert(t, node1.GetAllocation("placeholder") == nil, "placeholder should be removed from node")
+	assert.Assert(t, resources.IsZero(partition.GetQueue(defQueue).GetAllocatedResource()), "queue resource should be zero after placeholder removed")
+}


### PR DESCRIPTION
### Description
Fixes YUNIKORN-3379: Scheduler panics on a malformed PLACEHOLDER_REPLACED release with no linked replacement allocation.

In `PartitionContext.replacePlaceholderOnNode()`, `confirmed := alloc.GetRelease()` retrieves the replacement allocation paired with the placeholder being released. When a malformed or unexpected `PLACEHOLDER_REPLACED` release arrives for a placeholder that has no paired replacement allocation (`alloc.GetRelease() == nil`), `replacePlaceholderOnNode()` immediately calls `confirmed.GetAllocatedResource()`, triggering a SIGSEGV panic and crashing the scheduler.

Notably, YuniKorn's core already recognizes and defends against this unlinked placeholder replacement state at the application layer in `pkg/scheduler/objects/application.go:2102-2111` (`ReplaceAllocation()` logs a warning and safely returns when `alloc == nil`). However, this invariant was missing in `PartitionContext.replacePlaceholderOnNode()`, leaving the node/partition release path vulnerable to a crash.

This PR:
1. Adds a defensive guard `if confirmed == nil` in `replacePlaceholderOnNode()`:
   - Logs a warning with the nodeID and allocationKey.
   - Cleans up the placeholder from the node via `node.RemoveAllocation()`.
   - Adds the placeholder's allocated resources to `total` so the queue quota is correctly decremented by `queue.DecAllocatedResource(total)`.
   - Returns `nil` without panic.
2. Ensures `pc.removeAllocation()` correctly updates the cluster allocation count (`pc.updateAllocationCount(-1)`) and returns the released placeholder to notify the RM proxy.
3. Adds `TestRemoveAllocationPlaceholderReplacedWithoutReplacement` in `partition_test.go` reproducing the SIGSEGV panic and validating that Node, Queue, and Partition states are properly cleared.

### Type of change
- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3379

- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by Antigravity", where Antigravity is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit test added: `TestRemoveAllocationPlaceholderReplacedWithoutReplacement` in `pkg/scheduler/partition_test.go`.
- [x] Defect reproduction verified: the new test panicked with `SIGSEGV invalid memory address or nil pointer dereference` on unpatched master, and passes cleanly (0.00s) after the patch.
- [x] Concurrency & Race detection: `go test -race ./pkg/scheduler/...` passed 100% clean with zero data races.
- [x] Static analysis: `go vet ./pkg/...` passed cleanly.
- [x] License check: `make license-check` passed cleanly.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
*Generated by hedger9487 with assistance from Antigravity.*
