### PR TITLE
[YUNIKORN-3411] Remove synchronous RM allocation release replies

### DIFF
--- a/pkg/rmproxy/rmevent/events.go
+++ b/pkg/rmproxy/rmevent/events.go
@@ -89,7 +89,6 @@ type RMRejectedAllocationEvent struct {
 type RMReleaseAllocationEvent struct {
 	RmID                string
 	ReleasedAllocations []*si.AllocationRelease
-	Channel             chan *Result `json:"-"`
 }
 
 type RMNodeUpdateEvent struct {

--- a/pkg/rmproxy/rmproxy.go
+++ b/pkg/rmproxy/rmproxy.go
@@ -136,11 +136,9 @@ func (rmp *RMProxy) processRMReleaseAllocationEvent(event *rmevent.RMReleaseAllo
 		metrics.GetSchedulerMetrics().AddReleasedContainers(len(event.ReleasedAllocations))
 	}
 
-	// Done, notify channel
-	event.Channel <- &rmevent.Result{
-		Succeeded: true,
-		Reason:    "no. of allocations: " + strconv.Itoa(allocationsCount),
-	}
+	log.Log(log.RMProxy).Debug("Processed allocation release notification",
+		zap.String("rmID", event.RmID),
+		zap.Int("releasedAllocations", allocationsCount))
 }
 
 func (rmp *RMProxy) triggerUpdateAllocation(rmID string, response *si.AllocationResponse) {
@@ -213,11 +211,8 @@ func (rmp *RMProxy) drainPendingEvents() {
 	for {
 		select {
 		case ev := <-rmp.pendingRMEvents:
-			switch v := ev.(type) {
-			case *rmevent.RMNewAllocationsEvent:
-				drainReplyChannel(v.Channel)
-			case *rmevent.RMReleaseAllocationEvent:
-				drainReplyChannel(v.Channel)
+			if event, ok := ev.(*rmevent.RMNewAllocationsEvent); ok {
+				drainReplyChannel(event.Channel)
 			}
 		default:
 			return

--- a/pkg/rmproxy/rmproxy_mock.go
+++ b/pkg/rmproxy/rmproxy_mock.go
@@ -48,8 +48,6 @@ func (rmp *MockedRMProxy) HandleEvent(ev interface{}) {
 		rmp.handled = true
 	case *rmevent.RMNewAllocationsEvent:
 		c = v.Channel
-	case *rmevent.RMReleaseAllocationEvent:
-		c = v.Channel
 	}
 	if c != nil {
 		go func(rc chan *rmevent.Result) {

--- a/pkg/rmproxy/rmproxy_test.go
+++ b/pkg/rmproxy/rmproxy_test.go
@@ -24,19 +24,32 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/apache/yunikorn-core/pkg/mock"
 	"github.com/apache/yunikorn-core/pkg/rmproxy/rmevent"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
+
+type recordingReleaseCallback struct {
+	mock.ResourceManagerCallback
+	responses []*si.AllocationResponse
+}
+
+func (c *recordingReleaseCallback) UpdateAllocation(
+	response *si.AllocationResponse,
+) error {
+	c.responses = append(c.responses, response)
+	return nil
+}
 
 func TestRMProxy_StopUnblocksWaitingCaller(t *testing.T) {
 	rmp := NewRMProxy(nil)
 	rmp.StartService()
 
 	c := make(chan *rmevent.Result, 1)
-	rmp.HandleEvent(&rmevent.RMReleaseAllocationEvent{
-		ReleasedAllocations: []*si.AllocationRelease{},
-		RmID:                "rm-test",
-		Channel:             c,
+	rmp.HandleEvent(&rmevent.RMNewAllocationsEvent{
+		Allocations: []*si.Allocation{},
+		RmID:        "rm-test",
+		Channel:     c,
 	})
 
 	rmp.Stop() // exercises the case <-rmp.stop: drainPendingEvents() wiring
@@ -51,25 +64,22 @@ func TestRMProxy_StopUnblocksWaitingCaller(t *testing.T) {
 
 func TestRMProxy_DrainPendingEvents(t *testing.T) {
 	rmp := NewRMProxy(nil)
-
 	allocResultCh := make(chan *rmevent.Result, 1)
-	releaseResultCh := make(chan *rmevent.Result, 1)
 
+	rmp.HandleEvent(&rmevent.RMReleaseAllocationEvent{
+		ReleasedAllocations: []*si.AllocationRelease{},
+		RmID:                "rm-test",
+	})
 	rmp.HandleEvent(&rmevent.RMNewAllocationsEvent{
 		Allocations: []*si.Allocation{},
 		RmID:        "rm-test",
 		Channel:     allocResultCh,
 	})
-	rmp.HandleEvent(&rmevent.RMReleaseAllocationEvent{
-		ReleasedAllocations: []*si.AllocationRelease{},
-		RmID:                "rm-test",
-		Channel:             releaseResultCh,
-	})
 
 	rmp.drainPendingEvents()
 
 	assertDrainFailedResult(t, allocResultCh, "allocResultCh")
-	assertDrainFailedResult(t, releaseResultCh, "releaseResultCh")
+	assert.Equal(t, len(rmp.pendingRMEvents), 0)
 }
 
 func assertDrainFailedResult(t *testing.T, ch <-chan *rmevent.Result, name string) {
@@ -82,4 +92,107 @@ func assertDrainFailedResult(t *testing.T, ch <-chan *rmevent.Result, name strin
 	case <-time.After(1 * time.Second):
 		t.Fatalf("timed out waiting for response on %s", name)
 	}
+}
+
+func TestRMProxy_ReleaseWithoutReplyChannel(t *testing.T) {
+	rmp := NewRMProxy(nil)
+	event := &rmevent.RMReleaseAllocationEvent{
+		RmID:                "rm-test",
+		ReleasedAllocations: []*si.AllocationRelease{},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		rmp.processRMReleaseAllocationEvent(event)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Release processing does not require a reply channel.
+	case <-time.After(time.Second):
+		t.Fatal("RM proxy did not finish processing release notification")
+	}
+}
+
+func TestRMProxy_ReleaseReachesCallbackWithoutReplyChannel(t *testing.T) {
+	rmp := NewRMProxy(nil)
+	callback := &recordingReleaseCallback{}
+	rmp.rmIDToCallback["rm-test"] = callback
+
+	release := &si.AllocationRelease{
+		ApplicationID:   "app-test",
+		PartitionName:   "default",
+		AllocationKey:   "alloc-test",
+		TerminationType: si.TerminationType_PREEMPTED_BY_SCHEDULER,
+		Message:         "test preemption",
+	}
+	event := &rmevent.RMReleaseAllocationEvent{
+		RmID:                "rm-test",
+		ReleasedAllocations: []*si.AllocationRelease{release},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		rmp.processRMReleaseAllocationEvent(event)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RM proxy did not finish processing release notification")
+	}
+
+	assert.Equal(t, len(callback.responses), 1)
+	assert.Equal(t, len(callback.responses[0].Released), 1)
+	got := callback.responses[0].Released[0]
+	assert.Equal(t, got.ApplicationID, release.ApplicationID)
+	assert.Equal(t, got.PartitionName, release.PartitionName)
+	assert.Equal(t, got.AllocationKey, release.AllocationKey)
+	assert.Equal(t, got.TerminationType, release.TerminationType)
+	assert.Equal(t, got.Message, release.Message)
+}
+
+func TestRMProxy_ProcessesEventAfterRelease(t *testing.T) {
+	rmp := NewRMProxy(nil)
+	callback := &recordingReleaseCallback{}
+	rmp.rmIDToCallback["rm-test"] = callback
+
+	rmp.StartService()
+	defer rmp.Stop()
+
+	rmp.HandleEvent(&rmevent.RMReleaseAllocationEvent{
+		RmID: "rm-test",
+		ReleasedAllocations: []*si.AllocationRelease{
+			{
+				ApplicationID:   "app-test",
+				AllocationKey:   "alloc-test",
+				TerminationType: si.TerminationType_TIMEOUT,
+			},
+		},
+	})
+
+	// This event's reply proves that the preceding release finished processing.
+	reply := make(chan *rmevent.Result, 1)
+	rmp.HandleEvent(&rmevent.RMNewAllocationsEvent{
+		RmID:        "rm-test",
+		Allocations: []*si.Allocation{},
+		Channel:     reply,
+	})
+
+	select {
+	case result := <-reply:
+		assert.Assert(t, result.Succeeded)
+	case <-time.After(time.Second):
+		t.Fatal("RM event loop did not process the event after release")
+	}
+
+	assert.Equal(t, len(callback.responses), 1)
+	assert.Equal(t, len(callback.responses[0].Released), 1)
+	assert.Equal(
+		t,
+		callback.responses[0].Released[0].AllocationKey,
+		"alloc-test",
+	)
 }

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -815,11 +815,9 @@ func (cc *ClusterContext) notifyRMNewAllocation(rmID string, alloc *objects.Allo
 // Create a RM update event to notify RM of released allocations
 // Lock free call, all updates occur via events.
 func (cc *ClusterContext) notifyRMAllocationReleased(rmID string, partitionName string, released []*objects.Allocation, terminationType si.TerminationType, message string) {
-	c := make(chan *rmevent.Result, 1)
 	releaseEvent := &rmevent.RMReleaseAllocationEvent{
 		ReleasedAllocations: make([]*si.AllocationRelease, 0),
 		RmID:                rmID,
-		Channel:             c,
 	}
 	for _, alloc := range released {
 		releaseEvent.ReleasedAllocations = append(releaseEvent.ReleasedAllocations, &si.AllocationRelease{
@@ -832,13 +830,6 @@ func (cc *ClusterContext) notifyRMAllocationReleased(rmID string, partitionName 
 	}
 
 	cc.rmEventHandler.HandleEvent(releaseEvent)
-	// Wait from channel
-	result := <-c
-	if result.Succeeded {
-		log.Log(log.SchedContext).Debug("Successfully synced shim on released allocations. response: " + result.Reason)
-	} else {
-		log.Log(log.SchedContext).Info("failed to sync shim on released allocations")
-	}
 }
 
 // Get a scheduling node based on its name from the partition.

--- a/pkg/scheduler/context_test.go
+++ b/pkg/scheduler/context_test.go
@@ -21,6 +21,7 @@ package scheduler
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -41,6 +42,7 @@ type mockEventHandler struct {
 	rejectedNodes   []*si.RejectedNode
 	acceptedNodes   []*si.AcceptedNode
 	newAllocHandler func(*rmevent.RMNewAllocationsEvent)
+	releaseHandler  func(event *rmevent.RMReleaseAllocationEvent)
 }
 
 func newMockEventHandler() *mockEventHandler {
@@ -60,6 +62,10 @@ func (m *mockEventHandler) HandleEvent(ev interface{}) {
 
 	if allocEvent, ok := ev.(*rmevent.RMNewAllocationsEvent); ok && m.newAllocHandler != nil {
 		m.newAllocHandler(allocEvent)
+	}
+
+	if releaseEvent, ok := ev.(*rmevent.RMReleaseAllocationEvent); ok && m.releaseHandler != nil {
+		m.releaseHandler(releaseEvent)
 	}
 }
 
@@ -444,4 +450,37 @@ outer:
 	}
 
 	assert.Assert(t, checked, "Failed to find metric")
+}
+
+func TestContextReleaseDoesNotWaitForRMReply(t *testing.T) {
+	received := make(chan *rmevent.RMReleaseAllocationEvent, 1)
+	handler := newMockEventHandler()
+	handler.releaseHandler = func(event *rmevent.RMReleaseAllocationEvent) {
+		received <- event
+	}
+	cc := &ClusterContext{rmEventHandler: handler}
+
+	done := make(chan struct{})
+	go func() {
+		cc.notifyRMAllocationReleased(
+			"rm-test", "default", nil,
+			si.TerminationType_TIMEOUT, "test release",
+		)
+		close(done)
+	}()
+
+	var event *rmevent.RMReleaseAllocationEvent
+	select {
+	case event = <-received:
+	case <-time.After(time.Second):
+		t.Fatal("RM release event was not sent")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("context release notification waited for an RM reply")
+	}
+
+	assert.Equal(t, event.RmID, "rm-test")
 }

--- a/pkg/scheduler/objects/allocation_result.go
+++ b/pkg/scheduler/objects/allocation_result.go
@@ -41,6 +41,8 @@ type AllocationResult struct {
 	NodeID                string
 	ReservedNodeID        string
 	CancelledReservations int
+	// consumed by Application.tryAllocate after it releases the application lock
+	releaseNotification *releaseNotification
 }
 
 func (ar *AllocationResult) String() string {

--- a/pkg/scheduler/objects/allocation_result.go
+++ b/pkg/scheduler/objects/allocation_result.go
@@ -41,8 +41,6 @@ type AllocationResult struct {
 	NodeID                string
 	ReservedNodeID        string
 	CancelledReservations int
-	// consumed by Application.tryAllocate after it releases the application lock
-	releaseNotification *releaseNotification
 }
 
 func (ar *AllocationResult) String() string {

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -323,52 +323,52 @@ func (sa *Application) setStateTimer(timeout time.Duration, currentState string,
 
 func (sa *Application) timeoutStateTimer(expectedState string, event applicationEvent) func() {
 	return func() {
-		var notification *releaseNotification
-		func() {
-			sa.Lock()
-			defer sa.Unlock()
+		sa.Lock()
+		defer sa.Unlock()
 
-			// make sure we are still in the right state
-			// we could have been failed or something might have happened while waiting for a lock
-			if expectedState == sa.stateMachine.Current() {
-				log.Log(log.SchedApplication).Debug("Application state: auto progress",
-					zap.String("applicationID", sa.ApplicationID),
-					zap.String("state", sa.stateMachine.Current()))
-				// if the app is completing, but there are placeholders left, first do the cleanup
-				if sa.IsCompleting() && !resources.IsZero(sa.allocatedPlaceholder) {
-					replacing := 0
-					preempted := 0
-					var toRelease []*Allocation
-					for _, alloc := range sa.getPlaceholderAllocations() {
-						// skip over the allocations that are already marked for release
-						if alloc.IsReleased() {
-							replacing++
-							continue
-						}
-						err := alloc.SetReleased(true)
-						if err != nil {
-							log.Log(log.SchedApplication).Warn("allocation is already preempted, so skipping release process",
-								zap.String("applicationID", sa.ApplicationID),
-								zap.String("allocationKey", alloc.GetAllocationKey()))
-							preempted++
-							continue
-						}
-						toRelease = append(toRelease, alloc)
+		// make sure we are still in the right state
+		// we could have been failed or something might have happened while waiting for a lock
+		if expectedState == sa.stateMachine.Current() {
+			log.Log(log.SchedApplication).Debug("Application state: auto progress",
+				zap.String("applicationID", sa.ApplicationID),
+				zap.String("state", sa.stateMachine.Current()))
+			// if the app is completing, but there are placeholders left, first do the cleanup
+			if sa.IsCompleting() && !resources.IsZero(sa.allocatedPlaceholder) {
+				replacing := 0
+				preempted := 0
+				var toRelease []*Allocation
+				for _, alloc := range sa.getPlaceholderAllocations() {
+					// skip over the allocations that are already marked for release
+					if alloc.IsReleased() {
+						replacing++
+						continue
 					}
-					log.Log(log.SchedApplication).Info("application is getting timed out, releasing allocated placeholders",
-						zap.String("AppID", sa.ApplicationID),
-						zap.Int("replaced", replacing),
-						zap.Int("preempted", preempted),
-						zap.Int("releasing", len(toRelease)))
-					notification = newReleaseNotification(toRelease, si.TerminationType_TIMEOUT, "releasing placeholders on app complete")
-					sa.clearStateTimer()
-				} else {
-					// nolint: errcheck
-					_ = sa.HandleApplicationEvent(event)
+					err := alloc.SetReleased(true)
+					if err != nil {
+						log.Log(log.SchedApplication).Warn("allocation is already preempted, so skipping release process",
+							zap.String("applicationID", sa.ApplicationID),
+							zap.String("allocationKey", alloc.GetAllocationKey()))
+						preempted++
+						continue
+					}
+					toRelease = append(toRelease, alloc)
 				}
+				log.Log(log.SchedApplication).Info("application is getting timed out, releasing allocated placeholders",
+					zap.String("AppID", sa.ApplicationID),
+					zap.Int("replaced", replacing),
+					zap.Int("preempted", preempted),
+					zap.Int("releasing", len(toRelease)))
+				sa.clearStateTimer()
+				sa.notifyRMAllocationReleased(
+					toRelease,
+					si.TerminationType_TIMEOUT,
+					"releasing placeholders on app complete",
+				)
+			} else {
+				// nolint: errcheck
+				_ = sa.HandleApplicationEvent(event)
 			}
-		}()
-		sa.notifyRMAllocationRelease(notification)
+		}
 	}
 }
 
@@ -412,21 +412,8 @@ func (sa *Application) clearPlaceholderTimer() {
 // If the application is in New or Accepted state we clean up and take followup action based on the gang scheduling
 // style.
 func (sa *Application) timeoutPlaceholderProcessing() {
-	var notifications []*releaseNotification
-	func() {
-		sa.Lock()
-		defer sa.Unlock()
-		notifications = sa.timeoutPlaceholderProcessingInternal()
-	}()
-	for _, notification := range notifications {
-		sa.notifyRMAllocationRelease(notification)
-	}
-}
-
-// timeoutPlaceholderProcessingInternal performs placeholder timeout state changes while the application is locked.
-// RM notifications are returned to the caller so they can be sent after releasing the application lock.
-func (sa *Application) timeoutPlaceholderProcessingInternal() []*releaseNotification {
-	var notifications []*releaseNotification
+	sa.Lock()
+	defer sa.Unlock()
 	if (sa.IsRunning() || sa.IsCompleting()) && !resources.IsZero(sa.allocatedPlaceholder) {
 		// Case 1: if all app's placeholders are allocated, only part of them gets replaced, just delete the remaining placeholders
 		var toRelease []*Allocation
@@ -454,7 +441,11 @@ func (sa *Application) timeoutPlaceholderProcessingInternal() []*releaseNotifica
 			zap.Int("preempted", preempted),
 			zap.Int("releasing", len(toRelease)))
 		// trigger the release of the placeholders: accounting updates when the release is done
-		notifications = append(notifications, newReleaseNotification(toRelease, si.TerminationType_TIMEOUT, "releasing allocated placeholders on placeholder timeout"))
+		sa.notifyRMAllocationReleased(
+			toRelease,
+			si.TerminationType_TIMEOUT,
+			"releasing allocated placeholders on placeholder timeout",
+		)
 	} else {
 		// Case 2: in every other case progress the application, and notify the context about the expired placeholders
 		// change the status of the app based on gang style: soft resume normal allocations, hard fail the app
@@ -506,12 +497,19 @@ func (sa *Application) timeoutPlaceholderProcessingInternal() []*releaseNotifica
 		released := sa.removeAsksInternal("", si.EventRecord_REQUEST_TIMEOUT)
 		sa.executeReservationReleasedCallback(released)
 		// trigger the release of the allocated placeholders: accounting updates when the release is done
-		notifications = append(notifications, newReleaseNotification(toRelease, si.TerminationType_TIMEOUT, "releasing allocated placeholders on placeholder timeout"))
+		sa.notifyRMAllocationReleased(
+			toRelease,
+			si.TerminationType_TIMEOUT,
+			"releasing allocated placeholders on placeholder timeout",
+		)
 		// trigger the release of the pending placeholders: accounting has been done
-		notifications = append(notifications, newReleaseNotification(pendingRelease, si.TerminationType_TIMEOUT, "releasing pending placeholders on placeholder timeout"))
+		sa.notifyRMAllocationReleased(
+			pendingRelease,
+			si.TerminationType_TIMEOUT,
+			"releasing pending placeholders on placeholder timeout",
+		)
 	}
 	sa.clearPlaceholderTimer()
-	return notifications
 }
 
 // GetReservations returns an array of all reservation keys for the application.
@@ -1175,21 +1173,9 @@ func (sa *Application) canReplace(request *Allocation) bool {
 
 // tryAllocate will perform a regular allocation of a pending request, includes placeholders.
 func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption bool, preemptionDelay time.Duration, preemptAttemptsRemaining *int, nodeIterator func() NodeIterator, fullNodeIterator func() NodeIterator, getNodeFn func(string) *Node) *AllocationResult {
-	var result *AllocationResult
-	func() {
-		sa.Lock()
-		defer sa.Unlock()
-		result = sa.tryAllocateInternal(headRoom, allowPreemption, preemptionDelay, preemptAttemptsRemaining, nodeIterator, fullNodeIterator, getNodeFn)
-	}()
-	if result != nil {
-		sa.notifyRMAllocationRelease(result.releaseNotification)
-		result.releaseNotification = nil
-	}
-	return result
-}
+	sa.Lock()
+	defer sa.Unlock()
 
-// tryAllocateInternal performs allocation state changes while the application is locked.
-func (sa *Application) tryAllocateInternal(headRoom *resources.Resource, allowPreemption bool, preemptionDelay time.Duration, preemptAttemptsRemaining *int, nodeIterator func() NodeIterator, fullNodeIterator func() NodeIterator, getNodeFn func(string) *Node) *AllocationResult {
 	if len(sa.sortedRequests) == 0 {
 		return nil
 	}
@@ -1386,28 +1372,12 @@ func (sa *Application) cancelReservations(reservations []*reservation) int {
 //
 //nolint:funlen
 func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, getNodeFn func(string) *Node) *AllocationResult {
-	var result *AllocationResult
-	var notifications []*releaseNotification
-	func() {
-		sa.Lock()
-		defer sa.Unlock()
-		result, notifications = sa.tryPlaceholderAllocateInternal(nodeIterator, getNodeFn)
-	}()
-	for _, notification := range notifications {
-		sa.notifyRMAllocationRelease(notification)
-	}
-	return result
-}
+	sa.Lock()
+	defer sa.Unlock()
 
-// tryPlaceholderAllocateInternal performs placeholder replacement while the application is locked.
-// Incompatible placeholders are returned so the RM can be notified after releasing the lock.
-//
-//nolint:funlen
-func (sa *Application) tryPlaceholderAllocateInternal(nodeIterator func() NodeIterator, getNodeFn func(string) *Node) (*AllocationResult, []*releaseNotification) {
-	var notifications []*releaseNotification
 	// nothing to do if we have no placeholders allocated
 	if resources.IsZero(sa.allocatedPlaceholder) || sa.sortedRequests == nil {
-		return nil, nil
+		return nil
 	}
 	// keep the first fits for later
 	var phFit *Allocation
@@ -1445,7 +1415,11 @@ func (sa *Application) tryPlaceholderAllocateInternal(nodeIterator func() NodeIt
 						zap.String("applicationID", sa.ApplicationID),
 						zap.String("allocationKey", ph.GetAllocationKey()))
 				} else {
-					notifications = append(notifications, newReleaseNotification([]*Allocation{ph}, si.TerminationType_TIMEOUT, "cancel placeholder: resource incompatible"))
+					sa.notifyRMAllocationReleased(
+						[]*Allocation{ph},
+						si.TerminationType_TIMEOUT,
+						"cancel placeholder: resource incompatible",
+					)
 					sa.appEvents.SendPlaceholderLargerEvent(ph.taskGroupName, sa.ApplicationID, ph.allocationKey, request.GetAllocatedResource(), ph.GetAllocatedResource())
 				}
 				continue
@@ -1494,7 +1468,7 @@ func (sa *Application) tryPlaceholderAllocateInternal(nodeIterator func() NodeIt
 				request.SetBindTime(time.Now())
 				request.SetNodeID(node.NodeID)
 				request.SetInstanceType(node.GetInstanceType())
-				return newReplacedAllocationResult(node.NodeID, request), notifications
+				return newReplacedAllocationResult(node.NodeID, request)
 			}
 		}
 	}
@@ -1502,7 +1476,7 @@ func (sa *Application) tryPlaceholderAllocateInternal(nodeIterator func() NodeIt
 	// cannot allocate if the iterator is not giving us any schedulable nodes
 	iterator := nodeIterator()
 	if iterator == nil {
-		return nil, notifications
+		return nil
 	}
 
 	// we checked all placeholders and asks nothing worked as yet
@@ -1514,7 +1488,7 @@ func (sa *Application) tryPlaceholderAllocateInternal(nodeIterator func() NodeIt
 		// run predicates for this pod before in hand and fetch feasible nodes
 		feasibleNodes, predicatesResult := reqFit.preAllocateConditions(true)
 		if !predicatesResult {
-			return nil, notifications
+			return nil
 		}
 		iterator.ForEachNode(func(node *Node) bool {
 			if !node.IsSchedulable() {
@@ -1604,7 +1578,7 @@ func (sa *Application) tryPlaceholderAllocateInternal(nodeIterator func() NodeIt
 		})
 	}
 	// still nothing worked give up and hope the next round works
-	return allocResult, notifications
+	return allocResult
 }
 
 // check ask against both user headRoom and queue headRoom
@@ -1615,22 +1589,9 @@ func (sa *Application) checkHeadRooms(ask *Allocation, userHeadroom *resources.R
 
 // tryReservedAllocate tries allocating an outstanding reservation
 func (sa *Application) tryReservedAllocate(headRoom *resources.Resource, nodeIterator func() NodeIterator) *AllocationResult {
-	var result *AllocationResult
-	var notifications []*releaseNotification
-	func() {
-		sa.Lock()
-		defer sa.Unlock()
-		result, notifications = sa.tryReservedAllocateInternal(headRoom, nodeIterator)
-	}()
-	for _, notification := range notifications {
-		sa.notifyRMAllocationRelease(notification)
-	}
-	return result
-}
+	sa.Lock()
+	defer sa.Unlock()
 
-// tryReservedAllocateInternal performs reserved allocation state changes while the application is locked.
-func (sa *Application) tryReservedAllocateInternal(headRoom *resources.Resource, nodeIterator func() NodeIterator) (*AllocationResult, []*releaseNotification) {
-	var notifications []*releaseNotification
 	// calculate the users' headroom, includes group check which requires the applicationID
 	userHeadroom := ugm.GetUserManager().Headroom(sa.queuePath, sa.ApplicationID, sa.user)
 
@@ -1651,7 +1612,7 @@ func (sa *Application) tryReservedAllocateInternal(headRoom *resources.Resource,
 				unreserveAsk = ask
 			}
 			// remove the reservation as this should not be reserved
-			return newUnreservedAllocationResult(reserve.nodeID, unreserveAsk), notifications
+			return newUnreservedAllocationResult(reserve.nodeID, unreserveAsk)
 		}
 
 		if !sa.checkHeadRooms(ask, userHeadroom, headRoom) {
@@ -1672,9 +1633,7 @@ func (sa *Application) tryReservedAllocateInternal(headRoom *resources.Resource,
 			if !reserve.node.CanAllocate(ask.GetAllocatedResource()) && !ask.HasTriggeredPreemption() {
 				// try preemption and see if we can free up resource
 				preemptor := NewRequiredNodePreemptor(reserve.node, ask, sa)
-				if notification := preemptor.tryPreemption(); notification != nil {
-					notifications = append(notifications, notification)
-				}
+				preemptor.tryPreemption()
 				continue
 			}
 		}
@@ -1702,7 +1661,7 @@ func (sa *Application) tryReservedAllocateInternal(headRoom *resources.Resource,
 		// allocation worked fix the resultType and return
 		if result != nil {
 			result.ResultType = AllocatedReserved
-			return result, notifications
+			return result
 		}
 	}
 
@@ -1721,11 +1680,11 @@ func (sa *Application) tryReservedAllocateInternal(headRoom *resources.Resource,
 			result := sa.tryNodesNoReserve(alloc, iterator, reserve.nodeID)
 			// have a candidate return it, including the node that was reserved
 			if result != nil {
-				return result, notifications
+				return result
 			}
 		}
 	}
-	return nil, notifications
+	return nil
 }
 
 func (sa *Application) tryPreemption(headRoom *resources.Resource, preemptionDelay time.Duration, preemptionAttemptsRemaining *int, ask *Allocation, iterator NodeIterator, nodesTried bool) (*AllocationResult, bool) {
@@ -2398,43 +2357,17 @@ func (sa *Application) executeReservationReleasedCallback(released int) {
 	}
 }
 
-type releaseNotification struct {
-	released        []*Allocation
-	terminationType si.TerminationType
-	message         string
-}
-
-func newReleaseNotification(released []*Allocation, terminationType si.TerminationType, message string) *releaseNotification {
-	if len(released) == 0 {
-		return nil
-	}
-	return &releaseNotification{
-		released:        released,
-		terminationType: terminationType,
-		message:         message,
-	}
-}
-
-func (sa *Application) notifyRMAllocationRelease(notification *releaseNotification) {
-	if notification == nil {
-		return
-	}
-	sa.notifyRMAllocationReleased(notification.released, notification.terminationType, notification.message)
-}
-
-// notifyRMAllocationReleased send an allocation release event to the RM to if the event handler is configured
-// and at least one allocation has been released.
-// Must not be called while holding the application lock.
+// notifyRMAllocationReleased enqueues allocation releases when an event handler
+// is configured and the release list is non-empty. It does not wait for an RM reply.
+// The event handler must enqueue without waiting for RM processing.
 func (sa *Application) notifyRMAllocationReleased(released []*Allocation, terminationType si.TerminationType, message string) {
 	// only generate event if needed
 	if len(released) == 0 || sa.rmEventHandler == nil {
 		return
 	}
-	c := make(chan *rmevent.Result, 1)
 	releaseEvent := &rmevent.RMReleaseAllocationEvent{
 		ReleasedAllocations: make([]*si.AllocationRelease, 0),
 		RmID:                sa.rmID,
-		Channel:             c,
 	}
 	for _, alloc := range released {
 		releaseEvent.ReleasedAllocations = append(releaseEvent.ReleasedAllocations, &si.AllocationRelease{
@@ -2446,13 +2379,6 @@ func (sa *Application) notifyRMAllocationReleased(released []*Allocation, termin
 		})
 	}
 	sa.rmEventHandler.HandleEvent(releaseEvent)
-	// Wait from channel
-	result := <-c
-	if result.Succeeded {
-		log.Log(log.SchedApplication).Debug("Successfully synced shim on released allocations. response: " + result.Reason)
-	} else {
-		log.Log(log.SchedApplication).Info("failed to sync shim on released allocations")
-	}
 }
 
 func (sa *Application) IsAllocationAssignedToApp(alloc *Allocation) bool {

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -323,48 +323,52 @@ func (sa *Application) setStateTimer(timeout time.Duration, currentState string,
 
 func (sa *Application) timeoutStateTimer(expectedState string, event applicationEvent) func() {
 	return func() {
-		sa.Lock()
-		defer sa.Unlock()
+		var notification *releaseNotification
+		func() {
+			sa.Lock()
+			defer sa.Unlock()
 
-		// make sure we are still in the right state
-		// we could have been failed or something might have happened while waiting for a lock
-		if expectedState == sa.stateMachine.Current() {
-			log.Log(log.SchedApplication).Debug("Application state: auto progress",
-				zap.String("applicationID", sa.ApplicationID),
-				zap.String("state", sa.stateMachine.Current()))
-			// if the app is completing, but there are placeholders left, first do the cleanup
-			if sa.IsCompleting() && !resources.IsZero(sa.allocatedPlaceholder) {
-				replacing := 0
-				preempted := 0
-				var toRelease []*Allocation
-				for _, alloc := range sa.getPlaceholderAllocations() {
-					// skip over the allocations that are already marked for release
-					if alloc.IsReleased() {
-						replacing++
-						continue
+			// make sure we are still in the right state
+			// we could have been failed or something might have happened while waiting for a lock
+			if expectedState == sa.stateMachine.Current() {
+				log.Log(log.SchedApplication).Debug("Application state: auto progress",
+					zap.String("applicationID", sa.ApplicationID),
+					zap.String("state", sa.stateMachine.Current()))
+				// if the app is completing, but there are placeholders left, first do the cleanup
+				if sa.IsCompleting() && !resources.IsZero(sa.allocatedPlaceholder) {
+					replacing := 0
+					preempted := 0
+					var toRelease []*Allocation
+					for _, alloc := range sa.getPlaceholderAllocations() {
+						// skip over the allocations that are already marked for release
+						if alloc.IsReleased() {
+							replacing++
+							continue
+						}
+						err := alloc.SetReleased(true)
+						if err != nil {
+							log.Log(log.SchedApplication).Warn("allocation is already preempted, so skipping release process",
+								zap.String("applicationID", sa.ApplicationID),
+								zap.String("allocationKey", alloc.GetAllocationKey()))
+							preempted++
+							continue
+						}
+						toRelease = append(toRelease, alloc)
 					}
-					err := alloc.SetReleased(true)
-					if err != nil {
-						log.Log(log.SchedApplication).Warn("allocation is already preempted, so skipping release process",
-							zap.String("applicationID", sa.ApplicationID),
-							zap.String("allocationKey", alloc.GetAllocationKey()))
-						preempted++
-						continue
-					}
-					toRelease = append(toRelease, alloc)
+					log.Log(log.SchedApplication).Info("application is getting timed out, releasing allocated placeholders",
+						zap.String("AppID", sa.ApplicationID),
+						zap.Int("replaced", replacing),
+						zap.Int("preempted", preempted),
+						zap.Int("releasing", len(toRelease)))
+					notification = newReleaseNotification(toRelease, si.TerminationType_TIMEOUT, "releasing placeholders on app complete")
+					sa.clearStateTimer()
+				} else {
+					// nolint: errcheck
+					_ = sa.HandleApplicationEvent(event)
 				}
-				log.Log(log.SchedApplication).Info("application is getting timed out, releasing allocated placeholders",
-					zap.String("AppID", sa.ApplicationID),
-					zap.Int("replaced", replacing),
-					zap.Int("preempted", preempted),
-					zap.Int("releasing", len(toRelease)))
-				sa.notifyRMAllocationReleased(toRelease, si.TerminationType_TIMEOUT, "releasing placeholders on app complete")
-				sa.clearStateTimer()
-			} else {
-				// nolint: errcheck
-				_ = sa.HandleApplicationEvent(event)
 			}
-		}
+		}()
+		sa.notifyRMAllocationRelease(notification)
 	}
 }
 
@@ -408,8 +412,21 @@ func (sa *Application) clearPlaceholderTimer() {
 // If the application is in New or Accepted state we clean up and take followup action based on the gang scheduling
 // style.
 func (sa *Application) timeoutPlaceholderProcessing() {
-	sa.Lock()
-	defer sa.Unlock()
+	var notifications []*releaseNotification
+	func() {
+		sa.Lock()
+		defer sa.Unlock()
+		notifications = sa.timeoutPlaceholderProcessingInternal()
+	}()
+	for _, notification := range notifications {
+		sa.notifyRMAllocationRelease(notification)
+	}
+}
+
+// timeoutPlaceholderProcessingInternal performs placeholder timeout state changes while the application is locked.
+// RM notifications are returned to the caller so they can be sent after releasing the application lock.
+func (sa *Application) timeoutPlaceholderProcessingInternal() []*releaseNotification {
+	var notifications []*releaseNotification
 	if (sa.IsRunning() || sa.IsCompleting()) && !resources.IsZero(sa.allocatedPlaceholder) {
 		// Case 1: if all app's placeholders are allocated, only part of them gets replaced, just delete the remaining placeholders
 		var toRelease []*Allocation
@@ -437,7 +454,7 @@ func (sa *Application) timeoutPlaceholderProcessing() {
 			zap.Int("preempted", preempted),
 			zap.Int("releasing", len(toRelease)))
 		// trigger the release of the placeholders: accounting updates when the release is done
-		sa.notifyRMAllocationReleased(toRelease, si.TerminationType_TIMEOUT, "releasing allocated placeholders on placeholder timeout")
+		notifications = append(notifications, newReleaseNotification(toRelease, si.TerminationType_TIMEOUT, "releasing allocated placeholders on placeholder timeout"))
 	} else {
 		// Case 2: in every other case progress the application, and notify the context about the expired placeholders
 		// change the status of the app based on gang style: soft resume normal allocations, hard fail the app
@@ -489,11 +506,12 @@ func (sa *Application) timeoutPlaceholderProcessing() {
 		released := sa.removeAsksInternal("", si.EventRecord_REQUEST_TIMEOUT)
 		sa.executeReservationReleasedCallback(released)
 		// trigger the release of the allocated placeholders: accounting updates when the release is done
-		sa.notifyRMAllocationReleased(toRelease, si.TerminationType_TIMEOUT, "releasing allocated placeholders on placeholder timeout")
+		notifications = append(notifications, newReleaseNotification(toRelease, si.TerminationType_TIMEOUT, "releasing allocated placeholders on placeholder timeout"))
 		// trigger the release of the pending placeholders: accounting has been done
-		sa.notifyRMAllocationReleased(pendingRelease, si.TerminationType_TIMEOUT, "releasing pending placeholders on placeholder timeout")
+		notifications = append(notifications, newReleaseNotification(pendingRelease, si.TerminationType_TIMEOUT, "releasing pending placeholders on placeholder timeout"))
 	}
 	sa.clearPlaceholderTimer()
+	return notifications
 }
 
 // GetReservations returns an array of all reservation keys for the application.
@@ -1157,8 +1175,21 @@ func (sa *Application) canReplace(request *Allocation) bool {
 
 // tryAllocate will perform a regular allocation of a pending request, includes placeholders.
 func (sa *Application) tryAllocate(headRoom *resources.Resource, allowPreemption bool, preemptionDelay time.Duration, preemptAttemptsRemaining *int, nodeIterator func() NodeIterator, fullNodeIterator func() NodeIterator, getNodeFn func(string) *Node) *AllocationResult {
-	sa.Lock()
-	defer sa.Unlock()
+	var result *AllocationResult
+	func() {
+		sa.Lock()
+		defer sa.Unlock()
+		result = sa.tryAllocateInternal(headRoom, allowPreemption, preemptionDelay, preemptAttemptsRemaining, nodeIterator, fullNodeIterator, getNodeFn)
+	}()
+	if result != nil {
+		sa.notifyRMAllocationRelease(result.releaseNotification)
+		result.releaseNotification = nil
+	}
+	return result
+}
+
+// tryAllocateInternal performs allocation state changes while the application is locked.
+func (sa *Application) tryAllocateInternal(headRoom *resources.Resource, allowPreemption bool, preemptionDelay time.Duration, preemptAttemptsRemaining *int, nodeIterator func() NodeIterator, fullNodeIterator func() NodeIterator, getNodeFn func(string) *Node) *AllocationResult {
 	if len(sa.sortedRequests) == 0 {
 		return nil
 	}
@@ -1355,11 +1386,28 @@ func (sa *Application) cancelReservations(reservations []*reservation) int {
 //
 //nolint:funlen
 func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, getNodeFn func(string) *Node) *AllocationResult {
-	sa.Lock()
-	defer sa.Unlock()
+	var result *AllocationResult
+	var notifications []*releaseNotification
+	func() {
+		sa.Lock()
+		defer sa.Unlock()
+		result, notifications = sa.tryPlaceholderAllocateInternal(nodeIterator, getNodeFn)
+	}()
+	for _, notification := range notifications {
+		sa.notifyRMAllocationRelease(notification)
+	}
+	return result
+}
+
+// tryPlaceholderAllocateInternal performs placeholder replacement while the application is locked.
+// Incompatible placeholders are returned so the RM can be notified after releasing the lock.
+//
+//nolint:funlen
+func (sa *Application) tryPlaceholderAllocateInternal(nodeIterator func() NodeIterator, getNodeFn func(string) *Node) (*AllocationResult, []*releaseNotification) {
+	var notifications []*releaseNotification
 	// nothing to do if we have no placeholders allocated
 	if resources.IsZero(sa.allocatedPlaceholder) || sa.sortedRequests == nil {
-		return nil
+		return nil, nil
 	}
 	// keep the first fits for later
 	var phFit *Allocation
@@ -1397,7 +1445,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 						zap.String("applicationID", sa.ApplicationID),
 						zap.String("allocationKey", ph.GetAllocationKey()))
 				} else {
-					sa.notifyRMAllocationReleased([]*Allocation{ph}, si.TerminationType_TIMEOUT, "cancel placeholder: resource incompatible")
+					notifications = append(notifications, newReleaseNotification([]*Allocation{ph}, si.TerminationType_TIMEOUT, "cancel placeholder: resource incompatible"))
 					sa.appEvents.SendPlaceholderLargerEvent(ph.taskGroupName, sa.ApplicationID, ph.allocationKey, request.GetAllocatedResource(), ph.GetAllocatedResource())
 				}
 				continue
@@ -1446,7 +1494,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 				request.SetBindTime(time.Now())
 				request.SetNodeID(node.NodeID)
 				request.SetInstanceType(node.GetInstanceType())
-				return newReplacedAllocationResult(node.NodeID, request)
+				return newReplacedAllocationResult(node.NodeID, request), notifications
 			}
 		}
 	}
@@ -1454,7 +1502,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 	// cannot allocate if the iterator is not giving us any schedulable nodes
 	iterator := nodeIterator()
 	if iterator == nil {
-		return nil
+		return nil, notifications
 	}
 
 	// we checked all placeholders and asks nothing worked as yet
@@ -1466,7 +1514,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 		// run predicates for this pod before in hand and fetch feasible nodes
 		feasibleNodes, predicatesResult := reqFit.preAllocateConditions(true)
 		if !predicatesResult {
-			return nil
+			return nil, notifications
 		}
 		iterator.ForEachNode(func(node *Node) bool {
 			if !node.IsSchedulable() {
@@ -1556,7 +1604,7 @@ func (sa *Application) tryPlaceholderAllocate(nodeIterator func() NodeIterator, 
 		})
 	}
 	// still nothing worked give up and hope the next round works
-	return allocResult
+	return allocResult, notifications
 }
 
 // check ask against both user headRoom and queue headRoom
@@ -1567,8 +1615,22 @@ func (sa *Application) checkHeadRooms(ask *Allocation, userHeadroom *resources.R
 
 // tryReservedAllocate tries allocating an outstanding reservation
 func (sa *Application) tryReservedAllocate(headRoom *resources.Resource, nodeIterator func() NodeIterator) *AllocationResult {
-	sa.Lock()
-	defer sa.Unlock()
+	var result *AllocationResult
+	var notifications []*releaseNotification
+	func() {
+		sa.Lock()
+		defer sa.Unlock()
+		result, notifications = sa.tryReservedAllocateInternal(headRoom, nodeIterator)
+	}()
+	for _, notification := range notifications {
+		sa.notifyRMAllocationRelease(notification)
+	}
+	return result
+}
+
+// tryReservedAllocateInternal performs reserved allocation state changes while the application is locked.
+func (sa *Application) tryReservedAllocateInternal(headRoom *resources.Resource, nodeIterator func() NodeIterator) (*AllocationResult, []*releaseNotification) {
+	var notifications []*releaseNotification
 	// calculate the users' headroom, includes group check which requires the applicationID
 	userHeadroom := ugm.GetUserManager().Headroom(sa.queuePath, sa.ApplicationID, sa.user)
 
@@ -1589,7 +1651,7 @@ func (sa *Application) tryReservedAllocate(headRoom *resources.Resource, nodeIte
 				unreserveAsk = ask
 			}
 			// remove the reservation as this should not be reserved
-			return newUnreservedAllocationResult(reserve.nodeID, unreserveAsk)
+			return newUnreservedAllocationResult(reserve.nodeID, unreserveAsk), notifications
 		}
 
 		if !sa.checkHeadRooms(ask, userHeadroom, headRoom) {
@@ -1610,7 +1672,9 @@ func (sa *Application) tryReservedAllocate(headRoom *resources.Resource, nodeIte
 			if !reserve.node.CanAllocate(ask.GetAllocatedResource()) && !ask.HasTriggeredPreemption() {
 				// try preemption and see if we can free up resource
 				preemptor := NewRequiredNodePreemptor(reserve.node, ask, sa)
-				preemptor.tryPreemption()
+				if notification := preemptor.tryPreemption(); notification != nil {
+					notifications = append(notifications, notification)
+				}
 				continue
 			}
 		}
@@ -1638,7 +1702,7 @@ func (sa *Application) tryReservedAllocate(headRoom *resources.Resource, nodeIte
 		// allocation worked fix the resultType and return
 		if result != nil {
 			result.ResultType = AllocatedReserved
-			return result
+			return result, notifications
 		}
 	}
 
@@ -1657,11 +1721,11 @@ func (sa *Application) tryReservedAllocate(headRoom *resources.Resource, nodeIte
 			result := sa.tryNodesNoReserve(alloc, iterator, reserve.nodeID)
 			// have a candidate return it, including the node that was reserved
 			if result != nil {
-				return result
+				return result, notifications
 			}
 		}
 	}
-	return nil
+	return nil, notifications
 }
 
 func (sa *Application) tryPreemption(headRoom *resources.Resource, preemptionDelay time.Duration, preemptionAttemptsRemaining *int, ask *Allocation, iterator NodeIterator, nodesTried bool) (*AllocationResult, bool) {
@@ -2334,9 +2398,33 @@ func (sa *Application) executeReservationReleasedCallback(released int) {
 	}
 }
 
+type releaseNotification struct {
+	released        []*Allocation
+	terminationType si.TerminationType
+	message         string
+}
+
+func newReleaseNotification(released []*Allocation, terminationType si.TerminationType, message string) *releaseNotification {
+	if len(released) == 0 {
+		return nil
+	}
+	return &releaseNotification{
+		released:        released,
+		terminationType: terminationType,
+		message:         message,
+	}
+}
+
+func (sa *Application) notifyRMAllocationRelease(notification *releaseNotification) {
+	if notification == nil {
+		return
+	}
+	sa.notifyRMAllocationReleased(notification.released, notification.terminationType, notification.message)
+}
+
 // notifyRMAllocationReleased send an allocation release event to the RM to if the event handler is configured
 // and at least one allocation has been released.
-// No locking must be called while holding the lock
+// Must not be called while holding the application lock.
 func (sa *Application) notifyRMAllocationReleased(released []*Allocation, terminationType si.TerminationType, message string) {
 	// only generate event if needed
 	if len(released) == 0 || sa.rmEventHandler == nil {

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -1699,6 +1699,96 @@ func TestTimeoutPlaceholderAllocReleased(t *testing.T) {
 	assertUserGroupResource(t, getTestUserGroup(), res)
 }
 
+func TestTimeoutPlaceholderProcessingUnlocksBeforeRMReply(t *testing.T) {
+	setupUGM()
+	app := newApplication(appID1, "default", "root.a")
+	app.SetState(Accepted.String())
+
+	res := resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 100, "vcores": 10})
+	ph := newPlaceholderAlloc(appID1, nodeID1, res, tg1)
+	app.AddAllocation(ph)
+	app.addPlaceholderDataWithLocking(ph)
+	app.SetState(Running.String())
+	app.clearPlaceholderTimer()
+
+	releaseReceived := make(chan *rmevent.RMReleaseAllocationEvent, 1)
+	app.rmEventHandler = &mockAppEventHandler{
+		callback: func(ev interface{}) {
+			if releaseEvent, ok := ev.(*rmevent.RMReleaseAllocationEvent); ok {
+				releaseReceived <- releaseEvent
+			}
+		},
+	}
+
+	timeoutDone := make(chan struct{})
+	go func() {
+		app.timeoutPlaceholderProcessing()
+		close(timeoutDone)
+	}()
+	releaseEvent := waitForRMReleaseEvent(t, releaseReceived)
+
+	lockAcquired := make(chan struct{})
+	go func() {
+		app.Lock()
+		close(lockAcquired)
+		app.Unlock()
+	}()
+	select {
+	case <-lockAcquired:
+		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+	case <-time.After(time.Second):
+		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+		<-lockAcquired
+		t.Fatal("application lock held while waiting for placeholder timeout release response")
+	}
+	<-timeoutDone
+	assert.Equal(t, len(releaseEvent.ReleasedAllocations), 1)
+	assert.Equal(t, releaseEvent.ReleasedAllocations[0].AllocationKey, ph.GetAllocationKey())
+}
+
+func TestTimeoutStateTimerUnlocksBeforeRMReply(t *testing.T) {
+	setupUGM()
+	app := newApplication(appID1, "default", "root.a")
+	app.SetState(Accepted.String())
+	res := resources.NewResourceFromMap(map[string]resources.Quantity{"memory": 100})
+	ph := newPlaceholderAlloc(appID1, nodeID1, res, tg1)
+	app.AddAllocation(ph)
+	app.addPlaceholderDataWithLocking(ph)
+	app.clearPlaceholderTimer()
+	app.SetState(Completing.String())
+
+	releaseReceived := make(chan *rmevent.RMReleaseAllocationEvent, 1)
+	app.rmEventHandler = &mockAppEventHandler{callback: func(ev interface{}) {
+		if releaseEvent, ok := ev.(*rmevent.RMReleaseAllocationEvent); ok {
+			releaseReceived <- releaseEvent
+		}
+	}}
+
+	timerDone := make(chan struct{})
+	go func() {
+		app.timeoutStateTimer(Completing.String(), CompleteApplication)()
+		close(timerDone)
+	}()
+	releaseEvent := waitForRMReleaseEvent(t, releaseReceived)
+	lockAcquired := make(chan struct{})
+	go func() {
+		app.Lock()
+		close(lockAcquired)
+		app.Unlock()
+	}()
+	select {
+	case <-lockAcquired:
+		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+	case <-time.After(time.Second):
+		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+		<-lockAcquired
+		t.Fatal("application lock held while waiting for state timeout release response")
+	}
+	<-timerDone
+	assert.Equal(t, len(releaseEvent.ReleasedAllocations), 1)
+	assert.Equal(t, releaseEvent.ReleasedAllocations[0].AllocationKey, ph.GetAllocationKey())
+}
+
 func TestTimeoutPlaceholderAllocPreempted(t *testing.T) {
 	setupUGM()
 
@@ -3670,15 +3760,12 @@ func TestRequiredNodePreemption(t *testing.T) {
 	// tests successful RequiredNode (DaemonSet) preemption
 	app := newApplication(appID0, "default", "root.default")
 	var releaseEvents []*rmevent.RMReleaseAllocationEvent
+	releaseReceived := make(chan *rmevent.RMReleaseAllocationEvent, 1)
 	app.rmEventHandler = &mockAppEventHandler{
 		callback: func(ev interface{}) {
 			if rmEvent, ok := ev.(*rmevent.RMReleaseAllocationEvent); ok {
 				releaseEvents = append(releaseEvents, rmEvent)
-				go func() {
-					rmEvent.Channel <- &rmevent.Result{
-						Succeeded: true,
-					}
-				}()
+				releaseReceived <- rmEvent
 			}
 		},
 	}
@@ -3727,8 +3814,28 @@ func TestRequiredNodePreemption(t *testing.T) {
 	err = app.Reserve(node, ask2)
 	assert.NilError(t, err, "reservation failed")
 
-	// preemption
-	assert.Assert(t, app.tryReservedAllocate(headRoom, iterator) == nil, "unexpected result from reserved allocation")
+	// Preemption waits for the RM response, but must not hold the application lock while waiting.
+	preemptionDone := make(chan *AllocationResult, 1)
+	go func() {
+		preemptionDone <- app.tryReservedAllocate(headRoom, iterator)
+	}()
+	releaseEvent := waitForRMReleaseEvent(t, releaseReceived)
+	lockAcquired := make(chan struct{})
+	go func() {
+		app.Lock()
+		close(lockAcquired)
+		app.Unlock()
+	}()
+	select {
+	case <-lockAcquired:
+		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+	case <-time.After(time.Second):
+		// Unblock the operation before failing so the test does not leak goroutines.
+		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+		<-lockAcquired
+		t.Fatal("application lock held while waiting for RM release response")
+	}
+	assert.Assert(t, <-preemptionDone == nil, "unexpected result from reserved allocation")
 	assert.Assert(t, ask1.IsPreempted(), "ask1 has not been preempted")
 	assert.Assert(t, ask2.HasTriggeredPreemption(), "ask2 has not triggered preemption")
 	assert.Equal(t, 1, len(releaseEvents), "unexpected number of release events")
@@ -3953,6 +4060,17 @@ func (m mockAppEventHandler) HandleEvent(ev interface{}) {
 	m.callback(ev)
 }
 
+func waitForRMReleaseEvent(t *testing.T, events <-chan *rmevent.RMReleaseAllocationEvent) *rmevent.RMReleaseAllocationEvent {
+	t.Helper()
+	select {
+	case event := <-events:
+		return event
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for RM release event")
+		return nil
+	}
+}
+
 func TestApplication_canAllocationReserve(t *testing.T) {
 	res := resources.NewResource()
 	tests := []struct {
@@ -4049,6 +4167,12 @@ func TestTryPlaceHolderAllocateLargerRequest(t *testing.T) {
 	}
 
 	app := newApplication(appID0, "default", "root.default")
+	releaseReceived := make(chan *rmevent.RMReleaseAllocationEvent, 1)
+	app.rmEventHandler = &mockAppEventHandler{callback: func(ev interface{}) {
+		if releaseEvent, ok := ev.(*rmevent.RMReleaseAllocationEvent); ok {
+			releaseReceived <- releaseEvent
+		}
+	}}
 
 	queue, err := createRootQueue(nil)
 	assert.NilError(t, err, "queue create failed")
@@ -4067,7 +4191,26 @@ func TestTryPlaceHolderAllocateLargerRequest(t *testing.T) {
 	err = app.AddAllocationAsk(ask)
 	assert.NilError(t, err, "ask should have been added to app")
 
-	result := app.tryPlaceholderAllocate(iterator, getNode)
+	resultReceived := make(chan *AllocationResult, 1)
+	go func() {
+		resultReceived <- app.tryPlaceholderAllocate(iterator, getNode)
+	}()
+	releaseEvent := waitForRMReleaseEvent(t, releaseReceived)
+	lockAcquired := make(chan struct{})
+	go func() {
+		app.Lock()
+		close(lockAcquired)
+		app.Unlock()
+	}()
+	select {
+	case <-lockAcquired:
+		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+	case <-time.After(time.Second):
+		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+		<-lockAcquired
+		t.Fatal("application lock held while waiting for incompatible placeholder release response")
+	}
+	result := <-resultReceived
 	assert.Assert(t, result == nil, "result should be nil since the ask is larger than the placeholder")
 	assert.Assert(t, ph.IsReleased(), "placeholder should have been released")
 	// placeholder data remains unchanged until RM confirms the release

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -1699,7 +1699,7 @@ func TestTimeoutPlaceholderAllocReleased(t *testing.T) {
 	assertUserGroupResource(t, getTestUserGroup(), res)
 }
 
-func TestTimeoutPlaceholderProcessingUnlocksBeforeRMReply(t *testing.T) {
+func TestTimeoutPlaceholderProcessingDoesNotWaitForRMReply(t *testing.T) {
 	setupUGM()
 	app := newApplication(appID1, "default", "root.a")
 	app.SetState(Accepted.String())
@@ -1726,27 +1726,20 @@ func TestTimeoutPlaceholderProcessingUnlocksBeforeRMReply(t *testing.T) {
 		close(timeoutDone)
 	}()
 	releaseEvent := waitForRMReleaseEvent(t, releaseReceived)
-
-	lockAcquired := make(chan struct{})
-	go func() {
-		app.Lock()
-		close(lockAcquired)
-		app.Unlock()
-	}()
 	select {
-	case <-lockAcquired:
-		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+	case <-timeoutDone:
 	case <-time.After(time.Second):
-		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
-		<-lockAcquired
-		t.Fatal("application lock held while waiting for placeholder timeout release response")
+		t.Fatal("placeholder timeout processing waited for an RM reply")
 	}
-	<-timeoutDone
+
 	assert.Equal(t, len(releaseEvent.ReleasedAllocations), 1)
-	assert.Equal(t, releaseEvent.ReleasedAllocations[0].AllocationKey, ph.GetAllocationKey())
+	release := releaseEvent.ReleasedAllocations[0]
+	assert.Equal(t, release.AllocationKey, ph.GetAllocationKey())
+	assert.Equal(t, release.TerminationType, si.TerminationType_TIMEOUT)
+	assert.Assert(t, ph.IsReleased())
 }
 
-func TestTimeoutStateTimerUnlocksBeforeRMReply(t *testing.T) {
+func TestTimeoutStateTimerDoesNotWaitForRMReply(t *testing.T) {
 	setupUGM()
 	app := newApplication(appID1, "default", "root.a")
 	app.SetState(Accepted.String())
@@ -1770,23 +1763,17 @@ func TestTimeoutStateTimerUnlocksBeforeRMReply(t *testing.T) {
 		close(timerDone)
 	}()
 	releaseEvent := waitForRMReleaseEvent(t, releaseReceived)
-	lockAcquired := make(chan struct{})
-	go func() {
-		app.Lock()
-		close(lockAcquired)
-		app.Unlock()
-	}()
 	select {
-	case <-lockAcquired:
-		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+	case <-timerDone:
 	case <-time.After(time.Second):
-		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
-		<-lockAcquired
-		t.Fatal("application lock held while waiting for state timeout release response")
+		t.Fatal("state timeout processing waited for an RM reply")
 	}
-	<-timerDone
+
 	assert.Equal(t, len(releaseEvent.ReleasedAllocations), 1)
-	assert.Equal(t, releaseEvent.ReleasedAllocations[0].AllocationKey, ph.GetAllocationKey())
+	release := releaseEvent.ReleasedAllocations[0]
+	assert.Equal(t, release.AllocationKey, ph.GetAllocationKey())
+	assert.Equal(t, release.TerminationType, si.TerminationType_TIMEOUT)
+	assert.Assert(t, ph.IsReleased())
 }
 
 func TestTimeoutPlaceholderAllocPreempted(t *testing.T) {
@@ -3814,28 +3801,26 @@ func TestRequiredNodePreemption(t *testing.T) {
 	err = app.Reserve(node, ask2)
 	assert.NilError(t, err, "reservation failed")
 
-	// Preemption waits for the RM response, but must not hold the application lock while waiting.
+	// Preemption must return without an RM reply, even with a nil result.
 	preemptionDone := make(chan *AllocationResult, 1)
 	go func() {
 		preemptionDone <- app.tryReservedAllocate(headRoom, iterator)
 	}()
 	releaseEvent := waitForRMReleaseEvent(t, releaseReceived)
-	lockAcquired := make(chan struct{})
-	go func() {
-		app.Lock()
-		close(lockAcquired)
-		app.Unlock()
-	}()
+
 	select {
-	case <-lockAcquired:
-		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+	case result := <-preemptionDone:
+		assert.Assert(t, result == nil, "unexpected result from reserved allocation")
 	case <-time.After(time.Second):
-		// Unblock the operation before failing so the test does not leak goroutines.
-		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
-		<-lockAcquired
-		t.Fatal("application lock held while waiting for RM release response")
+		t.Fatal("required-node preemption waited for an RM reply")
 	}
-	assert.Assert(t, <-preemptionDone == nil, "unexpected result from reserved allocation")
+
+	assert.Equal(t, len(releaseEvent.ReleasedAllocations), 1)
+	assert.Equal(
+		t,
+		releaseEvent.ReleasedAllocations[0].TerminationType,
+		si.TerminationType_PREEMPTED_BY_SCHEDULER,
+	)
 	assert.Assert(t, ask1.IsPreempted(), "ask1 has not been preempted")
 	assert.Assert(t, ask2.HasTriggeredPreemption(), "ask2 has not triggered preemption")
 	assert.Equal(t, 1, len(releaseEvents), "unexpected number of release events")
@@ -3861,11 +3846,6 @@ func TestRequiredNodePreemptionFailed(t *testing.T) {
 		callback: func(ev interface{}) {
 			if rmEvent, ok := ev.(*rmevent.RMReleaseAllocationEvent); ok {
 				releaseEvents = append(releaseEvents, rmEvent)
-				go func() {
-					rmEvent.Channel <- &rmevent.Result{
-						Succeeded: true,
-					}
-				}()
 			}
 		},
 	}
@@ -4071,6 +4051,50 @@ func waitForRMReleaseEvent(t *testing.T, events <-chan *rmevent.RMReleaseAllocat
 	}
 }
 
+func TestNotifyRMAllocationReleasedDoesNotWaitForReply(t *testing.T) {
+	app := newApplication(appID1, "default", "root.a")
+	res := resources.NewResourceFromMap(
+		map[string]resources.Quantity{"memory": 100},
+	)
+	alloc := newPlaceholderAlloc(appID1, nodeID1, res, tg1)
+
+	received := make(chan *rmevent.RMReleaseAllocationEvent, 1)
+	app.rmEventHandler = &mockAppEventHandler{
+		callback: func(ev interface{}) {
+			if event, ok := ev.(*rmevent.RMReleaseAllocationEvent); ok {
+				received <- event
+			}
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		app.notifyRMAllocationReleased(
+			[]*Allocation{alloc},
+			si.TerminationType_TIMEOUT,
+			"test release",
+		)
+		close(done)
+	}()
+
+	event := waitForRMReleaseEvent(t, received)
+
+	select {
+	case <-done:
+	// Notification must return without an RM reply.
+	case <-time.After(time.Second):
+		t.Fatal("release notification waited for an RM reply")
+	}
+
+	assert.Equal(t, len(event.ReleasedAllocations), 1)
+	release := event.ReleasedAllocations[0]
+	assert.Equal(t, release.ApplicationID, alloc.GetApplicationID())
+	assert.Equal(t, release.AllocationKey, alloc.GetAllocationKey())
+	assert.Equal(t, release.PartitionName, app.Partition)
+	assert.Equal(t, release.TerminationType, si.TerminationType_TIMEOUT)
+	assert.Equal(t, release.Message, "test release")
+}
+
 func TestApplication_canAllocationReserve(t *testing.T) {
 	res := resources.NewResource()
 	tests := []struct {
@@ -4196,21 +4220,17 @@ func TestTryPlaceHolderAllocateLargerRequest(t *testing.T) {
 		resultReceived <- app.tryPlaceholderAllocate(iterator, getNode)
 	}()
 	releaseEvent := waitForRMReleaseEvent(t, releaseReceived)
-	lockAcquired := make(chan struct{})
-	go func() {
-		app.Lock()
-		close(lockAcquired)
-		app.Unlock()
-	}()
+	var result *AllocationResult
 	select {
-	case <-lockAcquired:
-		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+	case result = <-resultReceived:
 	case <-time.After(time.Second):
-		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
-		<-lockAcquired
-		t.Fatal("application lock held while waiting for incompatible placeholder release response")
+		t.Fatal("placeholder allocation waited for an RM release reply")
 	}
-	result := <-resultReceived
+
+	assert.Equal(t, len(releaseEvent.ReleasedAllocations), 1)
+	release := releaseEvent.ReleasedAllocations[0]
+	assert.Equal(t, release.AllocationKey, ph.GetAllocationKey())
+	assert.Equal(t, release.TerminationType, si.TerminationType_TIMEOUT)
 	assert.Assert(t, result == nil, "result should be nil since the ask is larger than the placeholder")
 	assert.Assert(t, ph.IsReleased(), "placeholder should have been released")
 	// placeholder data remains unchanged until RM confirms the release

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -732,10 +732,12 @@ func (p *Preemptor) TryPreemption() (*AllocationResult, bool) {
 		zap.String("nodeID", nodeID),
 		zap.Int("collected victim count", len(victims)),
 		zap.Int("preempted victim count", len(finalVictims)))
-	result := newReservedAllocationResult(nodeID, p.ask)
-	result.releaseNotification = newReleaseNotification(finalVictims, si.TerminationType_PREEMPTED_BY_SCHEDULER,
-		"preempting allocations to free up resources to run ask: "+p.ask.GetAllocationKey())
-	return result, true
+	p.application.notifyRMAllocationReleased(
+		finalVictims,
+		si.TerminationType_PREEMPTED_BY_SCHEDULER,
+		"preempting allocations to free up resources to run ask: "+p.ask.GetAllocationKey(),
+	)
+	return newReservedAllocationResult(nodeID, p.ask), true
 }
 
 // Duplicate creates a copy of this snapshot into the given map by queue path

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -726,17 +726,16 @@ func (p *Preemptor) TryPreemption() (*AllocationResult, bool) {
 	// mark ask as having triggered preemption so that we don't preempt again
 	p.ask.MarkTriggeredPreemption()
 
-	// notify RM that victims should be released
-	p.application.notifyRMAllocationReleased(finalVictims, si.TerminationType_PREEMPTED_BY_SCHEDULER,
-		"preempting allocations to free up resources to run ask: "+p.ask.GetAllocationKey())
-
 	// reserve the selected node for the new allocation if it will fit
 	log.Log(log.SchedPreemption).Info("Reserving node for ask after preemption",
 		zap.String("allocationKey", p.ask.GetAllocationKey()),
 		zap.String("nodeID", nodeID),
 		zap.Int("collected victim count", len(victims)),
 		zap.Int("preempted victim count", len(finalVictims)))
-	return newReservedAllocationResult(nodeID, p.ask), true
+	result := newReservedAllocationResult(nodeID, p.ask)
+	result.releaseNotification = newReleaseNotification(finalVictims, si.TerminationType_PREEMPTED_BY_SCHEDULER,
+		"preempting allocations to free up resources to run ask: "+p.ask.GetAllocationKey())
+	return result, true
 }
 
 // Duplicate creates a copy of this snapshot into the given map by queue path

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -461,7 +461,7 @@ func TestTryPreemption_SendEvent(t *testing.T) {
 	assert.Equal(t, len(ask3.GetAllocationLog()), 0)
 }
 
-func TestTryAllocateUnlocksBeforePreemptionRMReply(t *testing.T) {
+func TestTryAllocateDoesNotWaitForPreemptionRMReply(t *testing.T) {
 	appQueueMapping := NewAppQueueMapping()
 	node := newNode(nodeID1, map[string]resources.Quantity{"first": 10, "pods": 2})
 	iterator := getNodeIteratorFn(node)
@@ -501,25 +501,22 @@ func TestTryAllocateUnlocksBeforePreemptionRMReply(t *testing.T) {
 			true, 0, &remaining, iterator, iterator, func(string) *Node { return node })
 	}()
 	releaseEvent := waitForRMReleaseEvent(t, releaseReceived)
-
-	lockAcquired := make(chan struct{})
-	go func() {
-		app.Lock()
-		close(lockAcquired)
-		app.Unlock()
-	}()
+	var result *AllocationResult
 	select {
-	case <-lockAcquired:
-		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+	case result = <-resultReceived:
 	case <-time.After(time.Second):
-		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
-		<-lockAcquired
-		t.Fatal("application lock held while waiting for preemption release response")
+		t.Fatal("allocation waited for a preemption RM reply")
 	}
-	result := <-resultReceived
+
 	assert.Assert(t, result != nil)
 	assert.Equal(t, result.ResultType, Reserved)
+	assert.Assert(t, ask.HasTriggeredPreemption())
 	assert.Equal(t, len(releaseEvent.ReleasedAllocations), 1)
+	assert.Equal(
+		t,
+		releaseEvent.ReleasedAllocations[0].TerminationType,
+		si.TerminationType_PREEMPTED_BY_SCHEDULER,
+	)
 }
 
 // TestTryPreemptionOnNode Test try preemption on node with simple queue hierarchy. Since Node doesn't have enough resources to accomodate, preemption happens because of node resource constraint.

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -32,6 +32,7 @@ import (
 	evtMock "github.com/apache/yunikorn-core/pkg/events/mock"
 	"github.com/apache/yunikorn-core/pkg/mock"
 	"github.com/apache/yunikorn-core/pkg/plugins"
+	"github.com/apache/yunikorn-core/pkg/rmproxy/rmevent"
 	schedEvt "github.com/apache/yunikorn-core/pkg/scheduler/objects/events"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
@@ -458,6 +459,67 @@ func TestTryPreemption_SendEvent(t *testing.T) {
 	assert.Equal(t, si.EventRecord_REQUEST, event.Type)
 	assert.Equal(t, fmt.Sprintf("Preempted by %s from application %s in %s", "alloc3", appID2, "root.parent.child2"), event.Message)
 	assert.Equal(t, len(ask3.GetAllocationLog()), 0)
+}
+
+func TestTryAllocateUnlocksBeforePreemptionRMReply(t *testing.T) {
+	appQueueMapping := NewAppQueueMapping()
+	node := newNode(nodeID1, map[string]resources.Quantity{"first": 10, "pods": 2})
+	iterator := getNodeIteratorFn(node)
+	rootQ, err := createRootQueue(map[string]string{"first": "20", "pods": "4"})
+	assert.NilError(t, err)
+	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"first": "20", "pods": "4"}, map[string]string{"first": "10", "pods": "2"}, appQueueMapping)
+	assert.NilError(t, err)
+	childQ1, err := createManagedQueueGuaranteed(parentQ, "child1", false, map[string]string{"first": "10", "pods": "2"}, map[string]string{"first": "5", "pods": "1"}, appQueueMapping)
+	assert.NilError(t, err)
+	childQ2, err := createManagedQueueGuaranteed(parentQ, "child2", false, map[string]string{"first": "10", "pods": "2"}, map[string]string{"first": "5", "pods": "1"}, appQueueMapping)
+	assert.NilError(t, err)
+
+	_, _, err = creatApp1(childQ1, node, nil, map[string]resources.Quantity{"first": 5, "pods": 1}, appQueueMapping)
+	assert.NilError(t, err)
+	app, ask, err := creatApp2(childQ2, map[string]resources.Quantity{"first": 5, "pods": 1}, "alloc3", appQueueMapping)
+	assert.NilError(t, err)
+	ask.allowPreemptOther = true
+
+	plugin := mock.NewPreemptionPredicatePlugin([]mock.Preemption{
+		mock.NewPreemption(true, "alloc3", nodeID1, []string{"alloc1"}, 0, 0),
+	}, nil, false, false)
+	plugins.RegisterSchedulerPlugin(plugin)
+	defer plugins.UnregisterSchedulerPlugins()
+
+	releaseReceived := make(chan *rmevent.RMReleaseAllocationEvent, 1)
+	app.rmEventHandler = &mockAppEventHandler{callback: func(ev interface{}) {
+		if releaseEvent, ok := ev.(*rmevent.RMReleaseAllocationEvent); ok {
+			releaseReceived <- releaseEvent
+		}
+	}}
+
+	resultReceived := make(chan *AllocationResult, 1)
+	remaining := 1
+	go func() {
+		resultReceived <- app.tryAllocate(
+			resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10, "pods": 2}),
+			true, 0, &remaining, iterator, iterator, func(string) *Node { return node })
+	}()
+	releaseEvent := waitForRMReleaseEvent(t, releaseReceived)
+
+	lockAcquired := make(chan struct{})
+	go func() {
+		app.Lock()
+		close(lockAcquired)
+		app.Unlock()
+	}()
+	select {
+	case <-lockAcquired:
+		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+	case <-time.After(time.Second):
+		releaseEvent.Channel <- &rmevent.Result{Succeeded: true}
+		<-lockAcquired
+		t.Fatal("application lock held while waiting for preemption release response")
+	}
+	result := <-resultReceived
+	assert.Assert(t, result != nil)
+	assert.Equal(t, result.ResultType, Reserved)
+	assert.Equal(t, len(releaseEvent.ReleasedAllocations), 1)
 }
 
 // TestTryPreemptionOnNode Test try preemption on node with simple queue hierarchy. Since Node doesn't have enough resources to accomodate, preemption happens because of node resource constraint.

--- a/pkg/scheduler/objects/required_node_preemptor.go
+++ b/pkg/scheduler/objects/required_node_preemptor.go
@@ -62,7 +62,7 @@ func NewRequiredNodePreemptor(node *Node, requiredAsk *Allocation, application *
 	return preemptor
 }
 
-func (p *PreemptionContext) tryPreemption() {
+func (p *PreemptionContext) tryPreemption() *releaseNotification {
 	result := p.filterAllocations()
 	p.sortAllocations()
 
@@ -92,7 +92,7 @@ func (p *PreemptionContext) tryPreemption() {
 			victim.SendPreemptedBySchedulerEvent(p.requiredAsk.GetAllocationKey(), p.requiredAsk.GetApplicationID(), p.application.queuePath)
 		}
 		p.requiredAsk.MarkTriggeredPreemption()
-		p.application.notifyRMAllocationReleased(victims, si.TerminationType_PREEMPTED_BY_SCHEDULER,
+		return newReleaseNotification(victims, si.TerminationType_PREEMPTED_BY_SCHEDULER,
 			"preempting allocations to free up resources to run daemon set ask: "+p.requiredAsk.GetAllocationKey())
 	} else {
 		p.requiredAsk.LogAllocationFailure(common.NoVictimForRequiredNode, true)
@@ -107,6 +107,7 @@ func (p *PreemptionContext) tryPreemption() {
 			zap.Int("higher priority allocations", result.higherPriorityAllocations),
 			zap.Int("allocations with non-matching resources", result.atLeastOneResNotMatched))
 	}
+	return nil
 }
 
 func (p *PreemptionContext) filterAllocations() filteringResult {

--- a/pkg/scheduler/objects/required_node_preemptor.go
+++ b/pkg/scheduler/objects/required_node_preemptor.go
@@ -62,7 +62,7 @@ func NewRequiredNodePreemptor(node *Node, requiredAsk *Allocation, application *
 	return preemptor
 }
 
-func (p *PreemptionContext) tryPreemption() *releaseNotification {
+func (p *PreemptionContext) tryPreemption() {
 	result := p.filterAllocations()
 	p.sortAllocations()
 
@@ -92,8 +92,11 @@ func (p *PreemptionContext) tryPreemption() *releaseNotification {
 			victim.SendPreemptedBySchedulerEvent(p.requiredAsk.GetAllocationKey(), p.requiredAsk.GetApplicationID(), p.application.queuePath)
 		}
 		p.requiredAsk.MarkTriggeredPreemption()
-		return newReleaseNotification(victims, si.TerminationType_PREEMPTED_BY_SCHEDULER,
-			"preempting allocations to free up resources to run daemon set ask: "+p.requiredAsk.GetAllocationKey())
+		p.application.notifyRMAllocationReleased(
+			victims,
+			si.TerminationType_PREEMPTED_BY_SCHEDULER,
+			"preempting allocations to free up resources to run daemon set ask: "+p.requiredAsk.GetAllocationKey(),
+		)
 	} else {
 		p.requiredAsk.LogAllocationFailure(common.NoVictimForRequiredNode, true)
 		p.requiredAsk.SendRequiredNodePreemptionFailedEvent(p.node.NodeID)
@@ -107,7 +110,6 @@ func (p *PreemptionContext) tryPreemption() *releaseNotification {
 			zap.Int("higher priority allocations", result.higherPriorityAllocations),
 			zap.Int("allocations with non-matching resources", result.atLeastOneResNotMatched))
 	}
-	return nil
 }
 
 func (p *PreemptionContext) filterAllocations() filteringResult {


### PR DESCRIPTION
### Description
Send allocation release events without waiting for RM replies.
Remove deferred notification plumbing and log processing in RMProxy.

### Type of change
- [x] Improvement


### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3411

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
- [ ] The PR includes the phrase "Generated by <tool>", where <tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [x] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A
