### PR TITLE
[YUNIKORN-3449] Preemption falsely aborts and starves large asks by ignoring node available capacity in shortfall check

### DIFF
--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -643,11 +643,15 @@ func (p *Preemptor) TryPreemption() (*AllocationResult, bool) {
 	// on different criteria. for example, victims could be picked up either from specific node (bin packing) or
 	// from multiple nodes (fair) given the choices.
 	var finalVictims []*Allocation
+	hasVictimsOnOtherNodes := false
 	for _, victim := range victims {
 		// Victims from any node is acceptable as long as chosen node has enough space to accommodate the ask
 		// Otherwise, preempting victims from 'n' different nodes doesn't help to achieve the goal.
-		if !fitIn && victim.GetNodeID() != nodeID {
-			continue
+		if victim.GetNodeID() != nodeID {
+			hasVictimsOnOtherNodes = true
+			if !fitIn {
+				continue
+			}
 		}
 		// check if victim contributes to any resource dimension that is still needed
 		allocRes := victim.GetAllocatedResource()
@@ -663,9 +667,15 @@ func (p *Preemptor) TryPreemption() (*AllocationResult, bool) {
 	hasShortfall := victimsTotalResource.IsEmpty()
 	if !hasShortfall {
 		for k, victimVal := range victimsTotalResource.Resources {
-			if needVal, ok := p.ask.GetAllocatedResource().Resources[k]; ok && victimVal < needVal {
-				hasShortfall = true
-				break
+			if needVal, ok := p.ask.GetAllocatedResource().Resources[k]; ok {
+				var avail resources.Quantity
+				if !fitIn && !hasVictimsOnOtherNodes {
+					avail = p.nodeAvailableMap[nodeID].Resources[k]
+				}
+				if avail+victimVal < needVal {
+					hasShortfall = true
+					break
+				}
 			}
 		}
 	}

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -2467,3 +2467,46 @@ func Test_PreemptReleasesReservationsOnSuccess(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 }
+
+// TestTryPreemption_NodeAvailableDeficit proves YUNIKORN-3449:
+// When a node has partial available capacity, preemption should succeed if victims cover the remaining deficit.
+func TestTryPreemption_NodeAvailableDeficit(t *testing.T) {
+	appQueueMapping := NewAppQueueMapping()
+	node := newNode(nodeID1, map[string]resources.Quantity{"first": 4})
+	iterator := getNodeIteratorFn(node)
+	rootQ, err := createRootQueue(map[string]string{"first": "20"})
+	assert.NilError(t, err)
+	parentQ, err := createManagedQueueGuaranteed(rootQ, "parent", true, map[string]string{"first": "20"}, map[string]string{"first": "10"}, appQueueMapping)
+	assert.NilError(t, err)
+	childQ1, err := createManagedQueueGuaranteed(parentQ, "child1", false, nil, nil, appQueueMapping)
+	assert.NilError(t, err)
+	childQ2, err := createManagedQueueGuaranteed(parentQ, "child2", false, map[string]string{"first": "20"}, map[string]string{"first": "15"}, appQueueMapping)
+	assert.NilError(t, err)
+
+	app1 := newApplication(appID1, "default", "root.parent.child1")
+	app1.SetQueue(childQ1)
+	childQ1.AddApplication(app1)
+	appQueueMapping.AddAppQueueMapping(app1.ApplicationID, childQ1)
+
+	// alloc1 on node-1 uses first: 2. (Node capacity: 4, so nodeAvailable = 2 free)
+	ask1 := newAllocationAsk("alloc1", appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 2}))
+	assert.NilError(t, app1.AddAllocationAsk(ask1))
+	alloc1 := newAllocationWithKey("alloc1", appID1, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"first": 2}))
+	app1.AddAllocation(alloc1)
+	assert.Check(t, node.TryAddAllocation(alloc1), "node alloc1 failed")
+	assert.NilError(t, childQ1.TryIncAllocatedResource(ask1.GetAllocatedResource()))
+
+	// Preemptor ask in childQ2 needs first: 4
+	app2, ask2, err := creatApp2(childQ2, map[string]resources.Quantity{"first": 4}, "alloc2", appQueueMapping)
+	assert.NilError(t, err)
+
+	headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
+	preemptor := NewPreemptor(app2, headRoom, 30*time.Second, ask2, iterator(), false)
+
+	result, ok := preemptor.TryPreemption()
+	assert.Assert(t, ok, "preemption should succeed: 2 available on node + 2 victim = 4 needed")
+	assert.Assert(t, result != nil, "expected non-nil allocation result")
+	assert.Equal(t, "alloc2", result.Request.GetAllocationKey())
+	assert.Equal(t, nodeID1, result.NodeID)
+	assert.Check(t, alloc1.IsPreempted(), "alloc1 should be preempted")
+}


### PR DESCRIPTION
### Description
In `Preemptor.TryPreemption()`, after selecting candidate victims via `tryNodes()`, a shortfall verification checks whether the collected victims provide sufficient resources to satisfy the preemptor ask (`p.ask.GetAllocatedResource()`).

Previously, this shortfall check directly compared the sum of victim allocations (`victimsTotalResource`) against the ask demand (`victimVal < needVal`). However, this check completely ignored the candidate node's existing available capacity (`p.nodeAvailableMap[nodeID]`). 

When a candidate node has partial idle capacity (e.g. 2 vcores free) and `tryNodes()` correctly selects victims on that node to cover only the residual deficit (e.g. 2 vcores) to accommodate a 4-vcore ask, `TryPreemption()` evaluated `victimVal (2) < needVal (4)`, falsely logged `PreemptionShortfall`, and aborted preemption. This causes viable preemptions to fail unnecessarily, leading to preemption churn and pod starvation for large asks on partially loaded nodes.

This patch:
- Decouples single-node physical shortfall checks from queue preemption checks in `TryPreemption()`.
- Detects whether all collected victims reside on the target node (`!hasVictimsOnOtherNodes`).
- For node-driven preemption (`!fitIn && !hasVictimsOnOtherNodes`), accounts for the node's existing available capacity alongside victim resources (`avail + victimVal >= needVal`).
- Preserves the legacy check (`victimVal < needVal`) for queue-driven or multi-node preemption, ensuring 100% backward compatibility and zero regression.
- Adds `TestTryPreemption_NodeAvailableDeficit` in `preemption_test.go` to deterministically verify that preemption succeeds when node available capacity plus victim resources satisfy the ask.

### Type of change
- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3449

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by Antigravity", where Antigravity is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] Added `TestTryPreemption_NodeAvailableDeficit` covering the defect scenario (PASS 0.00s).
- [x] Ran all preemption unit tests with race detector (`go test -race -count=1 -run TestTryPreemption ./pkg/scheduler/objects`) with 100% pass.
- [x] Ran deadlock and concurrency stress checks (`go test -race -tags deadlock -count=5 ./pkg/scheduler/objects`) with zero warnings.
- [x] Ran full package tests with `-race` across `pkg/scheduler/objects` (14.619s, zero failures).
- [x] Ran `golangci-lint run --new-from-rev=upstream/master pkg/scheduler/objects/...` with 0 issues.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
Generated by hedger9487 with assistance from Antigravity.
