### PR TITLE
[YUNIKORN-3446] Race condition in ensureGroupTrackerForApp creates duplicate GroupTrackers and bypasses group quota

### DIFF
--- a/pkg/scheduler/ugm/manager.go
+++ b/pkg/scheduler/ugm/manager.go
@@ -240,16 +240,7 @@ func (m *Manager) ensureGroupTrackerForApp(queuePath, applicationID string, user
 
 	// something matched, get the tracker or create if it does not exist
 	if appGroup != common.Empty {
-		groupTracker = m.GetGroupTracker(appGroup)
-		if groupTracker == nil {
-			log.Log(log.SchedUGM).Info("Group tracker doesn't exists. Creating appGroup tracker",
-				zap.String("queue path", queuePath),
-				zap.String("group", appGroup))
-			groupTracker = newGroupTracker(appGroup, m.events)
-			m.Lock()
-			m.groupTrackers[appGroup] = groupTracker
-			m.Unlock()
-		}
+		groupTracker = m.getGroupTracker(appGroup)
 	}
 	log.Log(log.SchedUGM).Info("Group tracker set for user application",
 		zap.String("group", appGroup),
@@ -636,6 +627,20 @@ func (m *Manager) getUserTracker(user string) *UserTracker {
 	userTracker := newUserTracker(user, m.events)
 	m.userTrackers[user] = userTracker
 	return userTracker
+}
+
+// getGroupTracker returns the requested group tracker and creates one if it does not exist.
+func (m *Manager) getGroupTracker(group string) *GroupTracker {
+	m.Lock()
+	defer m.Unlock()
+	if gt, ok := m.groupTrackers[group]; ok {
+		return gt
+	}
+	log.Log(log.SchedUGM).Info("Group tracker doesn't exists. Creating group tracker.",
+		zap.String("group", group))
+	groupTracker := newGroupTracker(group, m.events)
+	m.groupTrackers[group] = groupTracker
+	return groupTracker
 }
 
 func (m *Manager) getUserWildCardLimitsConfig(queuePath string) *LimitConfig {

--- a/pkg/scheduler/ugm/manager_test.go
+++ b/pkg/scheduler/ugm/manager_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -2026,4 +2027,69 @@ func assertWildCardLimits(t *testing.T, limitsConfig map[string]*LimitConfig, ex
 		t.Errorf("new resource create returned error or wrong resource: error %t, res %v", err, configuredResource)
 	}
 	assert.Equal(t, resources.Equals(expResource, configuredResource), true)
+}
+
+func TestEnsureGroupTrackerForAppConcurrentRace(t *testing.T) {
+	groupName := "devs"
+	queuePath := queuePathLeaf
+	user := security.UserGroup{
+		User:   "alice",
+		Groups: []string{groupName},
+	}
+	usage := resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 100})
+
+	// Run multiple rounds to consistently trigger the check-then-act race window
+	for round := 1; round <= 10; round++ {
+		setupUGM()
+		manager := GetUserManager()
+
+		manager.Lock()
+		manager.configuredGroups = map[string][]string{
+			queuePath: {groupName},
+		}
+		manager.Unlock()
+
+		numApps := 50
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+
+		for i := 0; i < numApps; i++ {
+			wg.Add(1)
+			go func(appIndex int) {
+				defer wg.Done()
+				<-start
+				appID := fmt.Sprintf("app-r%d-%d", round, appIndex)
+				manager.IncreaseTrackedResource(queuePath, appID, usage, user)
+			}(i)
+		}
+
+		close(start)
+		wg.Wait()
+
+		canonicalGroupTracker := manager.GetGroupTracker(groupName)
+		assert.Assert(t, canonicalGroupTracker != nil, "canonical group tracker should exist in manager")
+
+		userTracker := manager.GetUserTracker("alice")
+		assert.Assert(t, userTracker != nil, "user tracker should exist")
+
+		userTracker.RLock()
+		uniqueTrackers := make(map[*GroupTracker]int)
+		mismatchedApps := make([]string, 0)
+		for appID, gt := range userTracker.appGroupTrackers {
+			uniqueTrackers[gt]++
+			if gt != canonicalGroupTracker {
+				mismatchedApps = append(mismatchedApps, appID)
+			}
+		}
+		userTracker.RUnlock()
+
+		if len(uniqueTrackers) > 1 || len(mismatchedApps) > 0 {
+			t.Logf("=== CHAOS HARNESS TRIGGERED IN ROUND %d ===", round)
+			t.Logf("Total applications launched: %d", numApps)
+			t.Logf("Distinct GroupTracker instances created in memory: %d", len(uniqueTrackers))
+			t.Logf("Applications linked to non-canonical orphaned GroupTrackers: %d", len(mismatchedApps))
+			t.Fatalf("CRITICAL BUG DETECTED: Multiple GroupTracker instances created for group '%s'! Expected 1, found %d instances (Round %d)",
+				groupName, len(uniqueTrackers), round)
+		}
+	}
 }


### PR DESCRIPTION
### Description
In `Manager.ensureGroupTrackerForApp()`, concurrent calls for new applications in the same group could simultaneously observe a `nil` tracker via `m.GetGroupTracker(appGroup)` (which only holds a read lock `RLock`). As a result, both routines entered the initialization branch and created separate `GroupTracker` instances outside of any lock. When writing back under `m.Lock()`, one instance would overwrite the other in `m.groupTrackers`, leaving the first application permanently bound to an orphaned `GroupTracker` instance. This broke quota tracking and allowed concurrent applications to bypass configured group limits.

This change fixes the race condition by:
1. Introducing a synchronized helper method `getGroupTracker(group string) *GroupTracker` that performs atomic lookup and creation under `m.Lock()`, mirroring the existing `getUserTracker(user string) *UserTracker` pattern.
2. Updating `ensureGroupTrackerForApp()` to delegate group tracker retrieval/creation to `m.getGroupTracker()`, eliminating the check-then-act race window.
3. Adding `TestEnsureGroupTrackerForAppConcurrentRace` in `manager_test.go` using barrier synchronization with 50 concurrent goroutines across 10 rounds to reliably guard against regressions.

### Type of change
- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3446

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by Antigravity", where Antigravity is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths (`TestEnsureGroupTrackerForAppConcurrentRace`).
- [x] `make test_all` was run, and no failures reported.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
Generated by hedger9487 with assistance from Antigravity.