### PR TITLE
[YUNIKORN-3365] Shutdown ordering: scheduler allocation notify can block on an RM reply the proxy never drains

### DIFF
--- a/pkg/rmproxy/rmproxy.go
+++ b/pkg/rmproxy/rmproxy.go
@@ -203,7 +203,36 @@ func (rmp *RMProxy) handleRMEvents() {
 				panic(fmt.Sprintf("%s is not an acceptable type for RM event.", reflect.TypeOf(v).String()))
 			}
 		case <-rmp.stop:
+			rmp.drainPendingEvents()
 			return
+		}
+	}
+}
+
+func (rmp *RMProxy) drainPendingEvents() {
+	for {
+		select {
+		case ev := <-rmp.pendingRMEvents:
+			switch v := ev.(type) {
+			case *rmevent.RMNewAllocationsEvent:
+				drainReplyChannel(v.Channel)
+			case *rmevent.RMReleaseAllocationEvent:
+				drainReplyChannel(v.Channel)
+			}
+		default:
+			return
+		}
+	}
+}
+
+func drainReplyChannel(ch chan *rmevent.Result) {
+	if ch != nil {
+		select {
+		case ch <- &rmevent.Result{
+			Succeeded: false,
+			Reason:    "RMProxy is stopping",
+		}:
+		default:
 		}
 	}
 }

--- a/pkg/rmproxy/rmproxy_test.go
+++ b/pkg/rmproxy/rmproxy_test.go
@@ -28,6 +28,27 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
+func TestRMProxy_StopUnblocksWaitingCaller(t *testing.T) {
+	rmp := NewRMProxy(nil)
+	rmp.StartService()
+
+	c := make(chan *rmevent.Result, 1)
+	rmp.HandleEvent(&rmevent.RMReleaseAllocationEvent{
+		ReleasedAllocations: []*si.AllocationRelease{},
+		RmID:                "rm-test",
+		Channel:             c,
+	})
+
+	rmp.Stop() // exercises the case <-rmp.stop: drainPendingEvents() wiring
+
+	select {
+	case res := <-c:
+		assert.Assert(t, res != nil) // normal reply or drained — either is fine, point is no leak
+	case <-time.After(time.Second):
+		t.Fatal("caller leaked: no reply after Stop")
+	}
+}
+
 func TestRMProxy_DrainPendingEvents(t *testing.T) {
 	rmp := NewRMProxy(nil)
 

--- a/pkg/rmproxy/rmproxy_test.go
+++ b/pkg/rmproxy/rmproxy_test.go
@@ -1,0 +1,64 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package rmproxy
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/apache/yunikorn-core/pkg/rmproxy/rmevent"
+	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
+)
+
+func TestRMProxy_DrainPendingEvents(t *testing.T) {
+	rmp := NewRMProxy(nil)
+
+	allocResultCh := make(chan *rmevent.Result, 1)
+	releaseResultCh := make(chan *rmevent.Result, 1)
+
+	rmp.HandleEvent(&rmevent.RMNewAllocationsEvent{
+		Allocations: []*si.Allocation{},
+		RmID:        "rm-test",
+		Channel:     allocResultCh,
+	})
+	rmp.HandleEvent(&rmevent.RMReleaseAllocationEvent{
+		ReleasedAllocations: []*si.AllocationRelease{},
+		RmID:                "rm-test",
+		Channel:             releaseResultCh,
+	})
+
+	rmp.drainPendingEvents()
+
+	assertDrainFailedResult(t, allocResultCh, "allocResultCh")
+	assertDrainFailedResult(t, releaseResultCh, "releaseResultCh")
+}
+
+func assertDrainFailedResult(t *testing.T, ch <-chan *rmevent.Result, name string) {
+	t.Helper()
+	select {
+	case res := <-ch:
+		assert.Assert(t, res != nil, "expected non-nil response on %s", name)
+		assert.Assert(t, !res.Succeeded, "expected Succeeded to be false on %s", name)
+		assert.Equal(t, res.Reason, "RMProxy is stopping")
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for response on %s", name)
+	}
+}

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -795,7 +795,7 @@ func (cc *ClusterContext) processAllocationReleases(releases []*si.AllocationRel
 // Create a RM update event to notify RM of new allocations
 // Lock free call, all updates occur via events.
 func (cc *ClusterContext) notifyRMNewAllocation(rmID string, alloc *objects.Allocation) {
-	c := make(chan *rmevent.Result)
+	c := make(chan *rmevent.Result, 1)
 	// communicate the allocation to the RM synchronously
 	cc.rmEventHandler.HandleEvent(&rmevent.RMNewAllocationsEvent{
 		Allocations: []*si.Allocation{alloc.NewSIFromAllocation()},
@@ -815,7 +815,7 @@ func (cc *ClusterContext) notifyRMNewAllocation(rmID string, alloc *objects.Allo
 // Create a RM update event to notify RM of released allocations
 // Lock free call, all updates occur via events.
 func (cc *ClusterContext) notifyRMAllocationReleased(rmID string, partitionName string, released []*objects.Allocation, terminationType si.TerminationType, message string) {
-	c := make(chan *rmevent.Result)
+	c := make(chan *rmevent.Result, 1)
 	releaseEvent := &rmevent.RMReleaseAllocationEvent{
 		ReleasedAllocations: make([]*si.AllocationRelease, 0),
 		RmID:                rmID,

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -2335,7 +2335,7 @@ func (sa *Application) notifyRMAllocationReleased(released []*Allocation, termin
 	if len(released) == 0 || sa.rmEventHandler == nil {
 		return
 	}
-	c := make(chan *rmevent.Result)
+	c := make(chan *rmevent.Result, 1)
 	releaseEvent := &rmevent.RMReleaseAllocationEvent{
 		ReleasedAllocations: make([]*si.AllocationRelease, 0),
 		RmID:                sa.rmID,


### PR DESCRIPTION
### Description
During scheduler shutdown (`ServiceContext.StopAll`), `Scheduler.handleAllocEvent` can select an in-flight allocation or release event concurrently with `s.stop` closing. This invokes `notifyRMNewAllocation` or `notifyRMAllocationReleased`, which posts an event to `RMProxy.pendingRMEvents` and synchronously waits on a reply channel. However, `RMProxy.handleRMEvents` previously exited immediately upon receiving `rmp.stop` without draining `pendingRMEvents`. Because no response was ever dispatched to the reply channel, the caller goroutine parked indefinitely, causing a goroutine leak on shutdown.

To resolve this:
1. **Drain on Stop**: `RMProxy.handleRMEvents` now calls `drainPendingEvents()` upon shutdown, consuming all remaining queued events and non-blockingly returning `Result{Succeeded: false, Reason: "RMProxy is stopping"}` to unblock pending callers.
2. **Buffered Reply Channels**: Converted notification reply channels in `pkg/scheduler/context.go` and `pkg/scheduler/objects/application.go` to buffered channels (`cap 1`).
3. **Unit Testing**: Added deterministic unit test `TestRMProxy_DrainPendingEvents` in `pkg/rmproxy/rmproxy_test.go` to verify graceful event draining on shutdown.

### Type of change
Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3365

- [ ] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by Antigravity CLI", where Antigravity CLI is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [x] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details

