### PR TITLE
[YUNIKORN-3236] Inter Queue Preemption: Improve victim selection algorithm

### DIFF
--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -485,9 +485,7 @@ func (p *Preemptor) calculateAdditionalVictims(nodeVictims []*Allocation) ([]*Al
 			potentialVictims = append(potentialVictims, victim)
 		}
 	}
-	sort.SliceStable(potentialVictims, func(i, j int) bool {
-		return compareAllocationLess(potentialVictims[i], potentialVictims[j])
-	})
+	SortAllocationsBasedOnAsk(potentialVictims, askQueue.GetMaxResource(), p.ask.GetAllocatedResource())
 
 	// evaluate each potential victim in turn, stopping once sufficient resources have been freed
 	victims := make([]*Allocation, 0)
@@ -876,33 +874,6 @@ func (qps *QueuePreemptionSnapshot) RemoveAllocation(alloc *resources.Resource) 
 	}
 	qps.Parent.RemoveAllocation(alloc)
 	qps.AllocatedResource.SubFrom(alloc)
-}
-
-// compareAllocationLess compares two allocations for preemption. Allocations which have opted into preemption are
-// considered first, then allocations which are not the originator of their associated application. Ties are broken
-// by creation time, with
-// then
-func compareAllocationLess(left *Allocation, right *Allocation) bool {
-	scoreLeft := scoreAllocation(left)
-	scoreRight := scoreAllocation(right)
-	if scoreLeft != scoreRight {
-		return scoreLeft < scoreRight
-	}
-	return left.createTime.After(right.createTime)
-}
-
-// scoreAllocation generates a relative score for an allocation. Lower-scored allocations are considered more likely
-// preemption candidates. Tasks which have opted into preemption are considered first, then tasks which are not
-// application originators.
-func scoreAllocation(allocation *Allocation) uint64 {
-	var score uint64 = 0
-	if allocation.IsOriginator() {
-		score |= scoreOriginator
-	}
-	if !allocation.IsAllowPreemptSelf() {
-		score |= scoreNoPreempt
-	}
-	return score
 }
 
 // sortVictimsForPreemption sorts allocations on each node, preferring those that have opted-in to preemption,

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -38,6 +38,8 @@ import (
 
 const alloc = "alloc"
 
+var testBaseTime = time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC)
+
 func creatApp1(
 	childQ1 *Queue,
 	node1 *Node,
@@ -1267,7 +1269,7 @@ func TestTryPreemption_AskResTypesDifferent_GuaranteedSetOnVictimAndPreemptorSid
 	app1, app2, app3 := createVictimApplications(childQ2, appQueueMapping)
 	for i := 5; i < 8; i++ {
 		askN := newAllocationAsk(alloc+strconv.Itoa(i), appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"mem": 100}))
-		askN.createTime = time.Now().Add(-2 * time.Minute)
+		askN.createTime = testBaseTime.Add(-2 * time.Minute)
 		assert.NilError(t, app1.AddAllocationAsk(askN))
 		allocN := newAllocationWithKey(askN.allocationKey, appID1, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"mem": 100}))
 		allocN.createTime = askN.createTime
@@ -1276,13 +1278,13 @@ func TestTryPreemption_AskResTypesDifferent_GuaranteedSetOnVictimAndPreemptorSid
 	}
 
 	ask1 := newAllocationAsk("alloc1", appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "mem": 100}))
-	ask1.createTime = time.Now().Add(-1 * time.Minute)
+	ask1.createTime = testBaseTime.Add(-1 * time.Minute)
 	assert.NilError(t, app1.AddAllocationAsk(ask1))
 	ask2 := newAllocationAsk("alloc2", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "mem": 100}))
-	ask2.createTime = time.Now()
+	ask2.createTime = testBaseTime
 	assert.NilError(t, app1.AddAllocationAsk(ask2))
 	ask3 := newAllocationAsk("alloc3", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "mem": 100}))
-	ask3.createTime = time.Now()
+	ask3.createTime = testBaseTime
 	assert.NilError(t, app1.AddAllocationAsk(ask3))
 	alloc1 := newAllocationWithKey("alloc1", appID1, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "mem": 100}))
 	alloc1.createTime = ask1.createTime
@@ -1491,7 +1493,7 @@ func TestTryPreemption_AskResTypesSame_GuaranteedSetOnPreemptorSide(t *testing.T
 			app1, app2, app3 := createVictimApplications(childQ2, appQueueMapping)
 			for i := 5; i < 8; i++ {
 				askN := newAllocationAsk(alloc+strconv.Itoa(i), appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"gpu": 100}))
-				askN.createTime = time.Now().Add(-2 * time.Minute)
+				askN.createTime = testBaseTime.Add(-2 * time.Minute)
 				assert.NilError(t, app1.AddAllocationAsk(askN))
 				allocN := newAllocationWithKey(askN.allocationKey, appID1, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"gpu": 100}))
 				allocN.createTime = askN.createTime
@@ -1500,13 +1502,13 @@ func TestTryPreemption_AskResTypesSame_GuaranteedSetOnPreemptorSide(t *testing.T
 			}
 
 			ask1 := newAllocationAsk("alloc1", appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "pods": 1}))
-			ask1.createTime = time.Now().Add(-1 * time.Minute)
+			ask1.createTime = testBaseTime.Add(-1 * time.Minute)
 			assert.NilError(t, app1.AddAllocationAsk(ask1))
 			ask2 := newAllocationAsk("alloc2", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "pods": 1}))
-			ask2.createTime = time.Now()
+			ask2.createTime = testBaseTime
 			assert.NilError(t, app1.AddAllocationAsk(ask2))
 			ask3 := newAllocationAsk("alloc3", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "pods": 1}))
-			ask3.createTime = time.Now()
+			ask3.createTime = testBaseTime
 			assert.NilError(t, app1.AddAllocationAsk(ask3))
 			alloc1 := newAllocationWithKey("alloc1", appID1, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1, "pods": 1}))
 			alloc1.createTime = ask1.createTime
@@ -1693,7 +1695,7 @@ func TestTryPreemption_AskResTypesSame_GuaranteedSetOnVictimAndPreemptorSides(t 
 	app1, app2, app3 := createVictimApplications(childQ2, appQueueMapping)
 	for i := 5; i < 8; i++ {
 		askN := newAllocationAsk(alloc+strconv.Itoa(i), appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"gpu": 100}))
-		askN.createTime = time.Now().Add(-2 * time.Minute)
+		askN.createTime = testBaseTime.Add(-2 * time.Minute)
 		assert.NilError(t, app1.AddAllocationAsk(askN))
 		allocN := newAllocationWithKey(askN.allocationKey, appID1, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"gpu": 100}))
 		allocN.createTime = askN.createTime
@@ -1702,13 +1704,13 @@ func TestTryPreemption_AskResTypesSame_GuaranteedSetOnVictimAndPreemptorSides(t 
 	}
 
 	ask1 := newAllocationAsk("alloc1", appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
-	ask1.createTime = time.Now().Add(-1 * time.Minute)
+	ask1.createTime = testBaseTime.Add(-1 * time.Minute)
 	assert.NilError(t, app1.AddAllocationAsk(ask1))
 	ask2 := newAllocationAsk("alloc2", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
-	ask2.createTime = time.Now()
+	ask2.createTime = testBaseTime
 	assert.NilError(t, app1.AddAllocationAsk(ask2))
 	ask3 := newAllocationAsk("alloc3", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
-	ask3.createTime = time.Now()
+	ask3.createTime = testBaseTime
 	assert.NilError(t, app1.AddAllocationAsk(ask3))
 	alloc1 := newAllocationWithKey("alloc1", appID1, nodeID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcores": 1}))
 	alloc1.createTime = ask1.createTime

--- a/pkg/scheduler/objects/preemption_utilities.go
+++ b/pkg/scheduler/objects/preemption_utilities.go
@@ -124,7 +124,10 @@ func SortAllocationsBasedOnAsk(allocations []*Allocation, total, ask *resources.
 		if comp == 1 {
 			return false
 		}
-		return true
+		if !l.GetCreateTime().Equal(r.GetCreateTime()) {
+			return l.GetCreateTime().After(r.GetCreateTime())
+		}
+		return l.GetAllocationKey() < r.GetAllocationKey()
 	})
 }
 

--- a/pkg/scheduler/objects/preemption_utilities_test.go
+++ b/pkg/scheduler/objects/preemption_utilities_test.go
@@ -320,3 +320,39 @@ func TestSortAllocationsBasedOnAsk_PreemptionOrdering(t *testing.T) {
 	assert.Equal(t, allocations[2].GetAllocationKey(), "originatorPod")
 	assert.Equal(t, allocations[3].GetAllocationKey(), "optedOutOriginatorPod")
 }
+
+func TestSortAllocationsBasedOnAsk_TieBreaking(t *testing.T) {
+	node := NewNode(&si.NodeInfo{
+		NodeID: "node1",
+		SchedulableResource: &si.Resource{
+			Resources: map[string]*si.Quantity{"first": {Value: 100}},
+		},
+	})
+	res := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
+	total := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 100})
+	ask := resources.NewResourceFromMap(map[string]resources.Quantity{"first": 10})
+
+	baseTime := time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC)
+
+	// Test 1: Tie-breaking by creation time (younger first) within the same hour bucket
+	allocOld := createAllocation("alloc-old", "app1", node.NodeID, true, false, 10, false, res)
+	allocOld.createTime = baseTime.Add(-10 * time.Minute)
+	allocYoung := createAllocation("alloc-young", "app1", node.NodeID, true, false, 10, false, res)
+	allocYoung.createTime = baseTime
+
+	allocations := []*Allocation{allocOld, allocYoung}
+	SortAllocationsBasedOnAsk(allocations, total, ask)
+	assert.Equal(t, allocations[0].GetAllocationKey(), "alloc-young")
+	assert.Equal(t, allocations[1].GetAllocationKey(), "alloc-old")
+
+	// Test 2: Tie-breaking by allocationKey when creation times are identical
+	allocB := createAllocation("alloc-b", "app1", node.NodeID, true, false, 10, false, res)
+	allocB.createTime = baseTime
+	allocA := createAllocation("alloc-a", "app1", node.NodeID, true, false, 10, false, res)
+	allocA.createTime = baseTime
+
+	allocations = []*Allocation{allocB, allocA}
+	SortAllocationsBasedOnAsk(allocations, total, ask)
+	assert.Equal(t, allocations[0].GetAllocationKey(), "alloc-a")
+	assert.Equal(t, allocations[1].GetAllocationKey(), "alloc-b")
+}


### PR DESCRIPTION
### Description
This pull request integrates the improved victim selection process into Inter-Queue Preemption:

1. **Inter-Queue Preemption Algorithm Upgrade**: Replaces legacy `compareAllocationLess` sorting with `SortAllocationsBasedOnAsk` in `calculateAdditionalVictims`, passing `askQueue.GetMaxResource()` to properly evaluate hierarchical queue quotas.
2. **Deterministic Tie-Breaking**: Resolves non-deterministic sorting in `SortAllocationsBasedOnAsk` when candidate allocations have identical resource ratios (`comp == 0`) by introducing a cascading tie-breaker (creation time `After` for younger-first, followed by `allocationKey` lexicographical ordering).
3. **Cleanup & Test Stabilization**: Removes unused legacy helpers (`compareAllocationLess` and `scoreAllocation`) and stabilizes preemption tests with fixed baseline timestamps to prevent hour-boundary flakiness.

### Type of change
- [ ] Bug Fix
- [x] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3236

- [ ] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by Antigravity CLI", where Antigravity CLI is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [x] `make test_all` was run, and no failures reported.
- [ ] A pull request will be opened for new e2e tests (apache/yunikorn-k8shim repository).

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
