### PR TITLE
[YUNIKORN-3445] SortAllocationsBasedOnAsk prioritizes originator and opted-out pods for preemption instead of protecting them

### DIFF
--- a/pkg/scheduler/objects/preemption_utilities.go
+++ b/pkg/scheduler/objects/preemption_utilities.go
@@ -129,8 +129,7 @@ func SortAllocationsBasedOnAsk(allocations []*Allocation, total, ask *resources.
 }
 
 // scoreAllocationBasedOnAsk generates a relative score for an allocation based on ask. Higher-scored allocations are considered more likely
-// preemption candidates. Tasks which are not application originators are considered first, then tasks which have
-// opted into preemption.
+// preemption candidates. Opted out pods are considered before originator pods.
 func scoreAllocationBasedOnAsk(allocation *Allocation, ask *resources.Resource) uint64 {
 	var score uint64 = 0
 	if !allocation.IsOriginator() {

--- a/pkg/scheduler/objects/preemption_utilities.go
+++ b/pkg/scheduler/objects/preemption_utilities.go
@@ -26,8 +26,8 @@ import (
 )
 
 var (
-	scoreNonOriginator uint64 = 1 << 33
-	scoreAllowPreempt  uint64 = 1 << 34
+	scoreNonOriginator uint64 = 1 << 34
+	scoreAllowPreempt  uint64 = 1 << 33
 )
 
 // SortAllocations Sort allocations based on the following criteria in the specified order:
@@ -129,8 +129,8 @@ func SortAllocationsBasedOnAsk(allocations []*Allocation, total, ask *resources.
 }
 
 // scoreAllocationBasedOnAsk generates a relative score for an allocation based on ask. Higher-scored allocations are considered more likely
-// preemption candidates. Tasks which have opted into preemption are considered first, then tasks which are not
-// application originators.
+// preemption candidates. Tasks which are not application originators are considered first, then tasks which have
+// opted into preemption.
 func scoreAllocationBasedOnAsk(allocation *Allocation, ask *resources.Resource) uint64 {
 	var score uint64 = 0
 	if !allocation.IsOriginator() {

--- a/pkg/scheduler/objects/preemption_utilities.go
+++ b/pkg/scheduler/objects/preemption_utilities.go
@@ -25,6 +25,11 @@ import (
 	"github.com/apache/yunikorn-core/pkg/common/resources"
 )
 
+var (
+	scoreNonOriginator uint64 = 1 << 33
+	scoreAllowPreempt  uint64 = 1 << 34
+)
+
 // SortAllocations Sort allocations based on the following criteria in the specified order:
 // 1. By type (regular pods, opted out pods, driver/owner pods),
 // 2. By priority (least priority ask placed first),
@@ -123,16 +128,16 @@ func SortAllocationsBasedOnAsk(allocations []*Allocation, total, ask *resources.
 	})
 }
 
-// scoreAllocation generates a relative score for an allocation. Lower-scored allocations are considered more likely
+// scoreAllocationBasedOnAsk generates a relative score for an allocation based on ask. Higher-scored allocations are considered more likely
 // preemption candidates. Tasks which have opted into preemption are considered first, then tasks which are not
 // application originators.
 func scoreAllocationBasedOnAsk(allocation *Allocation, ask *resources.Resource) uint64 {
 	var score uint64 = 0
-	if allocation.IsOriginator() {
-		score |= scoreOriginator
+	if !allocation.IsOriginator() {
+		score |= scoreNonOriginator
 	}
-	if !allocation.IsAllowPreemptSelf() {
-		score |= scoreNoPreempt
+	if allocation.IsAllowPreemptSelf() {
+		score |= scoreAllowPreempt
 	}
 	score += allocation.GetAllocatedResource().TypeMatching(ask)
 	return score

--- a/pkg/scheduler/objects/preemption_utilities_test.go
+++ b/pkg/scheduler/objects/preemption_utilities_test.go
@@ -316,7 +316,7 @@ func TestSortAllocationsBasedOnAsk_PreemptionOrdering(t *testing.T) {
 	SortAllocationsBasedOnAsk(allocations, total, ask)
 
 	assert.Equal(t, allocations[0].GetAllocationKey(), "regularPod")
-	assert.Equal(t, allocations[1].GetAllocationKey(), "originatorPod")
-	assert.Equal(t, allocations[2].GetAllocationKey(), "optedOutPod")
+	assert.Equal(t, allocations[1].GetAllocationKey(), "optedOutPod")
+	assert.Equal(t, allocations[2].GetAllocationKey(), "originatorPod")
 	assert.Equal(t, allocations[3].GetAllocationKey(), "optedOutOriginatorPod")
 }

--- a/pkg/scheduler/objects/preemption_utilities_test.go
+++ b/pkg/scheduler/objects/preemption_utilities_test.go
@@ -295,3 +295,28 @@ func TestSortAllocationsBasedOnAsk(t *testing.T) {
 		})
 	}
 }
+
+func TestSortAllocationsBasedOnAsk_PreemptionOrdering(t *testing.T) {
+	node := NewNode(&si.NodeInfo{
+		NodeID: "node1",
+		SchedulableResource: &si.Resource{
+			Resources: map[string]*si.Quantity{"first": {Value: 100}},
+		},
+	})
+	res := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
+	total := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 100})
+	ask := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
+
+	regularPod := createAllocation("regularPod", "app1", node.NodeID, true, false, 10, false, res)
+	originatorPod := createAllocation("originatorPod", "app1", node.NodeID, true, true, 10, false, res)
+	optedOutPod := createAllocation("optedOutPod", "app1", node.NodeID, false, false, 10, false, res)
+	optedOutOriginatorPod := createAllocation("optedOutOriginatorPod", "app1", node.NodeID, false, true, 10, false, res)
+
+	allocations := []*Allocation{optedOutOriginatorPod, optedOutPod, originatorPod, regularPod}
+	SortAllocationsBasedOnAsk(allocations, total, ask)
+
+	assert.Equal(t, allocations[0].GetAllocationKey(), "regularPod")
+	assert.Equal(t, allocations[1].GetAllocationKey(), "originatorPod")
+	assert.Equal(t, allocations[2].GetAllocationKey(), "optedOutPod")
+	assert.Equal(t, allocations[3].GetAllocationKey(), "optedOutOriginatorPod")
+}


### PR DESCRIPTION
### Description
`SortAllocationsBasedOnAsk()` orders candidate victims in descending order (`scoreLeft > scoreRight`). However, `scoreAllocationBasedOnAsk()` previously awarded high-order score bits to originator and opted-out (`!allowPreemptSelf`) allocations, inadvertently prioritizing protected allocations for preemption over regular unprotected allocations.

This PR corrects the scoring polarity:
- Assigns `scoreNonOriginator` (`1 << 34`) to allocations with `!IsOriginator()`.
- Assigns `scoreAllowPreempt` (`1 << 33`) to allocations with `IsAllowPreemptSelf() == true`.
- Adds unit test `TestSortAllocationsBasedOnAsk_PreemptionOrdering` covering all four allocation combinations.

### Type of change
Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3445

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by Antigravity CLI", where Antigravity CLI is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [x] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
NA
